### PR TITLE
docs: update improvement plan with verified test counts and corrected line refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,17 @@ You only see these tools when the host has started the TappsMCP server and attac
 
 | Tool | When to use it |
 |------|----------------|
+| **tapps_session_start** | **FIRST call in every session** — combines server info + project profile in one call. Skipping means all tools lack project context. |
 | **tapps_server_info** | At **session start** — discover version, available tools, and installed checkers. Response includes a short `recommended_workflow` string. |
 | **tapps_score_file** | When **editing or reviewing** a Python file. Use `quick=True` during edit–lint–fix loops; use full (default) **before declaring work complete**. |
+| **tapps_quick_check** | **After editing any Python file** — quick score + gate + basic security in one fast call. |
 | **tapps_security_scan** | When the change is **security-sensitive** or before a security-focused review. |
 | **tapps_quality_gate** | **Before declaring work complete** — ensures the file passes the configured quality preset. Do not consider work done until this passes (or the user accepts the risk). |
+| **tapps_validate_changed** | **Before declaring multi-file work complete** — auto-detects changed files via git diff and runs score + gate + security on each. |
 | **tapps_lookup_docs** | **Before writing code** that uses an external library — use the returned docs to avoid hallucinated APIs. |
 | **tapps_validate_config** | When **adding or changing** Dockerfile, docker-compose, or infra config. |
 | **tapps_consult_expert** | When making **domain-specific decisions** (security, testing, APIs, database, etc.) and you want authoritative, RAG-backed guidance. Pass `domain` when context makes it obvious (e.g. editing a test file → `domain="testing-strategies"`). |
+| **tapps_research** | When you need **combined expert + docs** in one call — consults the domain expert, then auto-supplements with Context7 documentation when RAG is empty or confidence is low. Saves a round-trip vs calling `tapps_consult_expert` + `tapps_lookup_docs` separately. |
 | **tapps_list_experts** | When you need to see **which expert domains exist** before calling `tapps_consult_expert`. |
 | **tapps_project_profile** | At **session start** or when you need project context — detects project type, tech stack, and structure so you can apply the right patterns. |
 | **tapps_session_notes** | When you make a **key decision or discover a constraint** — save it so you can recall it later in a long session. |
@@ -46,7 +50,7 @@ You only see these tools when the host has started the TappsMCP server and attac
 | **tapps_dashboard** | When the user wants to **review how TappsMCP is performing** — scoring accuracy, gate pass rates, expert effectiveness, cache performance, quality trends, and alerts. Supports json, markdown, and html output. |
 | **tapps_stats** | When the user wants **usage statistics** — call counts, success rates, average durations, cache hit rates, and gate pass rates. Filterable by tool and time period. |
 | **tapps_feedback** | After receiving a tool result — report whether the output was **helpful or not**. This feedback improves adaptive scoring and expert weights over time. |
-| **tapps_research** | When you need **combined expert + docs** in one call — consults the domain expert, then auto-supplements with Context7 documentation when RAG is empty or confidence is low. Saves a round-trip vs calling `tapps_consult_expert` + `tapps_lookup_docs` separately. |
+| **tapps_workflow** | When you want the **recommended tool call order** for a specific task type (general, feature, bugfix, refactor, security, review). |
 | **tapps_init** | At the **start of a pipeline run** — profiles the project, sets context, and plans the workflow stages (discover, research, develop, validate, verify). |
 
 ---
@@ -72,14 +76,13 @@ When in doubt, omit `domain` to let auto-detection from the question text choose
 
 ## Recommended workflow
 
-1. **Session start:** Call `tapps_server_info` and `tapps_project_profile` (and optionally `tapps_list_experts` if you may need experts).
+1. **Session start:** Call `tapps_session_start` (combines server info + project profile). Optionally call `tapps_list_experts` if you may need experts.
 2. **Record key decisions:** Use `tapps_session_notes(action="save", ...)` to persist constraints and decisions so they survive long sessions.
 3. **Before using a library:** Call `tapps_lookup_docs(library=...)` and use the returned content when implementing.
 4. **Before modifying a file's API:** Call `tapps_impact_analysis(file_path=...)` to see what depends on it.
-5. **During edits:** Call `tapps_score_file(file_path=..., quick=True)` (and `fix=True` if you want ruff to apply fixes).
+5. **During edits:** Call `tapps_quick_check(file_path=...)` or `tapps_score_file(file_path=..., quick=True)` after each change.
 6. **Before declaring work complete:**
-   - Call `tapps_score_file(file_path=..., quick=False)` on changed files.
-   - Call `tapps_quality_gate(file_path=...)` — work is not done until it passes.
+   - Call `tapps_validate_changed()` to score + gate + security scan all changed files.
    - Call `tapps_checklist(task_type=...)` and, if `complete` is false, call the missing required tools (use `missing_required_hints` for reasons).
    - Optionally call `tapps_report(format="markdown")` to generate a quality summary.
 7. **When in doubt:** Use `tapps_consult_expert` for domain-specific questions; use `tapps_validate_config` for Docker/infra files. **For library-specific domain questions**, pair `tapps_consult_expert` with `tapps_lookup_docs` to get expert guidance backed by current documentation (the expert response will suggest the right library/topic to look up).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Planned (Epic 10: Expert + Context7 Integration)
+No unreleased changes.
+
+---
+
+## [0.2.1] - 2026-02-21
+
+### Added (Epic 10: Expert + Context7 Integration)
 
 - **Expert + doc lookup coupling** — Workflow guidance for combining `tapps_consult_expert` with `tapps_lookup_docs` for testing/library questions (AGENTS.md, recommended_workflow)
 - **Structured hints when RAG is empty** — `suggested_tool`, `suggested_library`, `suggested_topic` in `tapps_consult_expert` response for machine-parseable follow-up
-- **Auto-fallback to Context7** — When expert RAG returns no chunks, optionally call lookup_docs and merge content (configurable)
-- **Broader testing-strategies KB** — Knowledge on test config, base URLs, env vars, fixtures, monkeypatch
-- **Optional `tapps_research` tool** — Single tool combining expert + Context7 in one call
+- **Auto-fallback to Context7** — When expert RAG returns no chunks, automatically calls lookup_docs and merges content (configurable via `expert_auto_fallback` and `expert_fallback_max_chars` settings)
+- **Broader testing-strategies KB** — Knowledge on test config, base URLs, env vars, fixtures, monkeypatch (`test-configuration-and-urls.md`)
+- **`tapps_research` tool** — Single tool combining expert consultation + Context7 documentation in one call
+
+### Added (Epic 11: Retrieval Optimization)
+
+- **Hybrid fusion + rerank** — `VectorKnowledgeBase._hybrid_fuse()` combines vector and keyword results with weighted scoring and structural bonus
+- **Hot-rank adaptive ranking** — `compute_hot_rank()` uses recency decay, helpfulness, confidence trend, and exploration bonus to prioritize domains
+- **Fuzzy matcher v2** — Multi-signal matching (LCS + edit distance + token overlap + alias + prefix + confidence bands + "did you mean" + manifest priors)
+- **Context7 code-reference normalization** — Snippet extraction, ranking, deduplication, reference cards, and token budgets (`content_normalizer.py`)
+- **Retrieval evaluation harness** — 10 benchmark queries across 8 domains with quality gates (pass rate, latency, keyword coverage)
 
 **Upgrade path for consuming projects:** After upgrading TappsMCP, run `tapps_init` with `overwrite_agents_md=True` and `overwrite_platform_rules=True` to refresh AGENTS.md and pipeline rules. See [docs/INIT_AND_UPGRADE_FEATURE_LIST.md](docs/INIT_AND_UPGRADE_FEATURE_LIST.md).
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ Restart Claude Desktop after changing the config.
 
 ### Suggested workflow for the AI
 
-1. Call **`tapps_server_info`** at session start to see version and installed checkers.
-2. Use **`tapps_score_file`** (with `quick: true`) during edit–lint–fix loops.
-3. Use **`tapps_score_file`** (full) and **`tapps_quality_gate`** before marking work complete.
+1. Call **`tapps_session_start`** at session start to initialize context.
+2. Use **`tapps_quick_check`** (or `tapps_score_file` with `quick: true`) during edit–lint–fix loops.
+3. Use **`tapps_validate_changed`** before marking work complete (validates all changed files).
 4. Call **`tapps_checklist`** to ensure no required steps were skipped.
 
 ---
@@ -208,13 +208,17 @@ Quick index:
 
 | Tool | One-line purpose |
 |------|------------------|
+| **tapps_session_start** | **FIRST call** — combines server info + project profile in one call. |
 | **tapps_server_info** | Discover server version, tools, checkers, and recommended workflow. |
 | **tapps_score_file** | Score a Python file 0–100 across 7 quality categories. |
+| **tapps_quick_check** | Fast score + gate + basic security in one call after editing a file. |
 | **tapps_security_scan** | Run Bandit + secret detection on a Python file. |
 | **tapps_quality_gate** | Pass/fail a file against a quality preset (standard/strict/framework). |
+| **tapps_validate_changed** | Score + gate + security scan all changed files (auto-detects via git diff). |
 | **tapps_lookup_docs** | Fetch current documentation for a library (Context7 + cache). |
 | **tapps_validate_config** | Validate Dockerfile, docker-compose, or infra configs. |
 | **tapps_consult_expert** | Ask a domain expert and get RAG-backed answer with confidence. |
+| **tapps_research** | Combined expert + docs lookup in one call (auto-supplements with Context7). |
 | **tapps_list_experts** | List the 16 built-in expert domains and their status. |
 | **tapps_checklist** | See which tools were called this session and what is still missing. |
 | **tapps_project_profile** | Detect project type, tech stack, and structure for context-aware analysis. |
@@ -225,6 +229,15 @@ Quick index:
 | **tapps_stats** | Retrieve aggregated usage statistics and quality trends across sessions. |
 | **tapps_feedback** | Submit feedback on tool results to improve adaptive scoring and expert answers. |
 | **tapps_init** | Initialize a pipeline run: profile the project, set context, and plan the workflow. |
+| **tapps_workflow** | Generate tool call order and recommendations for a specific task type. |
+
+---
+
+### tapps_session_start
+
+**What it does:** Combines `tapps_server_info` and `tapps_project_profile` in a single call. Returns server metadata, installed checker status, project type, tech stack, and structure. This is the **required first call** in every session.
+
+**Why use it:** Initializes the session with full context so all subsequent tool calls can use project-aware recommendations. Skipping this means tools lack project context and suggestions are generic.
 
 ---
 
@@ -260,6 +273,22 @@ Quick index:
 
 ---
 
+### tapps_quick_check
+
+**What it does:** Runs a quick score + quality gate + basic security check on a single Python file in one fast call. Combines what would otherwise be three separate tool calls into one. For thorough multi-file validation, use `tapps_validate_changed` instead.
+
+**Why use it:** The fastest way to check a file after editing. Use after every edit to catch quality regressions immediately. Skipping means issues accumulate until the final validation step.
+
+---
+
+### tapps_validate_changed
+
+**What it does:** Detects changed Python files (via `git diff` against a base ref) or accepts an explicit comma-separated list. Runs full score + quality gate + security scan on each file. Returns per-file results with pass/fail status and aggregated summary.
+
+**Why use it:** Required before declaring multi-file work complete. Auto-detects what changed so you don't have to specify each file. Ensures no changed file slips through without quality validation.
+
+---
+
 ### tapps_lookup_docs
 
 **What it does:** Fetches current documentation for a given library (e.g. FastAPI, React, SQLAlchemy). Resolves the library name via fuzzy matching, checks a local cache first, and on cache miss can call the Context7 API (when `TAPPS_MCP_CONTEXT7_API_KEY` is set). Accepts an optional **topic** (e.g. "routing", "hooks") and **mode** ("code" for API-style docs, "info" for conceptual). All returned content is checked for prompt-injection patterns before being returned. Response includes source (cache vs API), cache hit flag, and optional token estimate.
@@ -281,6 +310,14 @@ Quick index:
 **What it does:** Sends a natural-language question to a domain expert. The server has 16 built-in domains (e.g. security, testing, API design, database, observability). You can leave **domain** empty for auto-routing from the question, or pass a domain id (e.g. `"security"`, `"testing-strategies"`). The expert uses RAG over curated knowledge files, returns an answer, a confidence score, contributing factors, and source chunks. Answers are filtered for PII/secrets before return.
 
 **Why use it:** When the AI (or user) is unsure about patterns, trade-offs, or best practices in a specific area, a single call returns focused, sourced guidance instead of generic advice. Use for security decisions, test strategy, API design, DB schema, or observability so the response is grounded in the expert knowledge base and the confidence score signals how much to rely on it.
+
+---
+
+### tapps_research
+
+**What it does:** Combined expert consultation + documentation lookup in one call. Consults the domain expert first, then automatically supplements with Context7 documentation when expert RAG has no results or confidence is low. Accepts optional `library` and `topic` parameters (auto-inferred when empty). Returns expert answer, confidence, sources, and any supplementary docs content.
+
+**Why use it:** Saves a round-trip compared to calling `tapps_consult_expert` and `tapps_lookup_docs` separately. Use when you need both expert guidance and current library documentation for a domain-specific question. The auto-supplementation means you always get documentation backing when the expert knowledge base has gaps.
 
 ---
 
@@ -465,7 +502,7 @@ src/tapps_mcp/
 ├── knowledge/                          # Context7 client, cache, lookup, warming, RAG safety
 ├── validators/                         # Dockerfile, docker-compose, WebSocket, MQTT, InfluxDB
 ├── experts/                            # Domain detector, engine, RAG, registry, confidence,
-│                                       #   vector RAG, knowledge management, 119 knowledge files
+│                                       #   vector RAG, knowledge management, 122 knowledge files
 ├── project/                            # Project profiling, session notes, impact analysis, reports
 ├── adaptive/                           # Adaptive scoring, expert voting, weight distribution
 ├── metrics/                            # Collector, dashboard, alerts, trends, OTel export, feedback
@@ -489,11 +526,11 @@ src/tapps_mcp/
 | [docs/UPGRADE_FOR_CONSUMERS.md](docs/UPGRADE_FOR_CONSUMERS.md) | Short upgrade guide for projects that install TappsMCP. |
 | [docs/planning/TAPPS_MCP_PLAN.md](docs/planning/TAPPS_MCP_PLAN.md) | Architecture and design rationale. |
 | [docs/planning/epics/README.md](docs/planning/epics/README.md) | Epic index, dependency graph, tool delivery timeline. |
-| [docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) | Epic 10: Expert + Context7 integration (planned). |
+| [docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) | Epic 10+11: Expert + Context7 integration and retrieval optimization (complete). |
 | [CHANGELOG.md](CHANGELOG.md) | Release history following Keep a Changelog format. |
 | [SECURITY.md](SECURITY.md) | Security policy and vulnerability reporting. |
 
-**Roadmap (epics):** Foundation & Security ✅ · Core Quality MVP ✅ · Knowledge & Docs ✅ · Expert System ✅ · Project Context ✅ · Adaptive Learning ✅ · Distribution ✅ · Metrics & Dashboard ✅ · Pipeline Orchestration ✅ · Scoring Reliability ✅ · **Epic 10 (planned):** Expert + Context7 integration (auto-fallback, structured hints, tapps_research)
+**Roadmap (epics):** Foundation & Security ✅ · Core Quality MVP ✅ · Knowledge & Docs ✅ · Expert System ✅ · Project Context ✅ · Adaptive Learning ✅ · Distribution ✅ · Metrics & Dashboard ✅ · Pipeline Orchestration ✅ · Scoring Reliability ✅ · Expert + Context7 Integration ✅ · Retrieval Optimization ✅
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
 | 0.1.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability

--- a/docs/INIT_AND_UPGRADE_FEATURE_LIST.md
+++ b/docs/INIT_AND_UPGRADE_FEATURE_LIST.md
@@ -95,19 +95,24 @@ When you upgrade TappsMCP (`pip install -U tapps-mcp` or similar), new workflow 
 
 ---
 
-## Epic 10 (planned): Expert + Context7 integration
+## Epic 10+11 (complete): Expert + Context7 Integration & Retrieval Optimization
 
-Epic 10 will add tighter coupling between expert consultation and doc lookup. When shipped, the following will be reflected in templates and behavior:
+Epic 10 and Epic 11 added tighter coupling between expert consultation and doc lookup, plus retrieval quality improvements. All 10 stories are shipped and tested (230 epic-scoped tests passing).
 
-| Enhancement | Delivered via |
-|-------------|---------------|
-| Expert + doc lookup workflow guidance | AGENTS.md, agents_template.md, recommended_workflow |
-| Structured suggested_tool / suggested_library / suggested_topic when RAG is empty | tapps_consult_expert response |
-| Auto-fallback to Context7 when expert RAG is empty | tapps_consult_expert (optional, configurable) |
-| Broader testing-strategies KB (test config, URLs, env) | Knowledge files |
-| Optional tapps_research combined tool | New MCP tool |
+| Enhancement | Delivered via | Status |
+|-------------|---------------|--------|
+| Expert + doc lookup workflow guidance | AGENTS.md, agents_template.md, recommended_workflow | ✅ Shipped |
+| Structured `suggested_tool` / `suggested_library` / `suggested_topic` when RAG is empty | `tapps_consult_expert` response | ✅ Shipped |
+| Auto-fallback to Context7 when expert RAG is empty | `tapps_consult_expert` (configurable via `expert_auto_fallback`) | ✅ Shipped |
+| Broader testing-strategies KB (test config, URLs, env) | Knowledge files (`test-configuration-and-urls.md`) | ✅ Shipped |
+| `tapps_research` combined tool | New MCP tool | ✅ Shipped |
+| Hybrid fusion + rerank retrieval | `VectorKnowledgeBase._hybrid_fuse()` | ✅ Shipped |
+| Hot-rank adaptive ranking | `experts/hot_rank.py` | ✅ Shipped |
+| Fuzzy matcher v2 (multi-signal) | `knowledge/fuzzy_matcher.py` | ✅ Shipped |
+| Context7 code-reference normalization | `knowledge/content_normalizer.py` | ✅ Shipped |
+| Retrieval evaluation harness + quality gates | `experts/retrieval_eval.py` | ✅ Shipped |
 
-**To get Epic 10 content in your project:** After upgrading TappsMCP, run `tapps_init` with `overwrite_agents_md=True` and `overwrite_platform_rules=True` so AGENTS.md and platform rules include the new workflow. See [TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md).
+**To get Epic 10+11 content in your project:** After upgrading TappsMCP, run `tapps_init` with `overwrite_agents_md=True` and `overwrite_platform_rules=True` so AGENTS.md and platform rules include the new workflow. See [TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md).
 
 ---
 

--- a/docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md
@@ -2,8 +2,8 @@
 
 **Source:** [TAPPS_MCP_IMPROVEMENT_RECOMMENDATIONS.md](../../../HomeIQ/implementation/TAPPS_MCP_IMPROVEMENT_RECOMMENDATIONS.md)
 **Created:** 2026-02-18
-**Revised:** 2026-02-21 (all 10 stories implemented and verified)
-**Status:** COMPLETE — All 10 stories (Epic 10 + Epic 11) implemented, tested (145 tests passing), and verified
+**Revised:** 2026-02-21 (all 10 stories implemented and verified; re-verified 2026-02-21 with updated test counts)
+**Status:** COMPLETE — All 10 stories (Epic 10 + Epic 11) implemented, tested (230 epic-scoped tests passing; 1658 total suite), and verified
 **Audience:** TappsMCP maintainers
 
 ---
@@ -37,10 +37,10 @@ To keep this plan strictly factual, each status claim in Section 2 is tied to ob
 | Capability | Current status | Evidence |
 |---|---|---|
 | `tapps_consult_expert` basic flow (domain detect, retrieve, confidence, sources) | ✅ Implemented | `experts/engine.py`, `server.py` |
-| Low-confidence nudge to call `tapps_lookup_docs` | ✅ Implemented | `experts/engine.py:248-254` |
+| Low-confidence nudge to call `tapps_lookup_docs` | ✅ Implemented | `experts/engine.py:247-254` |
 | Automatic Context7 fallback inside expert flow when RAG empty | ✅ Implemented | `experts/engine.py:86-112` (`_lookup_docs_sync`), `engine.py:224-244` (fallback path), `settings.py:131-142` (config flags) |
-| Structured fields `suggested_tool`, `suggested_library`, `suggested_topic` in response model | ✅ Implemented | `experts/models.py:68-79`, `server.py:663-665`, `engine.py:199-201,213-214,266-268` |
-| Structured fields `fallback_used`, `fallback_library`, `fallback_topic` | ✅ Implemented | `experts/models.py:80-91`, `server.py:666-668`, `engine.py:202-204,235-237,269-271` |
+| Structured fields `suggested_tool`, `suggested_library`, `suggested_topic` in response model | ✅ Implemented | `experts/models.py:68-79`, `server.py:664-666`, `engine.py:199-201,213-214,266-268` |
+| Structured fields `fallback_used`, `fallback_library`, `fallback_topic` | ✅ Implemented | `experts/models.py:80-91`, `server.py:667-669`, `engine.py:202-204,235-237,269-271` |
 | Optional `tapps_research` tool | ✅ Implemented | `server.py` — `tapps_research()` tool registered, combines expert consultation + auto docs lookup |
 | Testing KB file `test-configuration-and-urls.md` | ✅ Implemented | `experts/knowledge/testing/test-configuration-and-urls.md` (57 lines) + retrieval validation tests in `test_expert_rag.py` |
 | Context7 cache + SWR + stale fallback | ✅ Implemented | `knowledge/lookup.py` |
@@ -57,7 +57,8 @@ To keep this plan strictly factual, each status claim in Section 2 is tied to ob
 - Epic 10 stories completed in code: **5 / 5** (10.1 ✅, 10.2 ✅, 10.3 ✅, 10.4 ✅, 10.5 ✅)
 - Epic 11 stories completed in code: **5 / 5** (11.1 ✅, 11.2 ✅, 11.3 ✅, 11.4 ✅, 11.5 ✅)
 - Overall planned stories completed: **10 / 10**
-- Tests: **145 passing** (126 unit + 19 integration)
+- Epic 10/11 scoped tests: **230 passing** (211 unit + 19 integration)
+- Full test suite: **1658 passing**, 7 skipped (1569 unit + 96 integration)
 
 ---
 
@@ -89,7 +90,7 @@ To keep this plan strictly factual, each status claim in Section 2 is tied to ob
 **Status:** ✅ Complete
 
 **Tasks:**
-- [x] Update `tapps_server_info` recommended workflow wording and stage hints. — `server.py:229-234` includes "For domain+library questions, pair with tapps_consult_expert()" in `recommended_workflow`.
+- [x] Update `tapps_server_info` recommended workflow wording and stage hints. — `server.py:230-236` includes "For domain+library questions, pair with tapps_consult_expert()" in `recommended_workflow`.
 - [x] Update AGENTS/template/research prompts to explicitly require combined expert+lookup for library-specific domain questions. — `AGENTS.md` step 7 now explicitly states: "For library-specific domain questions, pair `tapps_consult_expert` with `tapps_lookup_docs` to get expert guidance backed by current documentation." Also added `tapps_research` tool entry to the tool table.
 
 **DoD:** ✅ Workflow guidance consistently reflects expert+lookup coupling.
@@ -103,7 +104,7 @@ To keep this plan strictly factual, each status claim in Section 2 is tied to ob
 **Tasks:**
 - [x] Extend `ConsultationResult` with: `suggested_tool`, `suggested_library`, `suggested_topic`. — `models.py:68-79`.
 - [x] Populate those fields when no chunks are found. — `engine.py:213-214` sets `suggested_tool=”tapps_lookup_docs”` and calls `_infer_lookup_hints()` when `context` is empty.
-- [x] Return fields through MCP response mapping in `server.py`. — `server.py:663-665`.
+- [x] Return fields through MCP response mapping in `server.py`. — `server.py:664-666`.
 - [x] Add tests for field population and suggestion correctness. — `tests/unit/test_expert_engine.py:67-72` (unit), `tests/integration/test_expert_pipeline.py:179-184` (integration).
 
 **DoD:** ✅ Clients can parse and automatically follow up with `tapps_lookup_docs`.
@@ -174,7 +175,7 @@ This epic captures improvements discussed after Epic 10 planning and is not cove
 - [x] Apply hot-rank as tie-breaker in retrieval ranking. — `apply_hot_rank_boost()` adds narrow score boost (max 5%) to chunks from high-performing domains.
 - [x] Add guardrails to avoid popularity-only lock-in. — Exploration bonus (0.15) for domains with < 5 consultations.
 
-**DoD:** ✅ Repeat queries trend toward higher helpfulness with no quality regressions. 7 unit tests passing.
+**DoD:** ✅ Repeat queries trend toward higher helpfulness with no quality regressions. 21 unit tests passing.
 
 ---
 
@@ -188,7 +189,7 @@ This epic captures improvements discussed after Epic 10 planning and is not cove
 - [x] Add multi-signal matching (edit distance/token overlap + existing alias/prefix/LCS). — `knowledge/fuzzy_matcher.py` now has `edit_distance()`, `edit_distance_similarity()`, `token_overlap_score()`, and `multi_signal_score()` (weights: LCS 0.4, edit distance 0.35, token overlap 0.25).
 - [x] Add confidence bands + “did you mean” when low confidence. — `confidence_band()` classifies scores into high/medium/low. `did_you_mean()` returns suggestions for failed lookups. `lookup.py` integrates “did you mean?” hints into error messages.
 - [x] Incorporate project manifest/library detector priors for disambiguation. — `fuzzy_match_library()` accepts optional `project_libraries` param for +0.10 boost.
-- [x] Add eval tests for typo, alias, shorthand, and ambiguous library names. — 15 new tests in `test_fuzzy_matcher.py` covering edit distance, token overlap, multi-signal, confidence bands, “did you mean”, and manifest priors.
+- [x] Add eval tests for typo, alias, shorthand, and ambiguous library names. — 85 tests in `test_fuzzy_matcher.py` covering LCS, edit distance, token overlap, multi-signal, confidence bands, “did you mean”, manifest priors, alias resolution, and library/topic matching.
 
 **DoD:** ✅ Higher correct-resolution rate and fewer wrong fuzzy hits.
 
@@ -206,7 +207,7 @@ This epic captures improvements discussed after Epic 10 planning and is not cove
 - [x] Add compact “reference card” output shape in merged responses. — `ReferenceCard` dataclass with `to_markdown()` output.
 - [x] Enforce per-section token budgets to avoid context overflow. — `apply_token_budget()` with configurable per-section budget (default 800 tokens).
 
-**DoD:** ✅ Fewer noisy snippets; stronger practical examples. 16 unit tests passing.
+**DoD:** ✅ Fewer noisy snippets; stronger practical examples. 40 unit tests passing.
 
 ---
 
@@ -222,7 +223,7 @@ This epic captures improvements discussed after Epic 10 planning and is not cove
 - [x] Add CI check(s) for regression thresholds. — `check_quality_gates()` enforces: pass rate ≥ 60%, p95 latency ≤ 500ms, keyword coverage ≥ 30%.
 - [x] Publish periodic before/after score snapshots. — `EvalReport.to_dict()` provides serializable snapshot for logging/comparison.
 
-**DoD:** ✅ Retrieval optimization can be tuned safely and measured objectively. 8 unit tests passing (including real eval gate check).
+**DoD:** ✅ Retrieval optimization can be tuned safely and measured objectively. 20 unit tests passing (including real eval gate check).
 
 ---
 
@@ -256,8 +257,8 @@ This epic captures improvements discussed after Epic 10 planning and is not cove
 
 Run this quick audit before marking this plan complete:
 
-- [x] Verify new response fields exist in models + server mapping. — ✅ Verified 2026-02-21. All 6 fields (`suggested_tool`, `suggested_library`, `suggested_topic`, `fallback_used`, `fallback_library`, `fallback_topic`) present in `models.py`, populated in `engine.py`, and mapped in `server.py:663-668`.
-- [x] Verify auto-fallback path exists in `experts/engine.py`. — ✅ Verified 2026-02-21. `_lookup_docs_sync()` at line 86, fallback path at lines 224-244, config flags in `settings.py:131-142`.
+- [x] Verify new response fields exist in models + server mapping. — ✅ Verified 2026-02-21. All 6 fields (`suggested_tool`, `suggested_library`, `suggested_topic`, `fallback_used`, `fallback_library`, `fallback_topic`) present in `models.py:68-91`, populated in `engine.py:199-204,213-214,235-237,266-271`, and mapped in `server.py:664-669`.
+- [x] Verify auto-fallback path exists in `experts/engine.py`. — ✅ Re-verified 2026-02-21. `_lookup_docs_sync()` at line 86, fallback path at lines 224-244, config flags in `settings.py:131-142`.
 - [x] Verify new testing KB file exists and is indexed. — ✅ Verified 2026-02-21. `experts/knowledge/testing/test-configuration-and-urls.md` present (57 lines).
 - [x] Verify `tapps_research` tool exists (if implemented). — ✅ Implemented in `server.py::tapps_research()`, registered in `available_tools`, documented in `AGENTS.md`.
 - [x] Verify retrieval/ranking metrics are captured and compared to baseline. — ✅ `experts/retrieval_eval.py` provides benchmark queries, quality gates, and `check_quality_gates()`. Test `test_retrieval_eval.py::test_real_eval_passes_gates` validates gate compliance.
@@ -318,7 +319,7 @@ Target **Epic 10.3 only** in the first implementation PR to keep risk low and en
 ### 8.3) Pre-implementation checks (must pass before PR 1 coding)
 
 - [x] Confirm response model can add optional fields without breaking existing clients. — ✅ All new fields use `Field(default=None)` or `Field(default=False)`, backward-compatible.
-- [x] Identify all server response serialization paths for `tapps_consult_expert`. — ✅ Single path in `server.py:653-670`.
+- [x] Identify all server response serialization paths for `tapps_consult_expert`. — ✅ Single path in `server.py:654-670`.
 - [x] Freeze a baseline behavior snapshot for no-RAG responses (fixtures/snapshots). — ✅ Tests in `test_expert_engine.py:67-79` validate no-RAG field population.
 - [x] Define exact trigger condition for “no RAG” (`chunks_used == 0` and/or `sources == []`). — ✅ Trigger is `if context:` / `else:` in `engine.py:205-221` — fires when `kb.get_context()` returns empty string (which happens when `chunks == []`).
 
@@ -362,13 +363,61 @@ Implementation should start only when all are true:
   - `src/tapps_mcp/metrics/expert_metrics.py`
   - `src/tapps_mcp/metrics/rag_metrics.py`
 - Test files:
-  - `tests/unit/test_expert_engine.py` — expert engine + structured hints
-  - `tests/unit/test_expert_rag.py` — RAG retrieval + testing KB validation
-  - `tests/unit/test_fuzzy_matcher.py` — fuzzy matching v2
-  - `tests/unit/test_hot_rank.py` — hot-rank scoring
-  - `tests/unit/test_content_normalizer.py` — Context7 content normalization
-  - `tests/unit/test_retrieval_eval.py` — eval harness + quality gates
-  - `tests/integration/test_expert_pipeline.py` — end-to-end including tapps_research
+  - `tests/unit/test_expert_engine.py` — expert engine + structured hints (15 tests)
+  - `tests/unit/test_expert_rag.py` — RAG retrieval + testing KB validation (25 tests)
+  - `tests/unit/test_fuzzy_matcher.py` — fuzzy matching v2 (85 tests)
+  - `tests/unit/test_hot_rank.py` — hot-rank scoring (21 tests)
+  - `tests/unit/test_content_normalizer.py` — Context7 content normalization (40 tests)
+  - `tests/unit/test_retrieval_eval.py` — eval harness + quality gates (20 tests)
+  - `tests/unit/test_tapps_research.py` — tapps_research tool unit tests (5 tests)
+  - `tests/integration/test_expert_pipeline.py` — end-to-end including tapps_research (19 tests)
 - Prior plan and epic mapping docs:
   - `docs/planning/epics/README.md`
   - `docs/INIT_AND_UPGRADE_FEATURE_LIST.md`
+
+---
+
+## 10) Code-verified audit (2026-02-21)
+
+This section records the results of a full code-and-test audit performed against the repository.
+
+### 10.1) Methodology
+
+- Read every source file referenced in this plan and verified symbol existence and line numbers.
+- Ran `uv run pytest tests/ -v --tb=short` with Python 3.12 to confirm all tests pass.
+- Counted tests per file using `--collect-only` to verify plan claims.
+- Cross-checked AGENTS.md, server.py workflow hints, and settings.py config flags.
+
+### 10.2) Test inventory (epic-scoped files)
+
+| Test file | Tests | Notes |
+|---|---|---|
+| `tests/unit/test_expert_engine.py` | 15 | Expert engine + structured hints + fallback shape |
+| `tests/unit/test_expert_rag.py` | 25 | RAG retrieval + testing KB validation (3 tests for 10.4) |
+| `tests/unit/test_fuzzy_matcher.py` | 85 | LCS, edit distance, token overlap, multi-signal, confidence bands, "did you mean", manifest priors |
+| `tests/unit/test_hot_rank.py` | 21 | Hot-rank scoring, edge cases, boost application |
+| `tests/unit/test_content_normalizer.py` | 40 | Snippet extraction, ranking, dedup, token budgets, reference cards |
+| `tests/unit/test_retrieval_eval.py` | 20 | Benchmark queries, eval harness, quality gates |
+| `tests/unit/test_tapps_research.py` | 5 | Research tool response shape, routing, docs lookup |
+| `tests/integration/test_expert_pipeline.py` | 19 | End-to-end: consultation, RAG, domain detection, MCP handlers, tapps_research |
+| **Total (epic-scoped)** | **230** | **211 unit + 19 integration** |
+
+### 10.3) Full suite results
+
+```
+1658 passed, 7 skipped in 67.91s (Python 3.12.3)
+1569 unit tests + 96 integration tests = 1665 collected
+```
+
+### 10.4) Line-number corrections applied
+
+Several line references in the plan were off by 1-2 lines due to code edits since the original revision. Corrected in this audit:
+
+- `server.py:663-665` → `664-666` (suggested fields)
+- `server.py:666-668` → `667-669` (fallback fields)
+- `server.py:229-234` → `230-236` (recommended_workflow)
+- `server.py:653-670` → `654-670` (serialization path)
+
+### 10.5) Findings
+
+All 10 stories are fully implemented and tested. No gaps found between plan claims and repository code. All referenced symbols, handlers, files, and config flags exist at the specified locations (with minor line-number corrections applied above). The full test suite passes with zero failures.

--- a/docs/planning/TAPPS_MCP_PLAN.md
+++ b/docs/planning/TAPPS_MCP_PLAN.md
@@ -1,8 +1,8 @@
 # TappsMCP: Standalone MCP Server for LLM Code Quality
 
-**Status:** All Epics Complete (v0.1.1 released 2026-02-09)
+**Status:** All Epics Complete (v0.2.1 — Epics 0-11 shipped)
 **Created:** 2026-02-07
-**Revised:** 2026-02-09
+**Revised:** 2026-02-21
 **Source:** TappsCodingAgents (`C:\cursor\TappsCodingAgents`) — extracting the highest-value components into a standalone MCP server
 
 > **Epic Breakout (2026-02-07):** This monolithic plan has been broken into 8 separate

--- a/docs/planning/epics/README.md
+++ b/docs/planning/epics/README.md
@@ -16,11 +16,11 @@
 | [Epic 6](EPIC-6-DISTRIBUTION.md) | Distribution & Production Readiness | P3 | ~2-3 weeks | Epic 1+ | **Complete** |
 | [Epic 7](EPIC-7-METRICS-DASHBOARD.md) | Metrics, Observability & Dashboard | P1 | ~3-4 weeks | Epic 1, Epic 3, Epic 5 | **Complete** |
 | [Epic 8](EPIC-8-PIPELINE-ORCHESTRATION.md) | Pipeline Orchestration & Workflow Prompts | P1 | ~1.5-2 weeks | Epic 0-4 | **Complete** |
-| [Epic 10](../TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) | Expert + Context7 Integration | P1 | ~2-3 weeks | Epic 2, Epic 3 | **Planned** |
+| [Epic 10+11](../TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) | Expert + Context7 Integration & Retrieval Optimization | P1 | ~2-3 weeks | Epic 2, Epic 3 | **Complete** |
 
 **Total estimated LOE:** ~19-24 weeks (1 developer), ~10-13 weeks (2 developers with parallelized epics)
 
-> **Epic 10** implements enhancements from [TAPPS_MCP_IMPROVEMENT_RECOMMENDATIONS.md](../../../HomeIQ/implementation/TAPPS_MCP_IMPROVEMENT_RECOMMENDATIONS.md): auto-fallback to Context7 when expert RAG is empty, structured lookup hints, workflow coupling, broader testing KB, and optional `tapps_research` tool.
+> **Epic 10+11** implements enhancements from [TAPPS_MCP_IMPROVEMENT_RECOMMENDATIONS.md](../../../HomeIQ/implementation/TAPPS_MCP_IMPROVEMENT_RECOMMENDATIONS.md): auto-fallback to Context7 when expert RAG is empty, structured lookup hints, workflow coupling, broader testing KB, `tapps_research` tool, hybrid fusion + rerank, hot-rank adaptive ranking, fuzzy matcher v2, content normalization, and retrieval eval harness. All 10 stories shipped and tested (230 tests passing).
 
 ## Dependency Graph
 
@@ -67,6 +67,11 @@ With 2 developers:
 | `tapps_feedback` | Epic 7 | Week 14-17 |
 | `tapps_stats` | Epic 7 | Week 14-17 |
 | `tapps_dashboard` | Epic 7 | Week 16-20 |
+| `tapps_session_start` | Epic 8 | Week 12-14 |
+| `tapps_quick_check` | Epic 8 | Week 12-14 |
+| `tapps_validate_changed` | Epic 8 | Week 12-14 |
+| `tapps_workflow` | Epic 8 | Week 12-14 |
+| `tapps_research` | Epic 10 | Week 20-22 |
 
 ## Metrics Infrastructure (Epic 7 — carried from TappsCodingAgents)
 


### PR DESCRIPTION
Re-verified all Epic 10/11 implementation against actual code:
- Updated test counts: 230 epic-scoped tests (was 145), 1658 total suite
- Corrected server.py line references (off by 1-2 from prior revision)
- Added Section 10 with full audit methodology and per-file test inventory
- Added test_tapps_research.py to test file references

https://claude.ai/code/session_01QbW5UscMzLw7TknyGduYZC