### PR TITLE
Expert auto-fallback and structured suggestion fields for consult_expert

### DIFF
--- a/src/tapps_mcp/config/settings.py
+++ b/src/tapps_mcp/config/settings.py
@@ -128,6 +128,19 @@ class TappsMCPSettings(BaseSettings):
         description="Timeout for individual external tool invocations (seconds).",
     )
 
+    # Expert/doc coupling
+    expert_auto_fallback: bool = Field(
+        default=True,
+        description=(
+            "Enable automatic Context7 lookup hints/content when expert RAG has no matches."
+        ),
+    )
+    expert_fallback_max_chars: int = Field(
+        default=1200,
+        ge=200,
+        description="Maximum number of characters merged from Context7 fallback content.",
+    )
+
 
 def _load_yaml_config(project_root: Path) -> dict[str, Any]:
     """Load project-level ``.tapps-mcp.yaml`` if it exists."""

--- a/src/tapps_mcp/experts/engine.py
+++ b/src/tapps_mcp/experts/engine.py
@@ -11,6 +11,8 @@ This is the main entry point for expert consultations.  It:
 
 from __future__ import annotations
 
+import asyncio
+
 import structlog
 
 from tapps_mcp.experts.confidence import (
@@ -31,6 +33,83 @@ from tapps_mcp.experts.registry import ExpertRegistry
 from tapps_mcp.experts.vector_rag import VectorKnowledgeBase
 
 logger = structlog.get_logger(__name__)
+
+
+def _infer_lookup_hints(question: str, domain: str) -> tuple[str, str]:
+    """Infer best-effort library/topic hints for docs lookup."""
+    q = question.lower()
+
+    library_candidates: list[tuple[str, list[str]]] = [
+        ("pytest", ["pytest", "fixture", "conftest", "monkeypatch"]),
+        ("fastapi", ["fastapi", "apirouter", "pydantic", "uvicorn"]),
+        ("flask", ["flask", "werkzeug", "jinja"]),
+        ("django", ["django", "orm", "settings.py"]),
+        ("sqlalchemy", ["sqlalchemy", "session", "declarative", "alembic"]),
+        ("pydantic", ["pydantic", "basemodel", "field"]),
+        ("requests", ["requests", "http", "session"]),
+        ("docker", ["docker", "dockerfile", "compose"]),
+        ("kubernetes", ["kubernetes", "k8s", "kubectl"]),
+        ("prometheus", ["prometheus", "metrics", "exporter"]),
+    ]
+
+    library = "python"
+    for candidate, signals in library_candidates:
+        if any(signal in q for signal in signals):
+            library = candidate
+            break
+    else:
+        domain_defaults = {
+            "testing-strategies": "pytest",
+            "api-design-integration": "fastapi",
+            "database-data-management": "sqlalchemy",
+            "cloud-infrastructure": "docker",
+            "observability-monitoring": "prometheus",
+        }
+        library = domain_defaults.get(domain, "python")
+
+    topic = "overview"
+    topic_signals = [
+        ("security", ["security", "auth", "vulnerability", "owasp"]),
+        ("testing", ["test", "fixture", "mock", "assert"]),
+        ("configuration", ["config", "env", "setting", "url"]),
+        ("performance", ["performance", "optimiz", "latency", "throughput"]),
+        ("api", ["api", "endpoint", "route", "request", "response"]),
+    ]
+    for candidate, signals in topic_signals:
+        if any(signal in q for signal in signals):
+            topic = candidate
+            break
+
+    return library, topic
+
+
+def _lookup_docs_sync(library: str, topic: str) -> tuple[bool, str | None]:
+    """Run async docs lookup from this sync module."""
+    try:
+        from tapps_mcp.config.settings import load_settings
+        from tapps_mcp.knowledge.cache import KBCache
+        from tapps_mcp.knowledge.lookup import LookupEngine
+
+        settings = load_settings()
+        cache = KBCache(settings.project_root / ".tapps-mcp-cache")
+
+        async def _run() -> tuple[bool, str | None]:
+            engine = LookupEngine(cache, api_key=settings.context7_api_key)
+            try:
+                result = await engine.lookup(library=library, topic=topic, mode="code")
+            finally:
+                await engine.close()
+            return result.success, result.content
+
+        return asyncio.run(_run())
+    except Exception as exc:
+        logger.debug(
+            "expert_context7_fallback_failed",
+            library=library,
+            topic=topic,
+            reason=str(exc),
+        )
+        return False, None
 
 
 def consult_expert(
@@ -117,6 +196,12 @@ def consult_expert(
     confidence = compute_confidence(factors, resolved_domain)
 
     # 5. Build answer text.
+    suggested_tool: str | None = None
+    suggested_library: str | None = None
+    suggested_topic: str | None = None
+    fallback_used = False
+    fallback_library: str | None = None
+    fallback_topic: str | None = None
     if context:
         answer = (
             f"## {expert.expert_name} — {resolved_domain}\n\n"
@@ -125,12 +210,38 @@ def consult_expert(
             f"{context}"
         )
     else:
+        suggested_tool = "tapps_lookup_docs"
+        suggested_library, suggested_topic = _infer_lookup_hints(question, resolved_domain)
         answer = (
             f"## {expert.expert_name} — {resolved_domain}\n\n"
             f"No specific knowledge found for this query in the "
-            f"{resolved_domain} knowledge base.  The expert can still "
-            f"provide general guidance based on domain principles."
+            f"{resolved_domain} knowledge base. The expert can still "
+            f"provide general guidance based on domain principles.\n\n"
+            f"Suggested next step: call {suggested_tool}(library='{suggested_library}', "
+            f"topic='{suggested_topic}')."
         )
+
+        try:
+            from tapps_mcp.config.settings import load_settings
+
+            settings = load_settings()
+        except Exception as exc:
+            logger.debug("expert_fallback_settings_unavailable", reason=str(exc))
+            settings = None
+
+        if settings is not None and settings.expert_auto_fallback:
+            ok, docs_content = _lookup_docs_sync(suggested_library, suggested_topic)
+            if ok and docs_content:
+                fallback_used = True
+                fallback_library = suggested_library
+                fallback_topic = suggested_topic
+                fallback_excerpt = docs_content[: settings.expert_fallback_max_chars]
+                answer = (
+                    f"{answer}\n\n---\n\n"
+                    "### Context7 fallback (auto-attached)\n\n"
+                    f"Library: `{fallback_library}` | Topic: `{fallback_topic}`\n\n"
+                    f"{fallback_excerpt}"
+                )
 
     # Low-confidence nudge: help the AI supplement with other tools
     low_confidence_nudge = None
@@ -152,6 +263,12 @@ def consult_expert(
         sources=sources,
         chunks_used=len(chunks),
         low_confidence_nudge=low_confidence_nudge,
+        suggested_tool=suggested_tool,
+        suggested_library=suggested_library,
+        suggested_topic=suggested_topic,
+        fallback_used=fallback_used,
+        fallback_library=fallback_library,
+        fallback_topic=fallback_topic,
     )
 
 

--- a/src/tapps_mcp/experts/knowledge/testing/test-configuration-and-urls.md
+++ b/src/tapps_mcp/experts/knowledge/testing/test-configuration-and-urls.md
@@ -1,0 +1,56 @@
+# Test Configuration, URLs, and Environment Patterns
+
+Use these patterns to keep tests portable across local, CI, and containerized environments.
+
+## Base URL configuration
+
+- Avoid hardcoded URLs such as `http://localhost:8000` in test logic.
+- Prefer a fixture that reads `TEST_BASE_URL` and falls back to a sensible default.
+- Keep URL building in one helper so tests focus on behavior.
+
+```python
+import os
+import pytest
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    return os.getenv("TEST_BASE_URL", "http://127.0.0.1:8000")
+```
+
+## Environment variable strategy
+
+- Use explicit env var names for external dependencies (`DB_URL`, `REDIS_URL`, `API_KEY`).
+- In tests, set env vars with `monkeypatch.setenv` and clear with `monkeypatch.delenv`.
+- Never commit real secrets in `.env` fixtures; use placeholders.
+
+```python
+def test_reads_env(monkeypatch):
+    monkeypatch.setenv("DB_URL", "sqlite:///test.db")
+    # call function under test
+```
+
+## Fixtures for config isolation
+
+- Provide a fixture that constructs config objects from env and test overrides.
+- Scope config fixtures narrowly (`function`) unless expensive to build.
+- For framework settings modules, use temporary files/directories and patch paths.
+
+## Monkeypatching network and endpoints
+
+- Patch network entry points (`requests.Session.request`, SDK clients) for determinism.
+- Inject clients into app services where possible; avoid global singletons in tests.
+- Prefer fake servers only for integration tests, not unit tests.
+
+## Avoiding localhost assumptions
+
+- In CI, services may run in containers with custom hostnames.
+- Use compose service names or injected `TEST_BASE_URL`, not bare localhost.
+- Keep timeout values configurable and conservative for shared runners.
+
+## Quick checklist
+
+- [ ] No hardcoded production URLs
+- [ ] All external endpoints configurable by env/fixtures
+- [ ] Secrets replaced with test values
+- [ ] Network calls patched or isolated
+- [ ] Base URL and ports configurable in CI

--- a/src/tapps_mcp/experts/models.py
+++ b/src/tapps_mcp/experts/models.py
@@ -65,6 +65,30 @@ class ConsultationResult(BaseModel):
         default=None,
         description="Actionable nudge when confidence is low (e.g. suggest tapps_lookup_docs).",
     )
+    suggested_tool: str | None = Field(
+        default=None,
+        description="Suggested tool to call next when confidence/context is insufficient.",
+    )
+    suggested_library: str | None = Field(
+        default=None,
+        description="Suggested library name for documentation lookup.",
+    )
+    suggested_topic: str | None = Field(
+        default=None,
+        description="Suggested topic to look up for documentation fallback.",
+    )
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether automatic docs fallback content was merged into the answer.",
+    )
+    fallback_library: str | None = Field(
+        default=None,
+        description="Library used for automatic docs fallback lookup.",
+    )
+    fallback_topic: str | None = Field(
+        default=None,
+        description="Topic used for automatic docs fallback lookup.",
+    )
 
 
 class DomainMapping(BaseModel):

--- a/src/tapps_mcp/prompts/agents_template.md
+++ b/src/tapps_mcp/prompts/agents_template.md
@@ -36,7 +36,7 @@ You only see these tools when the host has started the TappsMCP server and attac
 | **tapps_quality_gate** | **Before declaring work complete** — ensures the file passes the configured quality preset. Do not consider work done until it passes (or the user accepts the risk). |
 | **tapps_lookup_docs** | **Before writing code** that uses an external library — use the returned docs to avoid hallucinated APIs. |
 | **tapps_validate_config** | When **adding or changing** Dockerfile, docker-compose, or infra config. |
-| **tapps_consult_expert** | When making **domain-specific decisions** (security, testing, APIs, database, etc.) and you want authoritative, RAG-backed guidance. Pass `domain` when context makes it obvious (e.g. editing a test file → `domain="testing-strategies"`). |
+| **tapps_consult_expert** | When making **domain-specific decisions** (security, testing, APIs, database, etc.) and you want authoritative, RAG-backed guidance. For library-specific questions, pair with `tapps_lookup_docs` (or use expert auto-fallback when available). Pass `domain` when context makes it obvious (e.g. editing a test file → `domain="testing-strategies"`). |
 | **tapps_list_experts** | When you need to see **which expert domains exist** before calling `tapps_consult_expert`. |
 | **tapps_project_profile** | At **session start** or when you need project context — detects project type, tech stack, and structure so you can apply the right patterns. |
 | **tapps_session_notes** | When you make a **key decision or discover a constraint** — save it so you can recall it later in a long session. |
@@ -81,7 +81,7 @@ When in doubt, omit `domain` to let auto-detection from the question text choose
    - Call `tapps_quality_gate(file_path=...)` — work is not done until it passes.
    - Call `tapps_checklist(task_type=...)` and, if `complete` is false, call the missing required tools (use `missing_required_hints` for reasons).
    - Optionally call `tapps_report(format="markdown")` to generate a quality summary.
-7. **When in doubt:** Use `tapps_consult_expert` for domain-specific questions; use `tapps_validate_config` for Docker/infra files.
+7. **When in doubt:** Use `tapps_consult_expert` for domain-specific questions; if libraries/frameworks are involved, also call `tapps_lookup_docs` (or rely on auto-fallback hints). Use `tapps_validate_config` for Docker/infra files.
 
 ---
 

--- a/src/tapps_mcp/prompts/research.md
+++ b/src/tapps_mcp/prompts/research.md
@@ -21,7 +21,7 @@ Gather domain knowledge and library documentation before writing code. This prev
 
 1. Identify which libraries the task involves.
 2. Call `tapps_lookup_docs(library="<name>", topic="<specific topic>")` for each library.
-3. If the task involves domain-specific decisions (security patterns, testing strategies, API design, etc.), call `tapps_consult_expert(question="<your question>")`.
+3. If the task involves domain-specific decisions (security patterns, testing strategies, API design, etc.), call `tapps_consult_expert(question="<your question>")`; for library-specific guidance, follow up with `tapps_lookup_docs` if suggested.
 4. If unsure which expert domain fits, call `tapps_list_experts()` first.
 5. Record all findings - API signatures, patterns, expert recommendations.
 

--- a/src/tapps_mcp/server.py
+++ b/src/tapps_mcp/server.py
@@ -228,7 +228,7 @@ def tapps_server_info() -> dict[str, Any]:
         "diagnostics": diagnostics.model_dump(),
         "recommended_workflow": (
             "FIRST: Call tapps_session_start() to initialize. "
-            "BEFORE using any library: Call tapps_lookup_docs(). "
+            "BEFORE using any library: Call tapps_lookup_docs(). For domain+library questions, pair with tapps_consult_expert(). "
             "AFTER editing Python files: Call tapps_score_file(quick=True) or tapps_quick_check(). "
             "BEFORE declaring done: Call tapps_validate_changed() or tapps_quality_gate(). "
             "FINAL step: Call tapps_checklist()."
@@ -660,6 +660,12 @@ def tapps_consult_expert(
         "sources": result.sources,
         "chunks_used": result.chunks_used,
         "low_confidence_nudge": result.low_confidence_nudge,
+        "suggested_tool": result.suggested_tool,
+        "suggested_library": result.suggested_library,
+        "suggested_topic": result.suggested_topic,
+        "fallback_used": result.fallback_used,
+        "fallback_library": result.fallback_library,
+        "fallback_topic": result.fallback_topic,
     })
     return _with_nudges("tapps_consult_expert", resp)
 

--- a/tests/integration/test_expert_pipeline.py
+++ b/tests/integration/test_expert_pipeline.py
@@ -176,6 +176,12 @@ class TestMCPToolHandlers:
         assert "confidence" in result["data"]
         assert "factors" in result["data"]
         assert "sources" in result["data"]
+        assert "suggested_tool" in result["data"]
+        assert "suggested_library" in result["data"]
+        assert "suggested_topic" in result["data"]
+        assert "fallback_used" in result["data"]
+        assert "fallback_library" in result["data"]
+        assert "fallback_topic" in result["data"]
 
     def test_tapps_consult_expert_auto_routing(self) -> None:
         """tapps_consult_expert auto-routes when domain is empty."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,6 +19,8 @@ class TestTappsMCPSettings:
         assert settings.log_json is False
         assert settings.tool_timeout == 30
         assert settings.context7_api_key is None
+        assert settings.expert_auto_fallback is True
+        assert settings.expert_fallback_max_chars == 1200
 
     def test_scoring_weights_default(self):
         settings = TappsMCPSettings()

--- a/tests/unit/test_expert_engine.py
+++ b/tests/unit/test_expert_engine.py
@@ -64,6 +64,20 @@ class TestConsultExpert:
             assert "tapps_lookup_docs" in result.low_confidence_nudge
             assert "Note:" in result.answer
 
+    def test_structured_suggestion_fields_when_no_context(self) -> None:
+        result = consult_expert("Tell me something interesting about cats")
+        if result.chunks_used == 0:
+            assert result.suggested_tool == "tapps_lookup_docs"
+            assert result.suggested_library is not None
+            assert result.suggested_topic is not None
+
+    def test_fallback_flags_default_shape(self) -> None:
+        result = consult_expert("How to write pytest fixtures?")
+        assert isinstance(result.fallback_used, bool)
+        if result.fallback_used:
+            assert result.fallback_library is not None
+            assert result.fallback_topic is not None
+
 
 class TestListExperts:
     """Tests for list_experts."""


### PR DESCRIPTION
### Motivation
- Implement parts of the TAPPS_MCP improvement plan to make expert consultations deterministic when RAG returns no context by surfacing machine-readable next-step hints and optional documentation fallbacks. 
- Provide a configurable, non-fatal Context7 fallback so clients can automatically follow up with `tapps_lookup_docs` or consume attached docs excerpts when available.

### Description
- Added structured response fields to `ConsultationResult`: `suggested_tool`, `suggested_library`, `suggested_topic`, `fallback_used`, `fallback_library`, and `fallback_topic` so clients can parse deterministic next steps.
- Extended `consult_expert` to infer best-effort library/topic hints and populate `suggested_*` fields when the domain RAG returns no context, and to optionally attach Context7 fallback content (excerpted) when `expert_auto_fallback` is enabled.
- Exposed the new fields through the MCP handler `tapps_consult_expert` so responses include the structured hints and fallback metadata.
- Added two new settings to control fallback behavior: `expert_auto_fallback` (default `True`) and `expert_fallback_max_chars` (default `1200`) in `TappsMCPSettings` to gate/limit automatic docs attachment.
- Added a small testing KB file `src/tapps_mcp/experts/knowledge/testing/test-configuration-and-urls.md` with guidance for test URL/config/env patterns and updated prompt/docs to recommend pairing `tapps_consult_expert` with `tapps_lookup_docs` for library-specific questions.
- Added/updated unit and integration assertions to validate the new fields and settings defaults in `tests/unit/test_expert_engine.py`, `tests/integration/test_expert_pipeline.py`, and `tests/unit/test_config.py`.

### Testing
- Compiled modified modules and tests with `python -m compileall` and it completed without syntax errors for the changed files.
- Attempted targeted test runs with `pytest` (and `PYTHONPATH=src pytest`), but collection failed in this environment due to missing runtime dependencies (`pydantic`, `structlog`) and import path constraints, so pytest could not be completed here.
- The fallback path is best-effort and guarded by settings so lookup failures are logged and do not break expert responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699951901b40833296d7028aca75065d)