### PR TITLE
fix: resolve all CI lint, format, and type-check failures

### DIFF
--- a/scripts/tapps_mcp_console.py
+++ b/scripts/tapps_mcp_console.py
@@ -2,6 +2,7 @@
 
 Calls the real CLI main() so the frozen exe behaves like ``tapps-mcp``.
 """
+
 from __future__ import annotations
 
 from tapps_mcp.cli import main

--- a/src/tapps_mcp/common/models.py
+++ b/src/tapps_mcp/common/models.py
@@ -78,9 +78,7 @@ class VectorRagDiagnostic(BaseModel):
         description="Whether sentence-transformers is importable."
     )
     numpy_available: bool = Field(description="Whether numpy is importable.")
-    status: str = Field(
-        description="'full_vector' if all deps present, 'keyword_only' otherwise."
-    )
+    status: str = Field(description="'full_vector' if all deps present, 'keyword_only' otherwise.")
 
 
 class KnowledgeDomainInfo(BaseModel):

--- a/src/tapps_mcp/common/nudges.py
+++ b/src/tapps_mcp/common/nudges.py
@@ -23,7 +23,7 @@ def _get_call_tracker() -> type[Any] | None:
     """Return CallTracker class if available, else None."""
     if _call_tracker_cache:
         val = _call_tracker_cache[0]
-        return val if val is not False else None
+        return val if isinstance(val, type) else None
     try:
         from tapps_mcp.tools.checklist import CallTracker
 
@@ -32,6 +32,7 @@ def _get_call_tracker() -> type[Any] | None:
     except ImportError:
         _call_tracker_cache.append(False)
         return None
+
 
 # Max nudges per response to avoid noise
 _MAX_NUDGES = 3
@@ -52,8 +53,9 @@ NudgeRule = tuple[Any, str]  # (callable, str) - use Any to avoid verbose typing
 _TOOL_NUDGES: dict[str, list[NudgeRule]] = {
     "tapps_server_info": [
         (
-            lambda called, _ctx: "tapps_project_profile" not in called
-            and "tapps_session_start" not in called,
+            lambda called, _ctx: (
+                "tapps_project_profile" not in called and "tapps_session_start" not in called
+            ),
             "NEXT: Call tapps_project_profile() to detect the project tech stack.",
         ),
     ],
@@ -85,8 +87,9 @@ _TOOL_NUDGES: dict[str, list[NudgeRule]] = {
             "Gate FAILED. Fix the issues, then re-run tapps_score_file() and tapps_quality_gate().",
         ),
         (
-            lambda called, ctx: (ctx or {}).get("gate_passed") is True
-            and "tapps_checklist" not in called,
+            lambda called, ctx: (
+                (ctx or {}).get("gate_passed") is True and "tapps_checklist" not in called
+            ),
             "NEXT: Call tapps_checklist() to verify no required steps were skipped.",
         ),
     ],
@@ -104,8 +107,9 @@ _TOOL_NUDGES: dict[str, list[NudgeRule]] = {
     ],
     "tapps_lookup_docs": [
         (
-            lambda called, _ctx: "tapps_score_file" not in called
-            and "tapps_quick_check" not in called,
+            lambda called, _ctx: (
+                "tapps_score_file" not in called and "tapps_quick_check" not in called
+            ),
             "NEXT: Write your code, then call tapps_score_file() or tapps_quick_check().",
         ),
     ],
@@ -125,9 +129,7 @@ _TOOL_NUDGES: dict[str, list[NudgeRule]] = {
 
 
 # Global nudge: remind about lookup_docs if never called
-_GLOBAL_LOOKUP_NUDGE = (
-    "REMINDER: Call tapps_lookup_docs() before using any external library API."
-)
+_GLOBAL_LOOKUP_NUDGE = "REMINDER: Call tapps_lookup_docs() before using any external library API."
 
 
 def compute_next_steps(

--- a/src/tapps_mcp/diagnostics.py
+++ b/src/tapps_mcp/diagnostics.py
@@ -113,9 +113,7 @@ def check_knowledge_base() -> KnowledgeBaseDiagnostic:
                 KnowledgeDomainInfo(domain=expert.primary_domain, file_count=file_count)
             )
         else:
-            domains_info.append(
-                KnowledgeDomainInfo(domain=expert.primary_domain, file_count=0)
-            )
+            domains_info.append(KnowledgeDomainInfo(domain=expert.primary_domain, file_count=0))
 
     missing = sorted(expected_domains - found_domains)
 

--- a/src/tapps_mcp/distribution/doctor.py
+++ b/src/tapps_mcp/distribution/doctor.py
@@ -61,37 +61,38 @@ def check_json_config(
     label: str,
 ) -> CheckResult:
     """Check a JSON MCP config file for a valid ``tapps-mcp`` entry."""
+    name = f"{label} config"
+    error = _validate_json_config(config_path, servers_key)
+    if error is not None:
+        return CheckResult(name, False, error)
+    return CheckResult(name, True, f"Configured in {config_path}")
+
+
+def _validate_json_config(config_path: Path, servers_key: str) -> str | None:
+    """Return an error message if *config_path* is invalid, else ``None``."""
     if not config_path.exists():
-        return CheckResult(f"{label} config", False, f"Not found: {config_path}")
+        return f"Not found: {config_path}"
 
     try:
         raw = config_path.read_text(encoding="utf-8")
         data: dict[str, Any] = json.loads(raw) if raw.strip() else {}
     except json.JSONDecodeError:
-        return CheckResult(f"{label} config", False, f"Invalid JSON: {config_path}")
+        return f"Invalid JSON: {config_path}"
 
     if not isinstance(data, dict):
-        return CheckResult(f"{label} config", False, f"Invalid structure: {config_path}")
+        return f"Invalid structure: {config_path}"
+
     servers = data.get(servers_key, {})
-    if not isinstance(servers, dict) or "tapps-mcp" not in servers:
-        return CheckResult(
-            f"{label} config",
-            False,
-            f"tapps-mcp not in {config_path}",
-        )
-
-    entry = servers.get("tapps-mcp")
+    entry = servers.get("tapps-mcp") if isinstance(servers, dict) else None
     if not isinstance(entry, dict):
-        return CheckResult(f"{label} config", False, f"Invalid tapps-mcp entry: {config_path}")
-    command = entry.get("command", "")
-    if command != "tapps-mcp":
-        return CheckResult(
-            f"{label} config",
-            False,
-            f"Unexpected command: '{command}' (expected 'tapps-mcp')",
-        )
+        return f"tapps-mcp not in {config_path}"
 
-    return CheckResult(f"{label} config", True, f"Configured in {config_path}")
+    command = entry.get("command", "")
+    return (
+        f"Unexpected command: '{command}' (expected 'tapps-mcp')"
+        if command != "tapps-mcp"
+        else None
+    )
 
 
 def check_claude_code_user(home: Path | None = None) -> CheckResult:
@@ -108,14 +109,18 @@ def check_claude_code_project(project_root: Path) -> CheckResult:
 def check_cursor_config(project_root: Path) -> CheckResult:
     """Check ``.cursor/mcp.json`` for tapps-mcp entry."""
     return check_json_config(
-        project_root / ".cursor" / "mcp.json", "mcpServers", "Cursor",
+        project_root / ".cursor" / "mcp.json",
+        "mcpServers",
+        "Cursor",
     )
 
 
 def check_vscode_config(project_root: Path) -> CheckResult:
     """Check ``.vscode/mcp.json`` for tapps-mcp entry."""
     return check_json_config(
-        project_root / ".vscode" / "mcp.json", "servers", "VS Code",
+        project_root / ".vscode" / "mcp.json",
+        "servers",
+        "VS Code",
     )
 
 

--- a/src/tapps_mcp/distribution/setup_generator.py
+++ b/src/tapps_mcp/distribution/setup_generator.py
@@ -279,48 +279,42 @@ def _check_config(host: str, project_root: Path, scope: str = "user") -> bool:
     config_path = _get_config_path(host, project_root, scope=scope)
     servers_key = _get_servers_key(host)
 
-    if not config_path.exists():
-        click.echo(click.style(f"Config file not found: {config_path}", fg="red"))
-        click.echo(f"  Run: tapps-mcp init --host {host}")
+    error = _validate_config_file(config_path, servers_key)
+    if error is not None:
+        click.echo(click.style(error, fg="red" if "Unexpected" not in error else "yellow"))
+        if "not found" in error.lower():
+            click.echo(f"  Run: tapps-mcp init --host {host}")
         return False
+
+    click.echo(click.style(f"tapps-mcp is correctly configured in {config_path}", fg="green"))
+    return True
+
+
+def _validate_config_file(config_path: Path, servers_key: str) -> str | None:
+    """Return an error string if *config_path* is invalid, else ``None``."""
+    if not config_path.exists():
+        return f"Config file not found: {config_path}"
 
     try:
         raw = config_path.read_text(encoding="utf-8")
         data = json.loads(raw)
     except json.JSONDecodeError:
-        click.echo(click.style(f"Invalid JSON in {config_path}", fg="red"))
-        return False
+        return f"Invalid JSON in {config_path}"
 
     if not isinstance(data, dict):
-        click.echo(click.style(f"Invalid structure in {config_path}", fg="red"))
-        return False
+        return f"Invalid structure in {config_path}"
+
     servers = data.get(servers_key, {})
-    if not isinstance(servers, dict) or "tapps-mcp" not in servers:
-        click.echo(
-            click.style(
-                f"tapps-mcp entry not found in {config_path} under '{servers_key}'",
-                fg="red",
-            )
-        )
-        click.echo(f"  Run: tapps-mcp init --host {host}")
-        return False
-
-    entry = servers.get("tapps-mcp")
+    entry = servers.get("tapps-mcp") if isinstance(servers, dict) else None
     if not isinstance(entry, dict):
-        click.echo(click.style(f"Invalid tapps-mcp entry in {config_path}", fg="red"))
-        return False
-    command = entry.get("command", "")
-    if command != "tapps-mcp":
-        click.echo(
-            click.style(
-                f"Unexpected command in tapps-mcp config: '{command}' (expected 'tapps-mcp')",
-                fg="yellow",
-            )
-        )
-        return False
+        return f"tapps-mcp entry not found in {config_path} under '{servers_key}'"
 
-    click.echo(click.style(f"tapps-mcp is correctly configured in {config_path}", fg="green"))
-    return True
+    command = entry.get("command", "")
+    return (
+        f"Unexpected command in tapps-mcp config: '{command}' (expected 'tapps-mcp')"
+        if command != "tapps-mcp"
+        else None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -375,13 +369,9 @@ def _generate_rules(host: str, project_root: Path) -> None:
     elif host == "cursor":
         action = _bootstrap_cursor(project_root)
         if action == "created":
-            click.echo(
-                click.style("  Created .cursor/rules/tapps-pipeline.md", fg="green")
-            )
+            click.echo(click.style("  Created .cursor/rules/tapps-pipeline.md", fg="green"))
         elif action == "updated":
-            click.echo(
-                click.style("  Updated .cursor/rules/tapps-pipeline.md", fg="green")
-            )
+            click.echo(click.style("  Updated .cursor/rules/tapps-pipeline.md", fg="green"))
         elif action == "skipped":
             click.echo("  .cursor/rules/tapps-pipeline.md already exists (skipped)")
     # VS Code has no platform rule equivalent — no-op
@@ -434,7 +424,12 @@ def run_init(
             return True
         click.echo(f"Detected MCP host(s): {', '.join(hosts)}")
         return _configure_multiple_hosts(
-            hosts, root, check=check, force=force, scope=scope, rules=rules,
+            hosts,
+            root,
+            check=check,
+            force=force,
+            scope=scope,
+            rules=rules,
         )
 
     if check:

--- a/src/tapps_mcp/experts/engine.py
+++ b/src/tapps_mcp/experts/engine.py
@@ -12,8 +12,12 @@ This is the main entry point for expert consultations.  It:
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 import structlog
+
+if TYPE_CHECKING:
+    from tapps_mcp.config.settings import TappsMCPSettings
 
 from tapps_mcp.experts.confidence import (
     compute_chunk_coverage,
@@ -224,18 +228,18 @@ def consult_expert(
         try:
             from tapps_mcp.config.settings import load_settings
 
-            settings = load_settings()
+            fallback_settings: TappsMCPSettings | None = load_settings()
         except Exception as exc:
             logger.debug("expert_fallback_settings_unavailable", reason=str(exc))
-            settings = None
+            fallback_settings = None
 
-        if settings is not None and settings.expert_auto_fallback:
+        if fallback_settings is not None and fallback_settings.expert_auto_fallback:
             ok, docs_content = _lookup_docs_sync(suggested_library, suggested_topic)
             if ok and docs_content:
                 fallback_used = True
                 fallback_library = suggested_library
                 fallback_topic = suggested_topic
-                fallback_excerpt = docs_content[: settings.expert_fallback_max_chars]
+                fallback_excerpt = docs_content[: fallback_settings.expert_fallback_max_chars]
                 answer = (
                     f"{answer}\n\n---\n\n"
                     "### Context7 fallback (auto-attached)\n\n"

--- a/src/tapps_mcp/experts/hot_rank.py
+++ b/src/tapps_mcp/experts/hot_rank.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import structlog
 
@@ -67,7 +69,11 @@ def compute_hot_rank(
         DomainHotRank with computed score and component breakdown.
     """
     # Recency weight: exponential decay.
-    recency = math.exp(-0.693 * days_since_last / _RECENCY_HALF_LIFE_DAYS) if days_since_last >= 0 else 1.0
+    recency = (
+        math.exp(-0.693 * days_since_last / _RECENCY_HALF_LIFE_DAYS)
+        if days_since_last >= 0
+        else 1.0
+    )
 
     # Exploration bonus for under-served domains.
     exploration = _EXPLORATION_BONUS if consultations < _EXPLORATION_THRESHOLD else 0.0
@@ -101,7 +107,6 @@ def get_domain_hot_ranks(metrics_dir: Path) -> list[DomainHotRank]:
     Returns:
         Sorted list of DomainHotRank (highest score first).
     """
-    from tapps_mcp.common.utils import utc_now
     from tapps_mcp.metrics.expert_metrics import ExpertPerformanceTracker
     from tapps_mcp.metrics.feedback import FeedbackTracker
 
@@ -116,7 +121,6 @@ def get_domain_hot_ranks(metrics_dir: Path) -> list[DomainHotRank]:
     expert_feedback = feedback_stats.get("tapps_consult_expert", {})
     overall_helpful_rate = expert_feedback.get("helpful_rate", 0.5) if expert_feedback else 0.5
 
-    now = utc_now()
     ranks: list[DomainHotRank] = []
 
     for domain, stats in domain_breakdown.items():
@@ -181,6 +185,6 @@ def apply_hot_rank_boost(
     boost = domain_rank.score * boost_factor
     for chunk in chunks:
         if hasattr(chunk, "score"):
-            chunk.score = min(1.0, chunk.score + boost)  # type: ignore[attr-defined]
+            chunk.score = min(1.0, chunk.score + boost)
 
     return chunks

--- a/src/tapps_mcp/experts/rag_warming.py
+++ b/src/tapps_mcp/experts/rag_warming.py
@@ -151,9 +151,7 @@ def warm_expert_rag_indices(
             knowledge_dir = kb_path / dir_name
 
             if not knowledge_dir.exists():
-                logger.debug(
-                    "rag_warm_skip_domain", domain=domain, reason="no_knowledge_dir"
-                )
+                logger.debug("rag_warm_skip_domain", domain=domain, reason="no_knowledge_dir")
                 continue
 
             idx_dir: Path | None = None

--- a/src/tapps_mcp/experts/retrieval_eval.py
+++ b/src/tapps_mcp/experts/retrieval_eval.py
@@ -10,14 +10,15 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from tapps_mcp.experts.models import KnowledgeChunk
-from tapps_mcp.experts.rag import SimpleKnowledgeBase
 from tapps_mcp.experts.registry import ExpertRegistry
 from tapps_mcp.experts.vector_rag import VectorKnowledgeBase
+
+if TYPE_CHECKING:
+    from tapps_mcp.experts.models import KnowledgeChunk
 
 logger = structlog.get_logger(__name__)
 
@@ -25,6 +26,7 @@ logger = structlog.get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Benchmark query set
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class BenchmarkQuery:
@@ -106,6 +108,7 @@ BENCHMARK_QUERIES: list[BenchmarkQuery] = [
 # Metrics
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class QueryResult:
     """Result of evaluating a single benchmark query."""
@@ -161,11 +164,14 @@ QUALITY_GATE_PASS_RATE = 0.6
 QUALITY_GATE_P95_LATENCY_MS = 500.0
 # Minimum average keyword coverage.
 QUALITY_GATE_MIN_KEYWORD_COVERAGE = 0.3
+# Minimum keyword coverage for a single query to be considered passing.
+_MIN_QUERY_KEYWORD_COVERAGE = 0.25
 
 
 # ---------------------------------------------------------------------------
 # Evaluation engine
 # ---------------------------------------------------------------------------
+
 
 def _evaluate_query(bq: BenchmarkQuery, kb: VectorKnowledgeBase) -> QueryResult:
     """Evaluate a single benchmark query against a knowledge base."""
@@ -181,7 +187,7 @@ def _evaluate_query(bq: BenchmarkQuery, kb: VectorKnowledgeBase) -> QueryResult:
     keyword_total = len(bq.expected_keywords)
     keyword_coverage = keyword_hits / keyword_total if keyword_total > 0 else 1.0
 
-    passed = len(chunks) >= bq.min_chunks and keyword_coverage >= 0.25
+    passed = len(chunks) >= bq.min_chunks and keyword_coverage >= _MIN_QUERY_KEYWORD_COVERAGE
 
     return QueryResult(
         query=bq,
@@ -230,7 +236,7 @@ def run_retrieval_eval(
         results.append(qr)
         if not qr.passed:
             failures.append(
-                f"FAIL [{bq.domain}] \"{bq.query[:60]}\" — "
+                f'FAIL [{bq.domain}] "{bq.query[:60]}" — '
                 f"chunks={qr.chunks_found}, keywords={qr.keyword_hits}/{qr.keyword_total}"
             )
 
@@ -243,10 +249,7 @@ def run_retrieval_eval(
     p95_latency = latencies[min(p95_idx, total - 1)] if total else 0.0
     top_scores = [r.top_score for r in results]
     avg_top = sum(top_scores) / total if total else 0.0
-    coverages = [
-        r.keyword_hits / r.keyword_total if r.keyword_total > 0 else 1.0
-        for r in results
-    ]
+    coverages = [r.keyword_hits / r.keyword_total if r.keyword_total > 0 else 1.0 for r in results]
     avg_coverage = sum(coverages) / total if total else 0.0
     fallback_count = sum(1 for r in results if r.chunks_found == 0)
     fallback_rate = fallback_count / total if total else 0.0

--- a/src/tapps_mcp/knowledge/content_normalizer.py
+++ b/src/tapps_mcp/knowledge/content_normalizer.py
@@ -25,6 +25,10 @@ _CHARS_PER_TOKEN = 4
 _MIN_SNIPPET_LENGTH = 30
 # Jaccard similarity threshold for deduplication.
 _DEDUP_THRESHOLD = 0.7
+# Minimum lines for a snippet to not be penalised.
+_MIN_SNIPPET_LINES = 3
+# Maximum lines for a snippet to not be penalised.
+_MAX_SNIPPET_LINES = 50
 
 
 @dataclass
@@ -130,6 +134,7 @@ def extract_snippets(content: str) -> list[CodeSnippet]:
 # Snippet ranking
 # ---------------------------------------------------------------------------
 
+
 def rank_snippets(
     snippets: list[CodeSnippet],
     query: str = "",
@@ -169,9 +174,7 @@ def rank_snippets(
 
         # Penalise very short or very long snippets.
         lines = snippet.code.count("\n") + 1
-        if lines < 3:
-            score -= 0.1
-        elif lines > 50:
+        if lines < _MIN_SNIPPET_LINES or lines > _MAX_SNIPPET_LINES:
             score -= 0.1
 
         snippet.score = round(min(1.0, max(0.0, score)), 4)
@@ -183,6 +186,7 @@ def rank_snippets(
 # ---------------------------------------------------------------------------
 # Deduplication
 # ---------------------------------------------------------------------------
+
 
 def deduplicate_snippets(
     snippets: list[CodeSnippet],
@@ -222,6 +226,7 @@ def deduplicate_snippets(
 # Token budget enforcement
 # ---------------------------------------------------------------------------
 
+
 def apply_token_budget(
     snippets: list[CodeSnippet],
     budget: int = _DEFAULT_SECTION_TOKEN_BUDGET,
@@ -240,6 +245,7 @@ def apply_token_budget(
 # ---------------------------------------------------------------------------
 # Main normalisation pipeline
 # ---------------------------------------------------------------------------
+
 
 def normalize_content(
     content: str,

--- a/src/tapps_mcp/knowledge/fuzzy_matcher.py
+++ b/src/tapps_mcp/knowledge/fuzzy_matcher.py
@@ -114,9 +114,9 @@ def edit_distance(a: str, b: str) -> int:
         for j in range(1, n + 1):
             cost = 0 if a[i - 1] == b[j - 1] else 1
             curr[j] = min(
-                prev[j] + 1,       # deletion
-                curr[j - 1] + 1,   # insertion
-                prev[j - 1] + cost, # substitution
+                prev[j] + 1,  # deletion
+                curr[j - 1] + 1,  # insertion
+                prev[j - 1] + cost,  # substitution
             )
         prev, curr = curr, [0] * (n + 1)
     return prev[n]
@@ -230,7 +230,9 @@ def fuzzy_match_library(
 
         if score >= threshold:
             band = confidence_band(score)
-            matches.append(FuzzyMatch(library=lib, score=round(score, 4), match_type=f"fuzzy_{band}"))
+            matches.append(
+                FuzzyMatch(library=lib, score=round(score, 4), match_type=f"fuzzy_{band}")
+            )
 
     # Sort by score descending
     matches.sort(key=lambda m: m.score, reverse=True)

--- a/src/tapps_mcp/knowledge/import_analyzer.py
+++ b/src/tapps_mcp/knowledge/import_analyzer.py
@@ -23,11 +23,24 @@ logger = structlog.get_logger(__name__)
 _STDLIB_MODULES: frozenset[str] = frozenset(sys.stdlib_module_names)
 
 # Common test/tool packages that aren't worth looking up docs for
-_SKIP_MODULES: frozenset[str] = frozenset({
-    "pytest", "unittest", "mock", "setuptools", "pip", "wheel",
-    "mypy", "ruff", "bandit", "radon", "pylint", "flake8",
-    "_pytest", "conftest",
-})
+_SKIP_MODULES: frozenset[str] = frozenset(
+    {
+        "pytest",
+        "unittest",
+        "mock",
+        "setuptools",
+        "pip",
+        "wheel",
+        "mypy",
+        "ruff",
+        "bandit",
+        "radon",
+        "pylint",
+        "flake8",
+        "_pytest",
+        "conftest",
+    }
+)
 
 
 def extract_external_imports(

--- a/src/tapps_mcp/knowledge/warming.py
+++ b/src/tapps_mcp/knowledge/warming.py
@@ -62,9 +62,7 @@ async def warm_cache(
         return 0
 
     # Filter out already-cached (non-stale) libraries
-    to_warm = [
-        lib for lib in libs[:max_libraries] if not cache.has(lib) or cache.is_stale(lib)
-    ]
+    to_warm = [lib for lib in libs[:max_libraries] if not cache.has(lib) or cache.is_stale(lib)]
 
     if not to_warm:
         logger.info("cache_warming_skipped", reason="all_cached")

--- a/src/tapps_mcp/metrics/dashboard.py
+++ b/src/tapps_mcp/metrics/dashboard.py
@@ -290,16 +290,13 @@ class DashboardGenerator:
         recent = self._execution.get_recent(limit=500)
 
         scored_files = {
-            m.file_path for m in recent
-            if m.tool_name == "tapps_score_file" and m.file_path
+            m.file_path for m in recent if m.tool_name == "tapps_score_file" and m.file_path
         }
         gated_files = {
-            m.file_path for m in recent
-            if m.tool_name == "tapps_quality_gate" and m.file_path
+            m.file_path for m in recent if m.tool_name == "tapps_quality_gate" and m.file_path
         }
         scanned_files = {
-            m.file_path for m in recent
-            if m.tool_name == "tapps_security_scan" and m.file_path
+            m.file_path for m in recent if m.tool_name == "tapps_security_scan" and m.file_path
         }
 
         # Gate skip rate: files scored but never gated
@@ -309,8 +306,10 @@ class DashboardGenerator:
         # Tool usage counts
         all_tool_names = {m.tool_name for m in recent}
         core_tools = {
-            "tapps_score_file", "tapps_quality_gate",
-            "tapps_security_scan", "tapps_checklist",
+            "tapps_score_file",
+            "tapps_quality_gate",
+            "tapps_security_scan",
+            "tapps_checklist",
         }
 
         lookup_calls = sum(1 for m in recent if m.tool_name == "tapps_lookup_docs")

--- a/src/tapps_mcp/metrics/feedback.py
+++ b/src/tapps_mcp/metrics/feedback.py
@@ -152,11 +152,13 @@ class FeedbackTracker:
         outcomes: list[dict[str, Any]] = []
         for r in records:
             if r.tool_name in scoring_tools:
-                outcomes.append({
-                    "first_pass_success": r.helpful,
-                    "initial_scores": {},
-                    "source": "feedback",
-                    "session_id": r.session_id,
-                    "timestamp": r.timestamp,
-                })
+                outcomes.append(
+                    {
+                        "first_pass_success": r.helpful,
+                        "initial_scores": {},
+                        "source": "feedback",
+                        "session_id": r.session_id,
+                        "timestamp": r.timestamp,
+                    }
+                )
         return outcomes

--- a/src/tapps_mcp/metrics/outcome_tracker.py
+++ b/src/tapps_mcp/metrics/outcome_tracker.py
@@ -109,7 +109,9 @@ class OutcomeTracker:
                 return None
 
             outcome.iterations += 1
-            outcome.final_scores = dict(scores) if isinstance(scores, dict) else outcome.final_scores
+            outcome.final_scores = (
+                dict(scores) if isinstance(scores, dict) else outcome.final_scores
+            )
             if expert_domain and expert_domain not in outcome.expert_consultations:
                 outcome.expert_consultations.append(expert_domain)
 

--- a/src/tapps_mcp/pipeline/init.py
+++ b/src/tapps_mcp/pipeline/init.py
@@ -140,7 +140,8 @@ def _verify_server(cfg: BootstrapConfig, state: _BootstrapState) -> None:
     """Run server verification and optional checker install."""
     if cfg.verify_server or cfg.install_missing_checkers:
         state.result["server_verification"] = _run_server_verification(
-            state.project_root, install_missing=cfg.install_missing_checkers,
+            state.project_root,
+            install_missing=cfg.install_missing_checkers,
         )
     else:
         state.result["server_verification"] = {"ok": True, "skipped": True}
@@ -191,7 +192,9 @@ def _create_agents_md(cfg: BootstrapConfig, state: _BootstrapState) -> None:
 
         try:
             action, detail = update_agents_md(
-                agents_path, template_content, overwrite=cfg.overwrite_agents_md,
+                agents_path,
+                template_content,
+                overwrite=cfg.overwrite_agents_md,
             )
             state.result["agents_md"] = {"action": action, **detail}
             if action == "validated":
@@ -233,25 +236,29 @@ def _warm_caches(cfg: BootstrapConfig, state: _BootstrapState) -> None:
     """Warm Context7 cache and expert RAG indices."""
     if cfg.warm_cache_from_tech_stack and state.profile is not None:
         cache_result = _run_cache_warming(
-            state.project_root, state.profile.tech_stack.context7_priority,
+            state.project_root,
+            state.profile.tech_stack.context7_priority,
         )
         state.result["cache_warming"] = cache_result
         if cache_result.get("error"):
             state.errors.append(f"Cache warming failed: {cache_result['error']}")
     else:
         state.result["cache_warming"] = {
-            "warmed": 0, "attempted": 0,
+            "warmed": 0,
+            "attempted": 0,
             "skipped": "disabled" if not cfg.warm_cache_from_tech_stack else "profile_failed",
             "libraries": [],
         }
 
     if cfg.warm_expert_rag_from_tech_stack and state.profile is not None:
         state.result["expert_rag_warming"] = _run_expert_rag_warming(
-            state.project_root, state.profile.tech_stack,
+            state.project_root,
+            state.profile.tech_stack,
         )
     else:
         state.result["expert_rag_warming"] = {
-            "warmed": 0, "attempted": 0,
+            "warmed": 0,
+            "attempted": 0,
             "skipped": "disabled" if not cfg.warm_expert_rag_from_tech_stack else "profile_failed",
             "domains": [],
         }
@@ -287,9 +294,7 @@ def _run_server_verification(
         for hint in install_hints:
             if hint and hint.startswith("pip install "):
                 pkg = hint.replace("pip install ", "").strip()
-                with contextlib.suppress(
-                    subprocess.TimeoutExpired, FileNotFoundError, OSError
-                ):
+                with contextlib.suppress(subprocess.TimeoutExpired, FileNotFoundError, OSError):
                     subprocess.run(
                         [sys.executable, "-m", "pip", "install", pkg],
                         capture_output=True,
@@ -334,26 +339,20 @@ def _render_tech_stack_md(profile: ProjectProfile) -> str:
     lines.extend(["", "## Context7 Priority (for doc lookups)"])
     for p in ts.context7_priority or []:
         lines.append(f"- {p}")
-    ci_str = (
-        "Yes (" + ", ".join(profile.ci_systems) + ")"
-        if profile.has_ci
-        else "No"
+    ci_str = "Yes (" + ", ".join(profile.ci_systems) + ")" if profile.has_ci else "No"
+    tests_str = "Yes (" + ", ".join(profile.test_frameworks) + ")" if profile.has_tests else "No"
+    lines.extend(
+        [
+            "",
+            "## Infrastructure",
+            f"- **CI:** {ci_str}",
+            f"- **Docker:** {'Yes' if profile.has_docker else 'No'}",
+            f"- **Tests:** {tests_str}",
+            f"- **Package managers:** {', '.join(profile.package_managers) or 'N/A'}",
+            "",
+            "## Recommendations",
+        ]
     )
-    tests_str = (
-        "Yes (" + ", ".join(profile.test_frameworks) + ")"
-        if profile.has_tests
-        else "No"
-    )
-    lines.extend([
-        "",
-        "## Infrastructure",
-        f"- **CI:** {ci_str}",
-        f"- **Docker:** {'Yes' if profile.has_docker else 'No'}",
-        f"- **Tests:** {tests_str}",
-        f"- **Package managers:** {', '.join(profile.package_managers) or 'N/A'}",
-        "",
-        "## Recommendations",
-    ])
     for rec in profile.quality_recommendations or ["(none)"]:
         lines.append(f"- {rec}")
     lines.append("")

--- a/src/tapps_mcp/project/report.py
+++ b/src/tapps_mcp/project/report.py
@@ -204,9 +204,7 @@ def _render_html(
 
     gate_rate = summary.get("gate_pass_rate")
     gate_line = (
-        f"<p>Gate pass rate: {gate_rate:.0%}</p>"
-        if isinstance(gate_rate, (int, float))
-        else ""
+        f"<p>Gate pass rate: {gate_rate:.0%}</p>" if isinstance(gate_rate, (int, float)) else ""
     )
 
     return f"""<!DOCTYPE html>

--- a/src/tapps_mcp/project/tech_stack.py
+++ b/src/tapps_mcp/project/tech_stack.py
@@ -283,7 +283,9 @@ def _extract_dep_name(raw: str) -> str | None:
 
 
 def _walk_project_files(
-    root: Path, patterns: list[str], max_files: int,
+    root: Path,
+    patterns: list[str],
+    max_files: int,
 ) -> Iterator[Path]:
     """Yield project files matching *patterns*, skipping ignored dirs."""
     n = 0

--- a/src/tapps_mcp/scoring/models.py
+++ b/src/tapps_mcp/scoring/models.py
@@ -14,9 +14,7 @@ class CategoryScore(BaseModel):
     details: dict[str, object] = Field(
         default_factory=dict, description="Category-specific detail."
     )
-    suggestions: list[str] = Field(
-        default_factory=list, description="Actionable improvement tips."
-    )
+    suggestions: list[str] = Field(default_factory=list, description="Actionable improvement tips.")
 
 
 class LintIssue(BaseModel):

--- a/src/tapps_mcp/scoring/scorer.py
+++ b/src/tapps_mcp/scoring/scorer.py
@@ -320,11 +320,7 @@ class CodeScorer:
         root = _find_project_root(file_path)
         if root is None:
             return 5.0
-        pts = sum(
-            points
-            for points, names in signals
-            if any((root / n).exists() for n in names)
-        )
+        pts = sum(points for points, names in signals if any((root / n).exists() for n in names))
         return clamp_individual(min(10.0, pts * 2.0))
 
     @staticmethod
@@ -413,8 +409,7 @@ class CodeScorer:
         if root is None:
             return 5.0
         pts = sum(
-            p for p, names in CodeScorer._DEVEX_SIGNALS
-            if any((root / n).exists() for n in names)
+            p for p, names in CodeScorer._DEVEX_SIGNALS if any((root / n).exists() for n in names)
         )
         pyproject = root / "pyproject.toml"
         if pyproject.exists():
@@ -557,8 +552,7 @@ def _suggest_complexity(
         )
     elif max_cc > _CC_MODERATE:
         tips.append(
-            f"Function '{func_name}' has CC={int(max_cc)}. "
-            "Consider simplifying conditional logic."
+            f"Function '{func_name}' has CC={int(max_cc)}. Consider simplifying conditional logic."
         )
     return tips
 
@@ -573,10 +567,7 @@ def _suggest_security(
         return tips
     issue_count = int(str(details.get("issue_count", 0)))
     if issue_count > 0:
-        tips.append(
-            f"Found {issue_count} security issue(s). "
-            "Run tapps_security_scan for details."
-        )
+        tips.append(f"Found {issue_count} security issue(s). Run tapps_security_scan for details.")
     patterns = details.get("patterns_found")
     if isinstance(patterns, list) and patterns:
         joined = ", ".join(str(p) for p in patterns)
@@ -641,10 +632,7 @@ def _suggest_performance(
                 "Decompose into smaller functions."
             )
         elif issue_str == "large_function":
-            tips.append(
-                f"Function exceeds {LARGE_FUNCTION_LINES} lines. "
-                "Consider breaking it up."
-            )
+            tips.append(f"Function exceeds {LARGE_FUNCTION_LINES} lines. Consider breaking it up.")
         elif issue_str == "very_deep_nesting":
             tips.append(
                 f"Nesting depth > {VERY_DEEP_NESTING_THRESHOLD}. "
@@ -652,18 +640,15 @@ def _suggest_performance(
             )
         elif issue_str == "deep_nesting":
             tips.append(
-                f"Nesting depth > {DEEP_NESTING_THRESHOLD}. "
-                "Extract inner logic into helpers."
+                f"Nesting depth > {DEEP_NESTING_THRESHOLD}. Extract inner logic into helpers."
             )
         elif issue_str == "nested_loops":
             tips.append(
-                "Nested for-loops detected. "
-                "Consider alternative data structures or itertools."
+                "Nested for-loops detected. Consider alternative data structures or itertools."
             )
         elif issue_str == "expensive_comprehension":
             tips.append(
-                "List comprehension with many function calls. "
-                "Consider a plain loop for clarity."
+                "List comprehension with many function calls. Consider a plain loop for clarity."
             )
     return tips
 
@@ -680,7 +665,5 @@ def _suggest_devex(score: float) -> list[str]:
     """Actionable suggestions for the devex category."""
     tips: list[str] = []
     if score < _SCORE_LOW:
-        tips.append(
-            "Add CLAUDE.md or AGENTS.md for AI-assisted development guidance."
-        )
+        tips.append("Add CLAUDE.md or AGENTS.md for AI-assisted development guidance.")
     return tips

--- a/src/tapps_mcp/server.py
+++ b/src/tapps_mcp/server.py
@@ -174,13 +174,27 @@ def tapps_server_info() -> dict[str, Any]:
         available_tools = list(tool_manager._tools.keys())
     except AttributeError:
         available_tools = [
-            "tapps_server_info", "tapps_session_start", "tapps_score_file",
-            "tapps_security_scan", "tapps_quality_gate", "tapps_lookup_docs",
-            "tapps_validate_config", "tapps_validate_changed", "tapps_quick_check",
-            "tapps_consult_expert", "tapps_list_experts", "tapps_checklist",
-            "tapps_project_profile", "tapps_session_notes", "tapps_impact_analysis",
-            "tapps_report", "tapps_init", "tapps_dashboard", "tapps_stats",
-            "tapps_feedback", "tapps_research",
+            "tapps_server_info",
+            "tapps_session_start",
+            "tapps_score_file",
+            "tapps_security_scan",
+            "tapps_quality_gate",
+            "tapps_lookup_docs",
+            "tapps_validate_config",
+            "tapps_validate_changed",
+            "tapps_quick_check",
+            "tapps_consult_expert",
+            "tapps_list_experts",
+            "tapps_checklist",
+            "tapps_project_profile",
+            "tapps_session_notes",
+            "tapps_impact_analysis",
+            "tapps_report",
+            "tapps_init",
+            "tapps_dashboard",
+            "tapps_stats",
+            "tapps_feedback",
+            "tapps_research",
         ]
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
@@ -188,46 +202,57 @@ def tapps_server_info() -> dict[str, Any]:
 
     from tapps_mcp.pipeline.models import STAGE_TOOLS, PipelineStage
 
-    resp = success_response("tapps_server_info", elapsed_ms, {
-        "server": {"name": "TappsMCP", "version": __version__, "protocol_version": "2025-11-25"},
-        "configuration": {
-            "project_root": str(settings.project_root),
-            "quality_preset": settings.quality_preset,
-            "log_level": settings.log_level,
+    resp = success_response(
+        "tapps_server_info",
+        elapsed_ms,
+        {
+            "server": {
+                "name": "TappsMCP",
+                "version": __version__,
+                "protocol_version": "2025-11-25",
+            },
+            "configuration": {
+                "project_root": str(settings.project_root),
+                "quality_preset": settings.quality_preset,
+                "log_level": settings.log_level,
+            },
+            "available_tools": available_tools,
+            "installed_checkers": [t.model_dump() for t in installed],
+            "diagnostics": diagnostics.model_dump(),
+            "recommended_workflow": (
+                "FIRST: Call tapps_session_start() to initialize. "
+                "BEFORE using any library: Call tapps_lookup_docs(). "
+                "AFTER editing Python files: "
+                "Call tapps_score_file(quick=True) or tapps_quick_check(). "
+                "BEFORE declaring done: Call tapps_validate_changed() or tapps_quality_gate(). "
+                "FINAL step: Call tapps_checklist()."
+            ),
+            "quick_start": [
+                "1. FIRST: Call tapps_session_start() to initialize the session",
+                "2. BEFORE using any library API: Call tapps_lookup_docs(library='<name>')",
+                "3. DURING edits: Call tapps_quick_check(file_path='<path>') after each change",
+                "4. BEFORE declaring done: Call tapps_validate_changed() - all gates MUST pass",
+                "5. FINAL step: Call tapps_checklist(task_type='<type>') to verify completeness",
+            ],
+            "critical_rules": [
+                "BLOCKING: tapps_quality_gate MUST pass before work is complete",
+                "BLOCKING: tapps_lookup_docs MUST be called before using external library APIs",
+                "REQUIRED: tapps_score_file MUST be called on every modified Python file",
+                "NEVER skip tapps_checklist as the final verification step",
+            ],
+            "pipeline": {
+                "name": "TAPPS Quality Pipeline",
+                "stages": [s.value for s in PipelineStage],
+                "current_hint": (
+                    "Start with tapps_pipeline_overview prompt, or follow stages in order."
+                ),
+                "stage_tools": {s.value: tools for s, tools in STAGE_TOOLS.items()},
+                "handoff_file": "docs/TAPPS_HANDOFF.md",
+                "runlog_file": "docs/TAPPS_RUNLOG.md",
+                "prompts_available": True,
+            },
         },
-        "available_tools": available_tools,
-        "installed_checkers": [t.model_dump() for t in installed],
-        "diagnostics": diagnostics.model_dump(),
-        "recommended_workflow": (
-            "FIRST: Call tapps_session_start() to initialize. "
-            "BEFORE using any library: Call tapps_lookup_docs(). "
-            "AFTER editing Python files: Call tapps_score_file(quick=True) or tapps_quick_check(). "
-            "BEFORE declaring done: Call tapps_validate_changed() or tapps_quality_gate(). "
-            "FINAL step: Call tapps_checklist()."
-        ),
-        "quick_start": [
-            "1. FIRST: Call tapps_session_start() to initialize the session",
-            "2. BEFORE using any library API: Call tapps_lookup_docs(library='<name>')",
-            "3. DURING edits: Call tapps_quick_check(file_path='<path>') after each change",
-            "4. BEFORE declaring done: Call tapps_validate_changed() - all gates MUST pass",
-            "5. FINAL step: Call tapps_checklist(task_type='<type>') to verify completeness",
-        ],
-        "critical_rules": [
-            "BLOCKING: tapps_quality_gate MUST pass before work is complete",
-            "BLOCKING: tapps_lookup_docs MUST be called before using external library APIs",
-            "REQUIRED: tapps_score_file MUST be called on every modified Python file",
-            "NEVER skip tapps_checklist as the final verification step",
-        ],
-        "pipeline": {
-            "name": "TAPPS Quality Pipeline",
-            "stages": [s.value for s in PipelineStage],
-            "current_hint": "Start with tapps_pipeline_overview prompt, or follow stages in order.",
-            "stage_tools": {s.value: tools for s, tools in STAGE_TOOLS.items()},
-            "handoff_file": "docs/TAPPS_HANDOFF.md",
-            "runlog_file": "docs/TAPPS_RUNLOG.md",
-            "prompts_available": True,
-        },
-    })
+    )
     return _with_nudges("tapps_server_info", resp)
 
 
@@ -252,30 +277,45 @@ def tapps_security_scan(file_path: str, scan_secrets: bool = True) -> dict[str, 
 
     settings = load_settings()
     result = run_security_scan(
-        str(resolved), scan_secrets=scan_secrets,
-        cwd=str(settings.project_root), timeout=settings.tool_timeout,
+        str(resolved),
+        scan_secrets=scan_secrets,
+        cwd=str(settings.project_root),
+        timeout=settings.tool_timeout,
     )
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution(
-        "tapps_security_scan", start,
-        file_path=str(resolved), degraded=not result.bandit_available,
+        "tapps_security_scan",
+        start,
+        file_path=str(resolved),
+        degraded=not result.bandit_available,
     )
 
-    resp = success_response("tapps_security_scan", elapsed_ms, {
-        "file_path": str(resolved), "passed": result.passed,
-        "total_issues": result.total_issues, "critical_count": result.critical_count,
-        "high_count": result.high_count, "medium_count": result.medium_count,
-        "low_count": result.low_count, "bandit_available": result.bandit_available,
-        "bandit_issues": serialize_issues(result.bandit_issues, limit=30),
-        "secret_findings": serialize_issues(result.secret_findings, limit=30),
-    }, degraded=not result.bandit_available)
+    resp = success_response(
+        "tapps_security_scan",
+        elapsed_ms,
+        {
+            "file_path": str(resolved),
+            "passed": result.passed,
+            "total_issues": result.total_issues,
+            "critical_count": result.critical_count,
+            "high_count": result.high_count,
+            "medium_count": result.medium_count,
+            "low_count": result.low_count,
+            "bandit_available": result.bandit_available,
+            "bandit_issues": serialize_issues(result.bandit_issues, limit=30),
+            "secret_findings": serialize_issues(result.secret_findings, limit=30),
+        },
+        degraded=not result.bandit_available,
+    )
     return _with_nudges("tapps_security_scan", resp)
 
 
 @mcp.tool()
 async def tapps_lookup_docs(
-    library: str, topic: str = "overview", mode: str = "code",
+    library: str,
+    topic: str = "overview",
+    mode: str = "code",
 ) -> dict[str, Any]:
     """BLOCKING REQUIREMENT before using any external library API. Returns
     current docs (Context7 + cache) to prevent hallucinated APIs.
@@ -303,8 +343,10 @@ async def tapps_lookup_docs(
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
 
     data: dict[str, Any] = {
-        "library": result.library, "topic": result.topic,
-        "source": result.source, "cache_hit": result.cache_hit,
+        "library": result.library,
+        "topic": result.topic,
+        "source": result.source,
+        "cache_hit": result.cache_hit,
         "response_time_ms": result.response_time_ms,
     }
     if result.content is not None:
@@ -316,7 +358,8 @@ async def tapps_lookup_docs(
         data["fuzzy_score"] = result.fuzzy_score
 
     _record_execution(
-        "tapps_lookup_docs", start,
+        "tapps_lookup_docs",
+        start,
         status="success" if result.success else "failed",
         error_code="api_key_missing" if (result.error and "API key" in result.error) else None,
     )
@@ -356,13 +399,20 @@ def tapps_validate_config(file_path: str, config_type: str = "auto") -> dict[str
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_validate_config", start, file_path=str(resolved))
 
-    resp = success_response("tapps_validate_config", elapsed_ms, {
-        "file_path": result.file_path, "config_type": result.config_type,
-        "valid": result.valid, "findings": [f.model_dump() for f in result.findings],
-        "suggestions": result.suggestions, "finding_count": len(result.findings),
-        "critical_count": sum(1 for f in result.findings if f.severity == "critical"),
-        "warning_count": sum(1 for f in result.findings if f.severity == "warning"),
-    })
+    resp = success_response(
+        "tapps_validate_config",
+        elapsed_ms,
+        {
+            "file_path": result.file_path,
+            "config_type": result.config_type,
+            "valid": result.valid,
+            "findings": [f.model_dump() for f in result.findings],
+            "suggestions": result.suggestions,
+            "finding_count": len(result.findings),
+            "critical_count": sum(1 for f in result.findings if f.severity == "critical"),
+            "warning_count": sum(1 for f in result.findings if f.severity == "warning"),
+        },
+    )
     return _with_nudges("tapps_validate_config", resp)
 
 
@@ -385,20 +435,27 @@ def tapps_consult_expert(question: str, domain: str = "") -> dict[str, Any]:
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_consult_expert", start)
 
-    resp = success_response("tapps_consult_expert", elapsed_ms, {
-        "domain": result.domain, "expert_id": result.expert_id,
-        "expert_name": result.expert_name, "answer": result.answer,
-        "confidence": round(result.confidence, 4),
-        "factors": result.factors.model_dump(), "sources": result.sources,
-        "chunks_used": result.chunks_used,
-        "low_confidence_nudge": result.low_confidence_nudge,
-        "suggested_tool": result.suggested_tool,
-        "suggested_library": result.suggested_library,
-        "suggested_topic": result.suggested_topic,
-        "fallback_used": result.fallback_used,
-        "fallback_library": result.fallback_library,
-        "fallback_topic": result.fallback_topic,
-    })
+    resp = success_response(
+        "tapps_consult_expert",
+        elapsed_ms,
+        {
+            "domain": result.domain,
+            "expert_id": result.expert_id,
+            "expert_name": result.expert_name,
+            "answer": result.answer,
+            "confidence": round(result.confidence, 4),
+            "factors": result.factors.model_dump(),
+            "sources": result.sources,
+            "chunks_used": result.chunks_used,
+            "low_confidence_nudge": result.low_confidence_nudge,
+            "suggested_tool": result.suggested_tool,
+            "suggested_library": result.suggested_library,
+            "suggested_topic": result.suggested_topic,
+            "fallback_used": result.fallback_used,
+            "fallback_library": result.fallback_library,
+            "fallback_topic": result.fallback_topic,
+        },
+    )
     return _with_nudges("tapps_consult_expert", resp)
 
 
@@ -414,9 +471,14 @@ def tapps_list_experts() -> dict[str, Any]:
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_list_experts", start)
 
-    resp = success_response("tapps_list_experts", elapsed_ms, {
-        "expert_count": len(experts), "experts": [e.model_dump() for e in experts],
-    })
+    resp = success_response(
+        "tapps_list_experts",
+        elapsed_ms,
+        {
+            "expert_count": len(experts),
+            "experts": [e.model_dump() for e in experts],
+        },
+    )
     return _with_nudges("tapps_list_experts", resp)
 
 
@@ -442,10 +504,16 @@ def tapps_checklist(task_type: str = "review") -> dict[str, Any]:
         elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
         _record_execution("tapps_checklist", start)
         fallback_data = {
-            "task_type": task_type, "called": [], "missing_required": [],
-            "missing_recommended": [], "missing_optional": [],
-            "missing_required_hints": [], "missing_recommended_hints": [],
-            "missing_optional_hints": [], "complete": False, "total_calls": 0,
+            "task_type": task_type,
+            "called": [],
+            "missing_required": [],
+            "missing_recommended": [],
+            "missing_optional": [],
+            "missing_required_hints": [],
+            "missing_recommended_hints": [],
+            "missing_optional_hints": [],
+            "complete": False,
+            "total_calls": 0,
             "checklist_unavailable": True,
             "message": (
                 "Module tapps_mcp.tools.checklist is not available. "
@@ -481,26 +549,34 @@ def tapps_project_profile(project_root: str = "") -> dict[str, Any]:
     except Exception as exc:
         elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
         _record_execution(
-            "tapps_project_profile", start,
-            status="failed", error_code="profile_failed",
+            "tapps_project_profile",
+            start,
+            status="failed",
+            error_code="profile_failed",
         )
         return error_response("tapps_project_profile", "profile_failed", str(exc))
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_project_profile", start)
 
-    resp = success_response("tapps_project_profile", elapsed_ms, {
-        "project_root": str(root),
-        "tech_stack": profile.tech_stack.model_dump(),
-        "project_type": profile.project_type,
-        "project_type_confidence": round(profile.project_type_confidence, 2),
-        "project_type_reason": profile.project_type_reason,
-        "has_ci": profile.has_ci, "ci_systems": profile.ci_systems,
-        "has_docker": profile.has_docker, "has_tests": profile.has_tests,
-        "test_frameworks": profile.test_frameworks,
-        "package_managers": profile.package_managers,
-        "quality_recommendations": profile.quality_recommendations,
-    })
+    resp = success_response(
+        "tapps_project_profile",
+        elapsed_ms,
+        {
+            "project_root": str(root),
+            "tech_stack": profile.tech_stack.model_dump(),
+            "project_type": profile.project_type,
+            "project_type_confidence": round(profile.project_type_confidence, 2),
+            "project_type_reason": profile.project_type_reason,
+            "has_ci": profile.has_ci,
+            "ci_systems": profile.ci_systems,
+            "has_docker": profile.has_docker,
+            "has_tests": profile.has_tests,
+            "test_frameworks": profile.test_frameworks,
+            "package_managers": profile.package_managers,
+            "quality_recommendations": profile.quality_recommendations,
+        },
+    )
     return _with_nudges("tapps_project_profile", resp)
 
 
@@ -537,7 +613,8 @@ def tapps_session_notes(action: str, key: str = "", value: str = "") -> dict[str
     if action == "save":
         if not key or not value:
             return error_response(
-                "tapps_session_notes", "missing_params",
+                "tapps_session_notes",
+                "missing_params",
                 "save requires key and value",
             )
         note = store.save(key, value)
@@ -557,7 +634,8 @@ def tapps_session_notes(action: str, key: str = "", value: str = "") -> dict[str
         data = {"action": "clear", "cleared_count": store.clear(key or None)}
     else:
         return error_response(
-            "tapps_session_notes", "invalid_action",
+            "tapps_session_notes",
+            "invalid_action",
             f"Unknown action: {action}. Use save/get/list/clear.",
         )
 
@@ -592,14 +670,20 @@ def tapps_impact_analysis(file_path: str, change_type: str = "modified") -> dict
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_impact_analysis", start, file_path=str(resolved))
 
-    resp = success_response("tapps_impact_analysis", elapsed_ms, {
-        "changed_file": report.changed_file, "change_type": report.change_type,
-        "severity": report.severity, "total_affected": report.total_affected,
-        "direct_dependents": [d.model_dump() for d in report.direct_dependents],
-        "transitive_dependents": [d.model_dump() for d in report.transitive_dependents],
-        "test_files": [t.model_dump() for t in report.test_files],
-        "recommendations": report.recommendations,
-    })
+    resp = success_response(
+        "tapps_impact_analysis",
+        elapsed_ms,
+        {
+            "changed_file": report.changed_file,
+            "change_type": report.change_type,
+            "severity": report.severity,
+            "total_affected": report.total_affected,
+            "direct_dependents": [d.model_dump() for d in report.direct_dependents],
+            "transitive_dependents": [d.model_dump() for d in report.transitive_dependents],
+            "test_files": [t.model_dump() for t in report.test_files],
+            "recommendations": report.recommendations,
+        },
+    )
     return _with_nudges("tapps_impact_analysis", resp)
 
 

--- a/src/tapps_mcp/server_metrics_tools.py
+++ b/src/tapps_mcp/server_metrics_tools.py
@@ -24,7 +24,8 @@ _PERIOD_DAYS: dict[str, int] = {"1d": 1, "7d": 7, "30d": 30}
 
 
 def _session_stats(
-    hub: MetricsHub, tool_name: str | None,
+    hub: MetricsHub,
+    tool_name: str | None,
 ) -> tuple[Any, list[dict[str, Any]]]:
     """Compute stats from in-memory session data."""
     from tapps_mcp.metrics.execution_metrics import ToolCallMetricsCollector
@@ -41,18 +42,22 @@ def _session_stats(
         if tool_name and tname != tool_name:
             continue
         ts = ToolCallMetricsCollector._compute_summary(tmetrics)
-        breakdowns.append({
-            "tool_name": tname,
-            "call_count": ts.total_calls,
-            "success_rate": ts.success_rate,
-            "avg_duration_ms": ts.avg_duration_ms,
-            "p95_duration_ms": ts.p95_duration_ms,
-        })
+        breakdowns.append(
+            {
+                "tool_name": tname,
+                "call_count": ts.total_calls,
+                "success_rate": ts.success_rate,
+                "avg_duration_ms": ts.avg_duration_ms,
+                "p95_duration_ms": ts.p95_duration_ms,
+            }
+        )
     return summary, breakdowns
 
 
 def _period_stats(
-    hub: MetricsHub, tool_name: str | None, period: str,
+    hub: MetricsHub,
+    tool_name: str | None,
+    period: str,
 ) -> tuple[Any, list[dict[str, Any]]]:
     """Compute stats from persisted data for a given time period."""
     from datetime import UTC, datetime, timedelta
@@ -162,16 +167,20 @@ def tapps_stats(
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_stats", start)
 
-    resp = success_response("tapps_stats", elapsed_ms, {
-        "period": period,
-        "total_calls": summary.total_calls,
-        "success_rate": summary.success_rate,
-        "avg_duration_ms": summary.avg_duration_ms,
-        "p95_duration_ms": summary.p95_duration_ms,
-        "gate_pass_rate": summary.gate_pass_rate,
-        "avg_score": summary.avg_score,
-        "tools": tool_breakdowns,
-    })
+    resp = success_response(
+        "tapps_stats",
+        elapsed_ms,
+        {
+            "period": period,
+            "total_calls": summary.total_calls,
+            "success_rate": summary.success_rate,
+            "avg_duration_ms": summary.avg_duration_ms,
+            "p95_duration_ms": summary.p95_duration_ms,
+            "gate_pass_rate": summary.gate_pass_rate,
+            "avg_score": summary.avg_score,
+            "tools": tool_breakdowns,
+        },
+    )
     return _with_nudges("tapps_stats", resp)
 
 
@@ -213,13 +222,17 @@ def tapps_feedback(
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_feedback", start)
 
-    resp = success_response("tapps_feedback", elapsed_ms, {
-        "recorded": True,
-        "tool_name": tool_name,
-        "helpful": helpful,
-        "tool_stats": stats,
-        "overall_stats": overall_stats,
-    })
+    resp = success_response(
+        "tapps_feedback",
+        elapsed_ms,
+        {
+            "recorded": True,
+            "tool_name": tool_name,
+            "helpful": helpful,
+            "tool_stats": stats,
+            "overall_stats": overall_stats,
+        },
+    )
     return _with_nudges("tapps_feedback", resp)
 
 
@@ -279,7 +292,9 @@ def tapps_research(
                 engine = LookupEngine(cache, api_key=settings.context7_api_key)
                 try:
                     lr = await engine.lookup(
-                        library=lookup_library, topic=lookup_topic, mode="code",
+                        library=lookup_library,
+                        topic=lookup_topic,
+                        mode="code",
                     )
                 finally:
                     await engine.close()
@@ -309,26 +324,30 @@ def tapps_research(
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_research", start)
 
-    resp = success_response("tapps_research", elapsed_ms, {
-        "domain": result.domain,
-        "expert_id": result.expert_id,
-        "expert_name": result.expert_name,
-        "answer": answer,
-        "confidence": round(result.confidence, 4),
-        "factors": result.factors.model_dump(),
-        "sources": result.sources,
-        "chunks_used": result.chunks_used,
-        "docs_supplemented": docs_content is not None,
-        "docs_library": docs_library,
-        "docs_topic": docs_topic,
-        "docs_error": docs_error,
-        "suggested_tool": result.suggested_tool,
-        "suggested_library": result.suggested_library,
-        "suggested_topic": result.suggested_topic,
-        "fallback_used": result.fallback_used,
-        "fallback_library": result.fallback_library,
-        "fallback_topic": result.fallback_topic,
-    })
+    resp = success_response(
+        "tapps_research",
+        elapsed_ms,
+        {
+            "domain": result.domain,
+            "expert_id": result.expert_id,
+            "expert_name": result.expert_name,
+            "answer": answer,
+            "confidence": round(result.confidence, 4),
+            "factors": result.factors.model_dump(),
+            "sources": result.sources,
+            "chunks_used": result.chunks_used,
+            "docs_supplemented": docs_content is not None,
+            "docs_library": docs_library,
+            "docs_topic": docs_topic,
+            "docs_error": docs_error,
+            "suggested_tool": result.suggested_tool,
+            "suggested_library": result.suggested_library,
+            "suggested_topic": result.suggested_topic,
+            "fallback_used": result.fallback_used,
+            "fallback_library": result.fallback_library,
+            "fallback_topic": result.fallback_topic,
+        },
+    )
     return _with_nudges("tapps_research", resp)
 
 

--- a/src/tapps_mcp/server_pipeline_tools.py
+++ b/src/tapps_mcp/server_pipeline_tools.py
@@ -65,13 +65,17 @@ async def tapps_validate_changed(
     if not paths:
         elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
         _record_execution("tapps_validate_changed", start)
-        resp = success_response("tapps_validate_changed", elapsed_ms, {
-            "files_validated": 0,
-            "all_gates_passed": True,
-            "total_security_issues": 0,
-            "results": [],
-            "summary": "No changed Python files found.",
-        })
+        resp = success_response(
+            "tapps_validate_changed",
+            elapsed_ms,
+            {
+                "files_validated": 0,
+                "all_gates_passed": True,
+                "total_security_issues": 0,
+                "results": [],
+                "summary": "No changed Python files found.",
+            },
+        )
         return _with_nudges("tapps_validate_changed", resp)
 
     capped = len(paths) > MAX_BATCH_FILES
@@ -118,13 +122,17 @@ async def tapps_validate_changed(
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_validate_changed", start, gate_passed=all_passed)
 
-    resp = success_response("tapps_validate_changed", elapsed_ms, {
-        "files_validated": len(results),
-        "all_gates_passed": all_passed,
-        "total_security_issues": total_sec,
-        "results": results,
-        "summary": summary,
-    })
+    resp = success_response(
+        "tapps_validate_changed",
+        elapsed_ms,
+        {
+            "files_validated": len(results),
+            "all_gates_passed": all_passed,
+            "total_security_issues": total_sec,
+            "results": results,
+            "summary": summary,
+        },
+    )
     return _with_nudges("tapps_validate_changed", resp)
 
 

--- a/src/tapps_mcp/server_scoring_tools.py
+++ b/src/tapps_mcp/server_scoring_tools.py
@@ -121,8 +121,7 @@ async def tapps_score_file(
         if uncached:
             data["uncached_libraries"] = uncached[:10]
             data["docs_hint"] = (
-                f"Call tapps_lookup_docs for {', '.join(uncached[:5])} "
-                "to avoid hallucinated APIs"
+                f"Call tapps_lookup_docs for {', '.join(uncached[:5])} to avoid hallucinated APIs"
             )
     except Exception:
         _logger.debug("uncached_libraries detection failed", exc_info=True)
@@ -136,9 +135,13 @@ async def tapps_score_file(
     )
 
     resp = success_response("tapps_score_file", elapsed_ms, data, degraded=result.degraded)
-    return _with_nudges("tapps_score_file", resp, {
-        "security_issue_count": len(result.security_issues),
-    })
+    return _with_nudges(
+        "tapps_score_file",
+        resp,
+        {
+            "security_issue_count": len(result.security_issues),
+        },
+    )
 
 
 async def tapps_quality_gate(
@@ -206,9 +209,13 @@ async def tapps_quality_gate(
         gate_data,
         degraded=score_result.degraded,
     )
-    return _with_nudges("tapps_quality_gate", resp, {
-        "gate_passed": gate_result.passed,
-    })
+    return _with_nudges(
+        "tapps_quality_gate",
+        resp,
+        {
+            "gate_passed": gate_result.passed,
+        },
+    )
 
 
 async def tapps_quick_check(
@@ -292,7 +299,8 @@ async def tapps_quick_check(
         data["lint_issues"] = serialize_issues(score_result.lint_issues)
     if sec_result.total_issues > 0:
         data["security_issues"] = serialize_issues(
-            sec_result.bandit_issues + sec_result.secret_findings, limit=10,
+            sec_result.bandit_issues + sec_result.secret_findings,
+            limit=10,
         )
 
     suggestions: list[str] = []
@@ -305,7 +313,9 @@ async def tapps_quick_check(
         data["suggestions"] = suggestions
 
     resp = success_response(
-        "tapps_quick_check", elapsed_ms, data,
+        "tapps_quick_check",
+        elapsed_ms,
+        data,
         degraded=not sec_result.bandit_available,
     )
     return _with_nudges("tapps_quick_check", resp)
@@ -326,8 +336,18 @@ def ast_quick_complexity(code: str) -> int | None:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             cc = 1
             for child in ast.walk(node):
-                if isinstance(child, (ast.If, ast.For, ast.While, ast.ExceptHandler,
-                                      ast.With, ast.Assert, ast.BoolOp)):
+                if isinstance(
+                    child,
+                    (
+                        ast.If,
+                        ast.For,
+                        ast.While,
+                        ast.ExceptHandler,
+                        ast.With,
+                        ast.Assert,
+                        ast.BoolOp,
+                    ),
+                ):
                     cc += 1
             max_cc = max(max_cc, cc)
     return max_cc

--- a/src/tapps_mcp/tools/parallel.py
+++ b/src/tapps_mcp/tools/parallel.py
@@ -98,16 +98,24 @@ async def run_all_tools(
 
     if mode == "direct":
         return await _run_direct(
-            file_path, cwd=cwd, timeout=timeout,
-            run_ruff=run_ruff, run_mypy=run_mypy,
-            run_bandit=run_bandit, run_radon=run_radon,
+            file_path,
+            cwd=cwd,
+            timeout=timeout,
+            run_ruff=run_ruff,
+            run_mypy=run_mypy,
+            run_bandit=run_bandit,
+            run_radon=run_radon,
         )
 
     # "subprocess" or "auto" — start with async subprocess
     return await _run_subprocess(
-        file_path, cwd=cwd, timeout=timeout,
-        run_ruff=run_ruff, run_mypy=run_mypy,
-        run_bandit=run_bandit, run_radon=run_radon,
+        file_path,
+        cwd=cwd,
+        timeout=timeout,
+        run_ruff=run_ruff,
+        run_mypy=run_mypy,
+        run_bandit=run_bandit,
+        run_radon=run_radon,
     )
 
 

--- a/src/tapps_mcp/tools/ruff_direct.py
+++ b/src/tapps_mcp/tools/ruff_direct.py
@@ -66,5 +66,8 @@ async def run_ruff_check_direct(
     contexts where async subprocess can silently fail.
     """
     return await asyncio.to_thread(
-        _run_ruff_sync, file_path, cwd=cwd, timeout=timeout,
+        _run_ruff_sync,
+        file_path,
+        cwd=cwd,
+        timeout=timeout,
     )

--- a/src/tapps_mcp/validators/dockerfile.py
+++ b/src/tapps_mcp/validators/dockerfile.py
@@ -25,7 +25,10 @@ _MAX_RUN_COMMANDS = 5
 
 
 def _check_from(
-    content: str, _lines: list[str], findings: list[ValidationFinding], _sug: list[str],
+    content: str,
+    _lines: list[str],
+    findings: list[ValidationFinding],
+    _sug: list[str],
 ) -> None:
     if not _FROM_RE.search(content):
         findings.append(
@@ -38,7 +41,10 @@ def _check_from(
 
 
 def _check_latest_tag(
-    content: str, lines: list[str], findings: list[ValidationFinding], _sug: list[str],
+    content: str,
+    lines: list[str],
+    findings: list[ValidationFinding],
+    _sug: list[str],
 ) -> None:
     if _FROM_LATEST_RE.search(content):
         for i, line in enumerate(lines, 1):
@@ -47,8 +53,7 @@ def _check_latest_tag(
                     ValidationFinding(
                         severity="warning",
                         message=(
-                            "Avoid 'latest' tag "
-                            "- pin a specific version for reproducibility."
+                            "Avoid 'latest' tag - pin a specific version for reproducibility."
                         ),
                         line=i,
                         category="best_practice",
@@ -57,30 +62,36 @@ def _check_latest_tag(
 
 
 def _check_user(
-    content: str, _lines: list[str], findings: list[ValidationFinding], _sug: list[str],
+    content: str,
+    _lines: list[str],
+    findings: list[ValidationFinding],
+    _sug: list[str],
 ) -> None:
     if not _USER_RE.search(content):
         findings.append(
             ValidationFinding(
                 severity="warning",
-                message=(
-                    "No USER instruction "
-                    "- container runs as root. Add a non-root USER."
-                ),
+                message=("No USER instruction - container runs as root. Add a non-root USER."),
                 category="security",
             )
         )
 
 
 def _check_healthcheck(
-    content: str, _lines: list[str], _findings: list[ValidationFinding], suggestions: list[str],
+    content: str,
+    _lines: list[str],
+    _findings: list[ValidationFinding],
+    suggestions: list[str],
 ) -> None:
     if not _HEALTHCHECK_RE.search(content):
         suggestions.append("Add a HEALTHCHECK instruction for container orchestration.")
 
 
 def _check_env_secrets(
-    _content: str, lines: list[str], findings: list[ValidationFinding], _sug: list[str],
+    _content: str,
+    lines: list[str],
+    findings: list[ValidationFinding],
+    _sug: list[str],
 ) -> None:
     for i, line in enumerate(lines, 1):
         if re.match(r"^ENV\s+\S*(PASSWORD|SECRET|KEY|TOKEN)\s*=", line, re.IGNORECASE):
@@ -95,21 +106,30 @@ def _check_env_secrets(
 
 
 def _check_apt_cache(
-    content: str, _lines: list[str], _findings: list[ValidationFinding], suggestions: list[str],
+    content: str,
+    _lines: list[str],
+    _findings: list[ValidationFinding],
+    suggestions: list[str],
 ) -> None:
     if _APT_GET_RE.search(content) and not _APT_CACHE_RE.search(content):
         suggestions.append("Add 'rm -rf /var/lib/apt/lists/*' after apt-get to reduce image size.")
 
 
 def _check_multi_stage(
-    content: str, _lines: list[str], _findings: list[ValidationFinding], suggestions: list[str],
+    content: str,
+    _lines: list[str],
+    _findings: list[ValidationFinding],
+    suggestions: list[str],
 ) -> None:
     if len(_MULTI_STAGE_RE.findall(content)) == 1:
         suggestions.append("Consider using multi-stage builds to reduce final image size.")
 
 
 def _check_run_count(
-    content: str, _lines: list[str], _findings: list[ValidationFinding], suggestions: list[str],
+    content: str,
+    _lines: list[str],
+    _findings: list[ValidationFinding],
+    suggestions: list[str],
 ) -> None:
     run_count = len(_RUN_RE.findall(content))
     if run_count > _MAX_RUN_COMMANDS:
@@ -119,7 +139,10 @@ def _check_run_count(
 
 
 def _check_layer_ordering(
-    content: str, _lines: list[str], _findings: list[ValidationFinding], suggestions: list[str],
+    content: str,
+    _lines: list[str],
+    _findings: list[ValidationFinding],
+    suggestions: list[str],
 ) -> None:
     copy_req_pos = _COPY_REQ_RE.search(content)
     copy_dot_pos = _COPY_DOT_RE.search(content)

--- a/tests/unit/test_composite_tools.py
+++ b/tests/unit/test_composite_tools.py
@@ -79,7 +79,9 @@ class TestTappsValidateChanged:
     @patch("tapps_mcp.server._validate_file_path")
     @patch("tapps_mcp.server.load_settings")
     async def test_no_files_returns_empty(
-        self, mock_settings: MagicMock, mock_validate: MagicMock,
+        self,
+        mock_settings: MagicMock,
+        mock_validate: MagicMock,
     ) -> None:
         from tapps_mcp.server import tapps_validate_changed
 
@@ -100,7 +102,10 @@ class TestTappsValidateChanged:
     @patch("tapps_mcp.server._validate_file_path")
     @patch("tapps_mcp.server.load_settings")
     async def test_explicit_file_paths(
-        self, mock_settings: MagicMock, mock_validate: MagicMock, tmp_path: Path,
+        self,
+        mock_settings: MagicMock,
+        mock_validate: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.server import tapps_validate_changed
 
@@ -119,10 +124,13 @@ class TestTappsValidateChanged:
     async def test_records_call(self) -> None:
         from tapps_mcp.server import tapps_validate_changed
 
-        with patch(
-            "tapps_mcp.tools.batch_validator.detect_changed_python_files",
-            return_value=[],
-        ), patch("tapps_mcp.server.load_settings") as mock_settings:
+        with (
+            patch(
+                "tapps_mcp.tools.batch_validator.detect_changed_python_files",
+                return_value=[],
+            ),
+            patch("tapps_mcp.server.load_settings") as mock_settings,
+        ):
             mock_settings.return_value.project_root = Path("/fake")
             await tapps_validate_changed()
 
@@ -141,7 +149,10 @@ class TestTappsQuickCheck:
     @patch("tapps_mcp.server._validate_file_path")
     @patch("tapps_mcp.server.load_settings")
     async def test_success(
-        self, mock_settings: MagicMock, mock_validate: MagicMock, tmp_path: Path,
+        self,
+        mock_settings: MagicMock,
+        mock_validate: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.server import tapps_quick_check
 
@@ -171,7 +182,10 @@ class TestTappsQuickCheck:
     @patch("tapps_mcp.server._validate_file_path")
     @patch("tapps_mcp.server.load_settings")
     async def test_records_call(
-        self, mock_settings: MagicMock, mock_validate: MagicMock, tmp_path: Path,
+        self,
+        mock_settings: MagicMock,
+        mock_validate: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.server import tapps_quick_check
 
@@ -189,7 +203,10 @@ class TestTappsQuickCheck:
     @patch("tapps_mcp.server._validate_file_path")
     @patch("tapps_mcp.server.load_settings")
     async def test_includes_nudges(
-        self, mock_settings: MagicMock, mock_validate: MagicMock, tmp_path: Path,
+        self,
+        mock_settings: MagicMock,
+        mock_validate: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.server import tapps_quick_check
 
@@ -236,7 +253,9 @@ class TestBatchValidator:
 
     @patch("tapps_mcp.tools.batch_validator.subprocess.run")
     def test_detect_changed_filters_py_only(
-        self, mock_run: MagicMock, tmp_path: Path,
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.tools.batch_validator import detect_changed_python_files
 
@@ -246,7 +265,8 @@ class TestBatchValidator:
         (tmp_path / "c.py").write_text("y = 2\n")
 
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="a.py\nb.txt\nc.py\n",
+            returncode=0,
+            stdout="a.py\nb.txt\nc.py\n",
         )
 
         result = detect_changed_python_files(tmp_path)
@@ -255,7 +275,9 @@ class TestBatchValidator:
 
     @patch("tapps_mcp.tools.batch_validator.subprocess.run")
     def test_detect_changed_empty_diff(
-        self, mock_run: MagicMock, tmp_path: Path,
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.tools.batch_validator import detect_changed_python_files
 
@@ -265,7 +287,9 @@ class TestBatchValidator:
 
     @patch("tapps_mcp.tools.batch_validator.subprocess.run")
     def test_detect_changed_deduplicates(
-        self, mock_run: MagicMock, tmp_path: Path,
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from tapps_mcp.tools.batch_validator import detect_changed_python_files
 

--- a/tests/unit/test_content_normalizer.py
+++ b/tests/unit/test_content_normalizer.py
@@ -15,7 +15,6 @@ from tapps_mcp.knowledge.content_normalizer import (
     rank_snippets,
 )
 
-
 SAMPLE_CONTENT = """# FastAPI Quick Start
 
 ## Installation
@@ -79,16 +78,22 @@ class TestExtractSnippets:
         for s in extract_snippets(SAMPLE_CONTENT):
             assert s.token_count > 0
 
-    @pytest.mark.parametrize("length,expected_count", [
-        (30, 1),   # exactly at MIN_SNIPPET_LENGTH
-        (29, 0),   # just below
-    ], ids=["at-min", "below-min"])
+    @pytest.mark.parametrize(
+        "length,expected_count",
+        [
+            (30, 1),  # exactly at MIN_SNIPPET_LENGTH
+            (29, 0),  # just below
+        ],
+        ids=["at-min", "below-min"],
+    )
     def test_snippet_length_boundary(self, length, expected_count) -> None:
         content = f"```python\n{'a' * length}\n```"
         assert len(extract_snippets(content)) == expected_count
 
     def test_no_language_specified(self) -> None:
-        snippets = extract_snippets("## Section\n\n```\nsome long content that is at least 30 chars\n```")
+        snippets = extract_snippets(
+            "## Section\n\n```\nsome long content that is at least 30 chars\n```"
+        )
         assert len(snippets) == 1 and snippets[0].language == ""
 
     def test_content_with_no_code_blocks(self) -> None:
@@ -99,7 +104,9 @@ class TestExtractSnippets:
         assert len(snippets) == 1
 
     def test_multiple_headers_picks_nearest(self) -> None:
-        content = "# First\n\nText.\n\n## Second\n\n```python\ndef foo():\n    return 'test' * 100\n```"
+        content = (
+            "# First\n\nText.\n\n## Second\n\n```python\ndef foo():\n    return 'test' * 100\n```"
+        )
         snippets = extract_snippets(content)
         assert len(snippets) == 1 and "Second" in snippets[0].context
 
@@ -108,7 +115,9 @@ class TestRankSnippets:
     def test_ranks_by_completeness(self) -> None:
         snippets = [
             CodeSnippet(code="x = 1", token_count=2),
-            CodeSnippet(code="from fastapi import FastAPI\ndef main():\n    return 'ok'", token_count=15),
+            CodeSnippet(
+                code="from fastapi import FastAPI\ndef main():\n    return 'ok'", token_count=15
+            ),
         ]
         ranked = rank_snippets(snippets)
         assert ranked[0].code.startswith("from fastapi")
@@ -116,14 +125,22 @@ class TestRankSnippets:
     def test_query_relevance_boosts(self) -> None:
         snippets = [
             CodeSnippet(code="print('hello world')\nreturn 1", language="python", token_count=5),
-            CodeSnippet(code="def test_sql_injection():\n    query = 'SELECT * FROM users'\n    return query", language="python", token_count=10),
+            CodeSnippet(
+                code=(
+                    "def test_sql_injection():\n    query = 'SELECT * FROM users'\n    return query"
+                ),
+                language="python",
+                token_count=10,
+            ),
         ]
         ranked = rank_snippets(snippets, query="sql injection")
         assert "sql" in ranked[0].code.lower()
 
     def test_empty_and_stopword_queries(self) -> None:
         """Empty and stopword-only queries don't crash."""
-        snip = CodeSnippet(code="from fastapi import FastAPI\ndef main():\n    return 'ok'", token_count=10)
+        snip = CodeSnippet(
+            code="from fastapi import FastAPI\ndef main():\n    return 'ok'", token_count=10
+        )
         assert len(rank_snippets([snip], query="")) == 1
         assert len(rank_snippets([snip], query="how to the a in")) == 1
 
@@ -134,12 +151,18 @@ class TestRankSnippets:
         assert py.score > sh.score
 
     def test_scores_clamped(self) -> None:
-        snip = CodeSnippet(code="from x import y\ndef f():\n    class C:\n        return 1", language="python", token_count=15)
+        snip = CodeSnippet(
+            code="from x import y\ndef f():\n    class C:\n        return 1",
+            language="python",
+            token_count=15,
+        )
         rank_snippets([snip], query="x y f C return")
         assert 0.0 <= snip.score <= 1.0
 
     def test_no_signals_score_zero(self) -> None:
-        snip = CodeSnippet(code="some plain text without keywords here now", language="rust", token_count=5)
+        snip = CodeSnippet(
+            code="some plain text without keywords here now", language="rust", token_count=5
+        )
         rank_snippets([snip])
         assert snip.score == 0.0
 
@@ -159,11 +182,15 @@ class TestDeduplicateSnippets:
         b = CodeSnippet(code="import pytest\ndef test_func():\n    assert True", token_count=8)
         assert len(deduplicate_snippets([a, b])) == 2
 
-    @pytest.mark.parametrize("input_list,expected_len", [
-        ([], 0),
-        ("single", 1),
-        ("triple", 1),
-    ], ids=["empty", "single", "all-identical"])
+    @pytest.mark.parametrize(
+        "input_list,expected_len",
+        [
+            ([], 0),
+            ("single", 1),
+            ("triple", 1),
+        ],
+        ids=["empty", "single", "all-identical"],
+    )
     def test_dedup_edge_cases(self, input_list, expected_len) -> None:
         if input_list == []:
             assert deduplicate_snippets([]) == []
@@ -182,13 +209,17 @@ class TestDeduplicateSnippets:
 
 
 class TestApplyTokenBudget:
-    @pytest.mark.parametrize("token_count,budget,expected_len", [
-        (100, 200, 2),     # fits 2 of 3
-        (50, 0, 0),        # zero budget
-        (100, 100, 1),     # exactly at budget
-        (101, 100, 0),     # one over budget
-        (50, 1000, 2),     # budget larger than total
-    ], ids=["fits-two", "zero-budget", "at-budget", "over-budget", "large-budget"])
+    @pytest.mark.parametrize(
+        "token_count,budget,expected_len",
+        [
+            (100, 200, 2),  # fits 2 of 3
+            (50, 0, 0),  # zero budget
+            (100, 100, 1),  # exactly at budget
+            (101, 100, 0),  # one over budget
+            (50, 1000, 2),  # budget larger than total
+        ],
+        ids=["fits-two", "zero-budget", "at-budget", "over-budget", "large-budget"],
+    )
     def test_budget_enforcement(self, token_count, budget, expected_len) -> None:
         if token_count == 100 and budget == 200:
             snippets = [CodeSnippet(code="x" * 100, token_count=100) for _ in range(3)]
@@ -245,7 +276,9 @@ class TestReferenceCard:
     def test_to_markdown_with_all_fields(self) -> None:
         card = ReferenceCard(
             title="Test Section",
-            snippets=[CodeSnippet(code="print('hi')", language="python", context="Example", token_count=3)],
+            snippets=[
+                CodeSnippet(code="print('hi')", language="python", context="Example", token_count=3)
+            ],
             summary="A test card.",
             token_count=3,
         )
@@ -271,8 +304,16 @@ class TestNormalizationResult:
     def test_to_dict_complete(self) -> None:
         result = NormalizationResult(
             cards=[ReferenceCard(title="Test", token_count=10)],
-            total_snippets=5, deduped_snippets=2, total_tokens=100, budget_applied=True,
+            total_snippets=5,
+            deduped_snippets=2,
+            total_tokens=100,
+            budget_applied=True,
         )
         d = result.to_dict()
-        assert d == {"total_snippets": 5, "deduped_snippets": 2, "total_tokens": 100,
-                     "budget_applied": True, "card_count": 1}
+        assert d == {
+            "total_snippets": 5,
+            "deduped_snippets": 2,
+            "total_tokens": 100,
+            "budget_applied": True,
+            "card_count": 1,
+        }

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -186,9 +186,7 @@ class TestCollectDiagnostics:
     def test_with_api_key(self, tmp_path: Path) -> None:
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
-        result = collect_diagnostics(
-            api_key=SecretStr("test-key"), cache_dir=cache_dir
-        )
+        result = collect_diagnostics(api_key=SecretStr("test-key"), cache_dir=cache_dir)
         assert result.context7.api_key_set is True
         assert result.context7.status == "available"
 

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -278,7 +278,8 @@ class TestCliDoctor:
             patch("tapps_mcp.distribution.doctor.shutil.which", return_value=None),
         ):
             result = runner.invoke(
-                main, ["doctor", "--project-root", str(tmp_path)],
+                main,
+                ["doctor", "--project-root", str(tmp_path)],
             )
         assert "Doctor Report" in result.output
 
@@ -290,6 +291,7 @@ class TestCliDoctor:
             patch("tapps_mcp.distribution.doctor.shutil.which", return_value=None),
         ):
             result = runner.invoke(
-                main, ["doctor", "--project-root", str(tmp_path)],
+                main,
+                ["doctor", "--project-root", str(tmp_path)],
             )
         assert result.exit_code == 1

--- a/tests/unit/test_expert_rag.py
+++ b/tests/unit/test_expert_rag.py
@@ -218,7 +218,14 @@ class TestTestingKBRetrieval:
     def test_base_url_config_returns_chunks(self) -> None:
         from pathlib import Path
 
-        kb_dir = Path(__file__).resolve().parent.parent.parent / "src" / "tapps_mcp" / "experts" / "knowledge" / "testing"
+        kb_dir = (
+            Path(__file__).resolve().parent.parent.parent
+            / "src"
+            / "tapps_mcp"
+            / "experts"
+            / "knowledge"
+            / "testing"
+        )
         kb = SimpleKnowledgeBase(kb_dir)
         results = kb.search("base URL configuration fixture")
         assert len(results) > 0
@@ -227,7 +234,14 @@ class TestTestingKBRetrieval:
     def test_monkeypatch_env_returns_chunks(self) -> None:
         from pathlib import Path
 
-        kb_dir = Path(__file__).resolve().parent.parent.parent / "src" / "tapps_mcp" / "experts" / "knowledge" / "testing"
+        kb_dir = (
+            Path(__file__).resolve().parent.parent.parent
+            / "src"
+            / "tapps_mcp"
+            / "experts"
+            / "knowledge"
+            / "testing"
+        )
         kb = SimpleKnowledgeBase(kb_dir)
         results = kb.search("monkeypatch environment variables")
         assert len(results) > 0
@@ -236,7 +250,14 @@ class TestTestingKBRetrieval:
     def test_localhost_avoidance_returns_chunks(self) -> None:
         from pathlib import Path
 
-        kb_dir = Path(__file__).resolve().parent.parent.parent / "src" / "tapps_mcp" / "experts" / "knowledge" / "testing"
+        kb_dir = (
+            Path(__file__).resolve().parent.parent.parent
+            / "src"
+            / "tapps_mcp"
+            / "experts"
+            / "knowledge"
+            / "testing"
+        )
         kb = SimpleKnowledgeBase(kb_dir)
         results = kb.search("avoid hardcoded localhost")
         assert len(results) > 0

--- a/tests/unit/test_fuzzy_matcher.py
+++ b/tests/unit/test_fuzzy_matcher.py
@@ -23,28 +23,44 @@ from tapps_mcp.knowledge.fuzzy_matcher import (
 
 
 class TestLCSLength:
-    @pytest.mark.parametrize("a,b,expected", [
-        ("abc", "abc", 3),
-        ("", "abc", 0),
-        ("abc", "", 0),
-        ("", "", 0),
-        ("xyz", "abc", 0),
-        ("ace", "abcde", 3),
-        ("fastapi", "flask", 3),
-        ("abc", "cba", 1),
-    ], ids=["identical", "empty-a", "empty-b", "both-empty",
-            "no-common", "subsequence", "partial", "reversed"])
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("abc", "abc", 3),
+            ("", "abc", 0),
+            ("abc", "", 0),
+            ("", "", 0),
+            ("xyz", "abc", 0),
+            ("ace", "abcde", 3),
+            ("fastapi", "flask", 3),
+            ("abc", "cba", 1),
+        ],
+        ids=[
+            "identical",
+            "empty-a",
+            "empty-b",
+            "both-empty",
+            "no-common",
+            "subsequence",
+            "partial",
+            "reversed",
+        ],
+    )
     def test_lcs_length(self, a, b, expected):
         assert lcs_length(a, b) == expected
 
 
 class TestLCSSimilarity:
-    @pytest.mark.parametrize("a,b,expected", [
-        ("fastapi", "fastapi", 1.0),
-        ("", "", 1.0),
-        ("abc", "", 0.0),
-        ("FastAPI", "fastapi", 1.0),
-    ], ids=["identical", "both-empty", "one-empty", "case-insensitive"])
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("fastapi", "fastapi", 1.0),
+            ("", "", 1.0),
+            ("abc", "", 0.0),
+            ("FastAPI", "fastapi", 1.0),
+        ],
+        ids=["identical", "both-empty", "one-empty", "case-insensitive"],
+    )
     def test_exact_values(self, a, b, expected):
         assert lcs_similarity(a, b) == expected
 
@@ -72,37 +88,55 @@ class TestResolveAlias:
 
     def test_all_known_aliases(self):
         from tapps_mcp.knowledge.fuzzy_matcher import LIBRARY_ALIASES
+
         for alias, canonical in LIBRARY_ALIASES.items():
             assert resolve_alias(alias) == canonical
 
 
 class TestEditDistance:
-    @pytest.mark.parametrize("a,b,expected", [
-        ("abc", "abc", 0),
-        ("abc", "adc", 1),
-        ("abc", "abcd", 1),
-        ("abcd", "abc", 1),
-        ("", "abc", 3),
-        ("abc", "", 3),
-        ("", "", 0),
-        ("fastaip", "fastapi", 2),
-        ("abc", "xyz", 3),
-        ("ab", "ba", 2),
-    ], ids=["identical", "substitution", "insertion", "deletion",
-            "empty-a", "empty-b", "both-empty", "typo",
-            "completely-different", "transposition"])
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("abc", "abc", 0),
+            ("abc", "adc", 1),
+            ("abc", "abcd", 1),
+            ("abcd", "abc", 1),
+            ("", "abc", 3),
+            ("abc", "", 3),
+            ("", "", 0),
+            ("fastaip", "fastapi", 2),
+            ("abc", "xyz", 3),
+            ("ab", "ba", 2),
+        ],
+        ids=[
+            "identical",
+            "substitution",
+            "insertion",
+            "deletion",
+            "empty-a",
+            "empty-b",
+            "both-empty",
+            "typo",
+            "completely-different",
+            "transposition",
+        ],
+    )
     def test_edit_distance(self, a, b, expected):
         assert edit_distance(a, b) == expected
 
 
 class TestEditDistanceSimilarity:
-    @pytest.mark.parametrize("a,b,expected", [
-        ("fastapi", "fastapi", 1.0),
-        ("", "", 1.0),
-        ("abc", "", 0.0),
-        ("FastAPI", "fastapi", 1.0),
-        ("abc", "xyz", 0.0),
-    ], ids=["identical", "both-empty", "one-empty", "case-insensitive", "different"])
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("fastapi", "fastapi", 1.0),
+            ("", "", 1.0),
+            ("abc", "", 0.0),
+            ("FastAPI", "fastapi", 1.0),
+            ("abc", "xyz", 0.0),
+        ],
+        ids=["identical", "both-empty", "one-empty", "case-insensitive", "different"],
+    )
     def test_exact_values(self, a, b, expected):
         assert edit_distance_similarity(a, b) == expected
 
@@ -111,16 +145,27 @@ class TestEditDistanceSimilarity:
 
 
 class TestTokenOverlap:
-    @pytest.mark.parametrize("a,b,expected", [
-        ("scikit-learn", "scikit-learn", 1.0),
-        ("fastapi", "django", 0.0),
-        ("", "something", 0.0),
-        ("", "", 0.0),
-        ("my-lib", "my-other", 0.5),
-        ("my_lib", "my_other", 0.5),
-        ("my lib", "my other", 0.5),
-    ], ids=["identical", "no-overlap", "empty-first", "both-empty",
-            "hyphen-split", "underscore-split", "space-split"])
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("scikit-learn", "scikit-learn", 1.0),
+            ("fastapi", "django", 0.0),
+            ("", "something", 0.0),
+            ("", "", 0.0),
+            ("my-lib", "my-other", 0.5),
+            ("my_lib", "my_other", 0.5),
+            ("my lib", "my other", 0.5),
+        ],
+        ids=[
+            "identical",
+            "no-overlap",
+            "empty-first",
+            "both-empty",
+            "hyphen-split",
+            "underscore-split",
+            "space-split",
+        ],
+    )
     def test_token_overlap(self, a, b, expected):
         assert token_overlap_score(a, b) == expected
 
@@ -151,18 +196,31 @@ class TestMultiSignalScore:
 
 
 class TestConfidenceBand:
-    @pytest.mark.parametrize("score,expected", [
-        (0.9, "high"),
-        (CONFIDENCE_HIGH, "high"),
-        (CONFIDENCE_HIGH - 0.01, "medium"),
-        (0.7, "medium"),
-        (CONFIDENCE_MEDIUM, "medium"),
-        (CONFIDENCE_MEDIUM - 0.01, "low"),
-        (0.3, "low"),
-        (0.0, "low"),
-        (1.0, "high"),
-    ], ids=["high", "boundary-high", "just-below-high", "medium",
-            "boundary-medium", "just-below-medium", "low", "zero", "one"])
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (0.9, "high"),
+            (CONFIDENCE_HIGH, "high"),
+            (CONFIDENCE_HIGH - 0.01, "medium"),
+            (0.7, "medium"),
+            (CONFIDENCE_MEDIUM, "medium"),
+            (CONFIDENCE_MEDIUM - 0.01, "low"),
+            (0.3, "low"),
+            (0.0, "low"),
+            (1.0, "high"),
+        ],
+        ids=[
+            "high",
+            "boundary-high",
+            "just-below-high",
+            "medium",
+            "boundary-medium",
+            "just-below-medium",
+            "low",
+            "zero",
+            "one",
+        ],
+    )
     def test_confidence_band(self, score, expected):
         assert confidence_band(score) == expected
 
@@ -242,12 +300,16 @@ class TestFuzzyMatchTopic:
 
 
 class TestCombinedScore:
-    @pytest.mark.parametrize("lib,topic,weights,expected", [
-        (1.0, 0.5, {}, 0.8),                                        # default weights
-        (0.8, 0.6, {"library_weight": 0.7, "topic_weight": 0.3}, 0.74),
-        (0.0, 0.0, {}, 0.0),
-        (1.0, 1.0, {}, 1.0),
-    ], ids=["default-weights", "custom-weights", "zeros", "maxed"])
+    @pytest.mark.parametrize(
+        "lib,topic,weights,expected",
+        [
+            (1.0, 0.5, {}, 0.8),  # default weights
+            (0.8, 0.6, {"library_weight": 0.7, "topic_weight": 0.3}, 0.74),
+            (0.0, 0.0, {}, 0.0),
+            (1.0, 1.0, {}, 1.0),
+        ],
+        ids=["default-weights", "custom-weights", "zeros", "maxed"],
+    )
     def test_combined_score(self, lib, topic, weights, expected):
         assert abs(combined_score(lib, topic, **weights) - expected) < 0.001
 
@@ -287,6 +349,8 @@ class TestProjectManifestPrior:
         assert len(r1) == len(r2)
 
     def test_project_library_case_insensitive(self):
-        results = fuzzy_match_library("fast", ["FastAPI"], threshold=0.3, project_libraries=["fastapi"])
+        results = fuzzy_match_library(
+            "fast", ["FastAPI"], threshold=0.3, project_libraries=["fastapi"]
+        )
         results_no = fuzzy_match_library("fast", ["FastAPI"], threshold=0.3)
         assert results[0].score >= results_no[0].score

--- a/tests/unit/test_hot_rank.py
+++ b/tests/unit/test_hot_rank.py
@@ -50,10 +50,14 @@ class TestComputeHotRank:
 class TestComputeHotRankEdgeCases:
     """Boundary conditions and edge cases."""
 
-    @pytest.mark.parametrize("days,expected_recency", [
-        (0.0, 1.0),     # just now
-        (-5.0, 1.0),    # negative treated as max
-    ], ids=["zero-days", "negative-days"])
+    @pytest.mark.parametrize(
+        "days,expected_recency",
+        [
+            (0.0, 1.0),  # just now
+            (-5.0, 1.0),  # negative treated as max
+        ],
+        ids=["zero-days", "negative-days"],
+    )
     def test_max_recency(self, days, expected_recency) -> None:
         rank = compute_hot_rank("test", 10, 0.5, 0.5, days)
         assert rank.recency_weight == expected_recency
@@ -66,9 +70,15 @@ class TestComputeHotRankEdgeCases:
         rank = compute_hot_rank("test", 10, 0.5, 0.5, 365.0)
         assert rank.recency_weight < 0.01
 
-    @pytest.mark.parametrize("consultations,has_bonus", [
-        (4, True), (5, False), (6, False),
-    ], ids=["below-threshold", "at-threshold", "above-threshold"])
+    @pytest.mark.parametrize(
+        "consultations,has_bonus",
+        [
+            (4, True),
+            (5, False),
+            (6, False),
+        ],
+        ids=["below-threshold", "at-threshold", "above-threshold"],
+    )
     def test_exploration_threshold(self, consultations, has_bonus) -> None:
         rank = compute_hot_rank("test", consultations, 0.5, 0.5, 1.0)
         assert (rank.exploration_bonus > 0.0) == has_bonus
@@ -93,12 +103,16 @@ class TestApplyHotRankBoost:
     """Tests for apply_hot_rank_boost."""
 
     def test_none_metrics_dir_no_change(self) -> None:
-        chunk = KnowledgeChunk(content="test", source_file="a.md", line_start=1, line_end=5, score=0.5)
+        chunk = KnowledgeChunk(
+            content="test", source_file="a.md", line_start=1, line_end=5, score=0.5
+        )
         result = apply_hot_rank_boost([chunk], "security", metrics_dir=None)
         assert result[0].score == 0.5
 
     def test_nonexistent_metrics_dir_no_change(self, tmp_path) -> None:
-        chunk = KnowledgeChunk(content="test", source_file="a.md", line_start=1, line_end=5, score=0.5)
+        chunk = KnowledgeChunk(
+            content="test", source_file="a.md", line_start=1, line_end=5, score=0.5
+        )
         result = apply_hot_rank_boost([chunk], "security", metrics_dir=tmp_path / "nonexistent")
         assert len(result) == 1
 
@@ -108,6 +122,7 @@ class TestApplyHotRankBoost:
     def test_objects_without_score_attribute(self) -> None:
         class NoScoreObj:
             pass
+
         result = apply_hot_rank_boost([NoScoreObj()], "security", metrics_dir=None)
         assert len(result) == 1
 

--- a/tests/unit/test_hybrid_fuse.py
+++ b/tests/unit/test_hybrid_fuse.py
@@ -28,11 +28,15 @@ def _chunk(
 class TestHybridFuseInputVariations:
     """Empty / single-source fusion scenarios."""
 
-    @pytest.mark.parametrize("vec,kw,expected_len,expected_score", [
-        ([], [], 0, None),
-        ([], [{"source_file": "kw.md", "score": 0.9}], 1, 0.27),   # keyword-only: 0.3*0.9
-        ([{"source_file": "vec.md", "score": 0.9}], [], 1, 0.54),  # vector-only: 0.6*0.9
-    ], ids=["both-empty", "keyword-only", "vector-only"])
+    @pytest.mark.parametrize(
+        "vec,kw,expected_len,expected_score",
+        [
+            ([], [], 0, None),
+            ([], [{"source_file": "kw.md", "score": 0.9}], 1, 0.27),  # keyword-only: 0.3*0.9
+            ([{"source_file": "vec.md", "score": 0.9}], [], 1, 0.54),  # vector-only: 0.6*0.9
+        ],
+        ids=["both-empty", "keyword-only", "vector-only"],
+    )
     def test_single_source_scoring(self, vec, kw, expected_len, expected_score) -> None:
         v = [_chunk(**c) for c in vec]
         k = [_chunk(**c) for c in kw]
@@ -65,10 +69,14 @@ class TestHybridFuseOverlap:
 
     def test_full_overlap(self) -> None:
         """All chunks in both sets → all get structural bonus > 0.5."""
-        vec = [_chunk(source_file="a.md", line_start=1, score=0.9),
-               _chunk(source_file="b.md", line_start=5, score=0.7)]
-        kw = [_chunk(source_file="a.md", line_start=1, score=0.8),
-              _chunk(source_file="b.md", line_start=5, score=0.6)]
+        vec = [
+            _chunk(source_file="a.md", line_start=1, score=0.9),
+            _chunk(source_file="b.md", line_start=5, score=0.7),
+        ]
+        kw = [
+            _chunk(source_file="a.md", line_start=1, score=0.8),
+            _chunk(source_file="b.md", line_start=5, score=0.6),
+        ]
         result = VectorKnowledgeBase._hybrid_fuse(vec, kw, max_results=5)
         assert len(result) == 2
         assert all(r.score > 0.5 for r in result)
@@ -85,8 +93,10 @@ class TestHybridFuseDedup:
 
     def test_keyword_dedup_keeps_highest_score(self) -> None:
         vec = [_chunk(source_file="a.md", line_start=1, score=0.8)]
-        kw = [_chunk(source_file="b.md", line_start=1, score=0.5),
-              _chunk(source_file="b.md", line_start=1, score=0.9)]  # same key, higher
+        kw = [
+            _chunk(source_file="b.md", line_start=1, score=0.5),
+            _chunk(source_file="b.md", line_start=1, score=0.9),
+        ]  # same key, higher
         result = VectorKnowledgeBase._hybrid_fuse(vec, kw, max_results=5)
         kw_result = [r for r in result if r.source_file == "b.md"]
         assert len(kw_result) == 1
@@ -116,9 +126,11 @@ class TestHybridFuseScoring:
         assert custom[0].score > default[0].score
 
     def test_sorted_by_score_descending(self) -> None:
-        vec = [_chunk(source_file="low.md", score=0.3),
-               _chunk(source_file="high.md", score=0.9),
-               _chunk(source_file="mid.md", score=0.6)]
+        vec = [
+            _chunk(source_file="low.md", score=0.3),
+            _chunk(source_file="high.md", score=0.9),
+            _chunk(source_file="mid.md", score=0.6),
+        ]
         result = VectorKnowledgeBase._hybrid_fuse(vec, [], max_results=5)
         scores = [r.score for r in result]
         assert scores == sorted(scores, reverse=True)

--- a/tests/unit/test_lookup.py
+++ b/tests/unit/test_lookup.py
@@ -205,9 +205,7 @@ class TestLookupDidYouMean:
         cache.put(CacheEntry(library="flask", topic="overview", content="# Flask docs"))
 
         mock_client = AsyncMock()
-        mock_client.resolve_library.return_value = [
-            LibraryMatch(id="/test/fstapi", title="fstapi")
-        ]
+        mock_client.resolve_library.return_value = [LibraryMatch(id="/test/fstapi", title="fstapi")]
         mock_client.fetch_docs.return_value = None  # No content
         mock_client.close = AsyncMock()
 
@@ -233,9 +231,7 @@ class TestLookupDidYouMean:
         cache.put(CacheEntry(library="fastapi", topic="overview", content="# FastAPI"))
 
         mock_client = AsyncMock()
-        mock_client.resolve_library.return_value = [
-            LibraryMatch(id="/test/zzz", title="zzz")
-        ]
+        mock_client.resolve_library.return_value = [LibraryMatch(id="/test/zzz", title="zzz")]
         mock_client.fetch_docs.return_value = None
         mock_client.close = AsyncMock()
 
@@ -316,6 +312,7 @@ class TestLookupEdgeCases:
     async def test_api_error_with_stale_fallback(self, tmp_path):
         """When API fails and stale cache exists, stale content is returned."""
         from pydantic import SecretStr
+
         from tapps_mcp.knowledge.context7_client import Context7Error
 
         cache = KBCache(cache_dir=tmp_path / "cache")

--- a/tests/unit/test_nudges.py
+++ b/tests/unit/test_nudges.py
@@ -59,28 +59,32 @@ class TestComputeNextSteps:
     def test_score_file_security_nudge_when_issues(self) -> None:
         CallTracker.record("tapps_score_file")
         steps = compute_next_steps(
-            "tapps_score_file", {"security_issue_count": 3},
+            "tapps_score_file",
+            {"security_issue_count": 3},
         )
         assert any("tapps_security_scan" in s for s in steps)
 
     def test_score_file_no_security_nudge_when_zero_issues(self) -> None:
         CallTracker.record("tapps_score_file")
         steps = compute_next_steps(
-            "tapps_score_file", {"security_issue_count": 0},
+            "tapps_score_file",
+            {"security_issue_count": 0},
         )
         assert not any("WARNING" in s for s in steps)
 
     def test_quality_gate_failed_nudge(self) -> None:
         CallTracker.record("tapps_quality_gate")
         steps = compute_next_steps(
-            "tapps_quality_gate", {"gate_passed": False},
+            "tapps_quality_gate",
+            {"gate_passed": False},
         )
         assert any("FAILED" in s for s in steps)
 
     def test_quality_gate_passed_nudges_checklist(self) -> None:
         CallTracker.record("tapps_quality_gate")
         steps = compute_next_steps(
-            "tapps_quality_gate", {"gate_passed": True},
+            "tapps_quality_gate",
+            {"gate_passed": True},
         )
         assert any("tapps_checklist" in s for s in steps)
 
@@ -88,7 +92,8 @@ class TestComputeNextSteps:
         CallTracker.record("tapps_quality_gate")
         CallTracker.record("tapps_checklist")
         steps = compute_next_steps(
-            "tapps_quality_gate", {"gate_passed": True},
+            "tapps_quality_gate",
+            {"gate_passed": True},
         )
         assert not any("tapps_checklist" in s for s in steps)
 
@@ -245,7 +250,9 @@ class TestWithNudges:
             "data": {"passed": False},
         }
         result = _with_nudges(
-            "tapps_quality_gate", response, {"gate_passed": False},
+            "tapps_quality_gate",
+            response,
+            {"gate_passed": False},
         )
         steps = result["data"].get("next_steps", [])
         assert any("FAILED" in s for s in steps)

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -338,10 +338,19 @@ class TestDirectMode:
             ) as mock_direct,
         ):
             await run_all_tools(
-                "test.py", mode="direct",
-                run_ruff=True, run_mypy=False, run_bandit=False, run_radon=True,
+                "test.py",
+                mode="direct",
+                run_ruff=True,
+                run_mypy=False,
+                run_bandit=False,
+                run_radon=True,
             )
             mock_direct.assert_called_once_with(
-                "test.py", cwd=None, timeout=30,
-                run_ruff=True, run_mypy=False, run_bandit=False, run_radon=True,
+                "test.py",
+                cwd=None,
+                timeout=30,
+                run_ruff=True,
+                run_mypy=False,
+                run_bandit=False,
+                run_radon=True,
             )

--- a/tests/unit/test_pipeline_agents_md.py
+++ b/tests/unit/test_pipeline_agents_md.py
@@ -20,6 +20,7 @@ from tapps_mcp.prompts.prompt_loader import load_agents_template
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _template() -> str:
     return load_agents_template()
 

--- a/tests/unit/test_pipeline_init.py
+++ b/tests/unit/test_pipeline_init.py
@@ -197,9 +197,7 @@ class TestBootstrapPipeline:
         assert "tapps_server_info" in content  # template content merged in
 
     def test_creates_tech_stack_md(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text(
-            "[project]\nname = 'foo'\ndependencies = []\n"
-        )
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'foo'\ndependencies = []\n")
         result = bootstrap_pipeline(
             tmp_path,
             create_handoff=False,
@@ -224,9 +222,7 @@ class TestBootstrapPipeline:
         assert "missing_checkers" in sv
 
     def test_cache_warming_in_result(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text(
-            "[project]\ndependencies = []\n"
-        )
+        (tmp_path / "pyproject.toml").write_text("[project]\ndependencies = []\n")
         result = bootstrap_pipeline(
             tmp_path,
             create_handoff=False,
@@ -243,9 +239,7 @@ class TestBootstrapPipeline:
 
     def test_expert_rag_warming_in_result(self, tmp_path):
         """Expert RAG warming runs and returns expected structure."""
-        (tmp_path / "pyproject.toml").write_text(
-            "[project]\ndependencies = []\n"
-        )
+        (tmp_path / "pyproject.toml").write_text("[project]\ndependencies = []\n")
         result = bootstrap_pipeline(
             tmp_path,
             create_handoff=False,
@@ -297,9 +291,7 @@ class TestAgentsMdIntegration:
 
     def test_overwrite_flag(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("# Custom only\n", encoding="utf-8")
-        result = bootstrap_pipeline(
-            tmp_path, **self._common, overwrite_agents_md=True
-        )
+        result = bootstrap_pipeline(tmp_path, **self._common, overwrite_agents_md=True)
         assert result["agents_md"]["action"] == "overwritten"
         content = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
         assert "tapps_server_info" in content

--- a/tests/unit/test_radon.py
+++ b/tests/unit/test_radon.py
@@ -222,9 +222,7 @@ class TestRadonAsyncFallback:
     @patch("tapps_mcp.tools.radon.run_command_async", new_callable=AsyncMock)
     @patch("tapps_mcp.tools.radon._radon_cc_direct")
     async def test_cc_falls_back_on_timeout(self, mock_direct, mock_cmd):
-        mock_cmd.return_value = CommandResult(
-            returncode=-1, stdout="", stderr="", timed_out=True
-        )
+        mock_cmd.return_value = CommandResult(returncode=-1, stdout="", stderr="", timed_out=True)
         mock_direct.return_value = []
         result = await run_radon_cc_async("test.py")
         mock_direct.assert_called_once()
@@ -233,9 +231,7 @@ class TestRadonAsyncFallback:
     @pytest.mark.asyncio
     @patch("tapps_mcp.tools.radon.run_command_async", new_callable=AsyncMock)
     async def test_cc_uses_subprocess_when_available(self, mock_cmd):
-        mock_cmd.return_value = CommandResult(
-            returncode=0, stdout=SAMPLE_CC_JSON, stderr=""
-        )
+        mock_cmd.return_value = CommandResult(returncode=0, stdout=SAMPLE_CC_JSON, stderr="")
         result = await run_radon_cc_async("test.py")
         assert len(result) == 2
 

--- a/tests/unit/test_radon_direct.py
+++ b/tests/unit/test_radon_direct.py
@@ -145,10 +145,7 @@ class TestMiDirect:
     @patch("tapps_mcp.tools.radon_direct._read_source")
     def test_returns_float_for_valid_code(self, mock_read, _mock_avail):
         mock_read.return_value = (
-            '"""Module docstring."""\n\n'
-            "def foo():\n"
-            '    """Function docstring."""\n'
-            "    return 1\n"
+            '"""Module docstring."""\n\ndef foo():\n    """Function docstring."""\n    return 1\n'
         )
         mi = mi_direct("test.py")
         assert isinstance(mi, float)

--- a/tests/unit/test_retrieval_eval.py
+++ b/tests/unit/test_retrieval_eval.py
@@ -26,6 +26,7 @@ class TestBenchmarkQueries:
     def test_all_queries_valid(self) -> None:
         """Each query has domain, keywords, and valid min_chunks."""
         from tapps_mcp.experts.registry import ExpertRegistry
+
         valid_domains = {e.primary_domain for e in ExpertRegistry.get_all_experts()}
         for bq in BENCHMARK_QUERIES:
             assert bq.domain, f"Missing domain: {bq.query}"
@@ -59,14 +60,20 @@ class TestRunRetrievalEval:
         assert all(k in d for k in ("pass_rate", "avg_latency_ms", "failures"))
 
     def test_custom_queries(self) -> None:
-        custom = [BenchmarkQuery(domain="security", query="SQL injection prevention",
-                                 expected_keywords=["sql", "injection"])]
+        custom = [
+            BenchmarkQuery(
+                domain="security",
+                query="SQL injection prevention",
+                expected_keywords=["sql", "injection"],
+            )
+        ]
         report = run_retrieval_eval(queries=custom)
         assert report.total_queries == 1
 
     def test_custom_query_with_no_keywords(self) -> None:
-        custom = [BenchmarkQuery(domain="security", query="security best practices",
-                                 expected_keywords=[])]
+        custom = [
+            BenchmarkQuery(domain="security", query="security best practices", expected_keywords=[])
+        ]
         report = run_retrieval_eval(queries=custom)
         if report.results:
             assert report.results[0].keyword_total == 0
@@ -77,8 +84,14 @@ class TestQualityGates:
 
     def _report(self, **overrides) -> EvalReport:
         """Create a passing EvalReport with optional overrides."""
-        defaults = dict(total_queries=10, passed_queries=8, pass_rate=0.8,
-                        avg_latency_ms=50.0, p95_latency_ms=100.0, avg_keyword_coverage=0.6)
+        defaults = {
+            "total_queries": 10,
+            "passed_queries": 8,
+            "pass_rate": 0.8,
+            "avg_latency_ms": 50.0,
+            "p95_latency_ms": 100.0,
+            "avg_keyword_coverage": 0.6,
+        }
         defaults.update(overrides)
         return EvalReport(**defaults)
 
@@ -86,11 +99,15 @@ class TestQualityGates:
         passed, violations = check_quality_gates(self._report())
         assert passed and violations == []
 
-    @pytest.mark.parametrize("field,value,violation_keyword", [
-        ("pass_rate", 0.3, "Pass rate"),
-        ("p95_latency_ms", 600.0, "latency"),
-        ("avg_keyword_coverage", 0.1, "keyword"),
-    ], ids=["pass-rate", "latency", "keyword-coverage"])
+    @pytest.mark.parametrize(
+        "field,value,violation_keyword",
+        [
+            ("pass_rate", 0.3, "Pass rate"),
+            ("p95_latency_ms", 600.0, "latency"),
+            ("avg_keyword_coverage", 0.1, "keyword"),
+        ],
+        ids=["pass-rate", "latency", "keyword-coverage"],
+    )
     def test_individual_gate_failure(self, field, value, violation_keyword) -> None:
         passed, violations = check_quality_gates(self._report(**{field: value}))
         assert not passed
@@ -101,11 +118,15 @@ class TestQualityGates:
         passed, violations = check_quality_gates(report)
         assert not passed and len(violations) == 3
 
-    @pytest.mark.parametrize("field,value", [
-        ("pass_rate", QUALITY_GATE_PASS_RATE),
-        ("p95_latency_ms", QUALITY_GATE_P95_LATENCY_MS),
-        ("avg_keyword_coverage", QUALITY_GATE_MIN_KEYWORD_COVERAGE),
-    ], ids=["pass-rate-boundary", "latency-boundary", "coverage-boundary"])
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("pass_rate", QUALITY_GATE_PASS_RATE),
+            ("p95_latency_ms", QUALITY_GATE_P95_LATENCY_MS),
+            ("avg_keyword_coverage", QUALITY_GATE_MIN_KEYWORD_COVERAGE),
+        ],
+        ids=["pass-rate-boundary", "latency-boundary", "coverage-boundary"],
+    )
     def test_boundary_values_pass(self, field, value) -> None:
         """Exact threshold values should pass (not fail)."""
         passed, _ = check_quality_gates(self._report(**{field: value}))
@@ -124,9 +145,14 @@ class TestEvalReportDataclass:
         assert report.total_queries == 0 and report.pass_rate == 0.0 and report.failures == []
 
     def test_to_dict_rounds_values(self) -> None:
-        report = EvalReport(pass_rate=0.33333, avg_latency_ms=123.456789,
-                            p95_latency_ms=456.789, avg_top_score=0.88888,
-                            avg_keyword_coverage=0.77777, fallback_rate=0.11111)
+        report = EvalReport(
+            pass_rate=0.33333,
+            avg_latency_ms=123.456789,
+            p95_latency_ms=456.789,
+            avg_top_score=0.88888,
+            avg_keyword_coverage=0.77777,
+            fallback_rate=0.11111,
+        )
         d = report.to_dict()
         assert d["pass_rate"] == 0.3333
         assert d["avg_latency_ms"] == 123.46

--- a/tests/unit/test_ruff_direct.py
+++ b/tests/unit/test_ruff_direct.py
@@ -30,7 +30,10 @@ class TestRunRuffSync:
         import subprocess
 
         mock_run.return_value = subprocess.CompletedProcess(
-            args=["ruff"], returncode=0, stdout="", stderr="",
+            args=["ruff"],
+            returncode=0,
+            stdout="",
+            stderr="",
         )
         issues = _run_ruff_sync("test.py")
         assert issues == []

--- a/tests/unit/test_scorer.py
+++ b/tests/unit/test_scorer.py
@@ -427,9 +427,7 @@ class TestSuggestSecurity:
         assert "3 security issue" in tips[0]
 
     def test_patterns_found(self):
-        tips = _suggest_security(
-            6.0, {"issue_count": 0, "patterns_found": ["eval(", "exec("]}
-        )
+        tips = _suggest_security(6.0, {"issue_count": 0, "patterns_found": ["eval(", "exec("]})
         assert len(tips) == 1
         assert "eval(" in tips[0]
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 from unittest import mock
 
-import pytest
-
 
 class TestScoringWeights:
     """Validate ScoringWeights defaults and constraints."""
@@ -15,7 +13,15 @@ class TestScoringWeights:
         from tapps_mcp.config.settings import ScoringWeights
 
         w = ScoringWeights()
-        total = w.complexity + w.security + w.maintainability + w.test_coverage + w.performance + w.structure + w.devex
+        total = (
+            w.complexity
+            + w.security
+            + w.maintainability
+            + w.test_coverage
+            + w.performance
+            + w.structure
+            + w.devex
+        )
         assert abs(total - 1.0) < 0.01
 
     def test_weight_range(self) -> None:

--- a/tests/unit/test_setup_generator.py
+++ b/tests/unit/test_setup_generator.py
@@ -603,8 +603,14 @@ class TestCliInit:
         result = runner.invoke(
             main,
             [
-                "init", "--host", "claude-code", "--scope", "project",
-                "--project-root", str(tmp_path), "--no-rules",
+                "init",
+                "--host",
+                "claude-code",
+                "--scope",
+                "project",
+                "--project-root",
+                str(tmp_path),
+                "--no-rules",
             ],
         )
         assert result.exit_code == 0
@@ -616,8 +622,12 @@ class TestCliInit:
         result = runner.invoke(
             main,
             [
-                "init", "--host", "cursor",
-                "--project-root", str(tmp_path), "--no-rules",
+                "init",
+                "--host",
+                "cursor",
+                "--project-root",
+                str(tmp_path),
+                "--no-rules",
             ],
         )
         assert result.exit_code == 0
@@ -682,7 +692,10 @@ class TestConfigureMultipleHosts:
     def test_configures_all_hosts(self, tmp_path):
         """Configures all provided hosts."""
         ok = _configure_multiple_hosts(
-            ["cursor", "vscode"], tmp_path, force=True, rules=False,
+            ["cursor", "vscode"],
+            tmp_path,
+            force=True,
+            rules=False,
         )
         assert ok is True
         assert (tmp_path / ".cursor" / "mcp.json").exists()
@@ -695,7 +708,9 @@ class TestConfigureMultipleHosts:
         cursor_dir.mkdir()
         (cursor_dir / "mcp.json").write_text("{bad}", encoding="utf-8")
         ok = _configure_multiple_hosts(
-            ["cursor", "vscode"], tmp_path, rules=False,
+            ["cursor", "vscode"],
+            tmp_path,
+            rules=False,
         )
         assert ok is False
         # VS Code should still succeed
@@ -710,14 +725,20 @@ class TestConfigureMultipleHosts:
         (cursor_dir / "mcp.json").write_text(json.dumps(config), encoding="utf-8")
         # vscode is missing → should return False
         ok = _configure_multiple_hosts(
-            ["cursor", "vscode"], tmp_path, check=True, rules=False,
+            ["cursor", "vscode"],
+            tmp_path,
+            check=True,
+            rules=False,
         )
         assert ok is False
 
     def test_generates_rules_when_enabled(self, tmp_path):
         """Rules are generated alongside config when rules=True."""
         _configure_multiple_hosts(
-            ["cursor"], tmp_path, force=True, rules=True,
+            ["cursor"],
+            tmp_path,
+            force=True,
+            rules=True,
         )
         assert (tmp_path / ".cursor" / "mcp.json").exists()
         assert (tmp_path / ".cursor" / "rules" / "tapps-pipeline.md").exists()
@@ -725,7 +746,10 @@ class TestConfigureMultipleHosts:
     def test_skips_rules_when_disabled(self, tmp_path):
         """Rules are skipped when rules=False."""
         _configure_multiple_hosts(
-            ["cursor"], tmp_path, force=True, rules=False,
+            ["cursor"],
+            tmp_path,
+            force=True,
+            rules=False,
         )
         assert (tmp_path / ".cursor" / "mcp.json").exists()
         assert not (tmp_path / ".cursor" / "rules" / "tapps-pipeline.md").exists()

--- a/tests/unit/test_tapps_research.py
+++ b/tests/unit/test_tapps_research.py
@@ -23,16 +23,33 @@ class TestTappsResearchResponseShape:
         assert result["success"] is True
         assert result["elapsed_ms"] >= 0
         data = result["data"]
-        expected_keys = {"domain", "expert_id", "expert_name", "answer", "confidence",
-                         "factors", "sources", "chunks_used", "docs_supplemented",
-                         "docs_library", "docs_topic", "docs_error",
-                         "suggested_tool", "suggested_library", "suggested_topic",
-                         "fallback_used", "fallback_library", "fallback_topic"}
+        expected_keys = {
+            "domain",
+            "expert_id",
+            "expert_name",
+            "answer",
+            "confidence",
+            "factors",
+            "sources",
+            "chunks_used",
+            "docs_supplemented",
+            "docs_library",
+            "docs_topic",
+            "docs_error",
+            "suggested_tool",
+            "suggested_library",
+            "suggested_topic",
+            "fallback_used",
+            "fallback_library",
+            "fallback_topic",
+        }
         assert expected_keys <= set(data.keys())
         assert isinstance(data["docs_supplemented"], bool)
         assert 0.0 <= data["confidence"] <= 1.0
-        assert all(k in data["factors"] for k in ("rag_quality", "domain_relevance",
-                                                    "source_count", "chunk_coverage"))
+        assert all(
+            k in data["factors"]
+            for k in ("rag_quality", "domain_relevance", "source_count", "chunk_coverage")
+        )
 
 
 class TestTappsResearchRouting:
@@ -56,12 +73,15 @@ class TestTappsResearchDocsLookup:
         """docs_error is None or a string, never other types."""
         result = tapps_research(
             question="How to use an obscure library xyz123?",
-            domain="security", library="xyz123_nonexistent",
+            domain="security",
+            library="xyz123_nonexistent",
         )
         err = result["data"]["docs_error"]
         assert err is None or isinstance(err, str)
 
     def test_answer_nonempty(self) -> None:
-        result = tapps_research(question="What are best practices for database migrations?",
-                                domain="database-data-management")
+        result = tapps_research(
+            question="What are best practices for database migrations?",
+            domain="database-data-management",
+        )
         assert len(result["data"]["answer"]) > 0


### PR DESCRIPTION
Fix 35 ruff lint errors (E501, PLR2004, PLR0911, TC001/TC003, F841,
F401, SIM114, C408, I001), reformat 49 files to match ruff style, and
fix 3 mypy --strict errors (incompatible return type in nudges.py,
unused type:ignore in hot_rank.py, None assignment in engine.py).

All CI steps now pass: ruff check, ruff format, mypy --strict,
1579 unit tests (84.23% coverage), and uv build.

https://claude.ai/code/session_01CgDvaAqtFgFWWvk2DwnYYx