### PR TITLE
fix: correct 5 bugs across RAG scoring, cache, path normalization, and domain detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,26 @@
 <!-- tapps-agents-version: 0.2.1 -->
 # TappsMCP — instructions for AI assistants
 
-When the **TappsMCP** MCP server is configured in your host (Cursor, Claude Desktop, etc.), you have access to tools that provide **deterministic code quality checks, doc lookup, and domain expert advice**. Use them to avoid hallucinated APIs, missed quality steps, and inconsistent output.
+When the **TappsMCP** MCP server is configured in your host (Claude Code, Cursor, VS Code Copilot, Claude Desktop, etc.), you have access to tools that provide **deterministic code quality checks, doc lookup, and domain expert advice**. TappsMCP is a quality toolset designed to help your project and LLM produce the best possible code — use it to avoid hallucinated APIs, missed quality steps, and inconsistent output.
 
 ---
 
 ## What TappsMCP is
 
-TappsMCP is an MCP server that exposes tools for:
+TappsMCP is an MCP server that provides a comprehensive quality toolset for your project. It exposes 21 tools for:
 
-- **Scoring** Python files (0-100 across 7 categories)
-- **Security scanning** (Bandit + secret detection)
-- **Quality gates** (pass/fail vs presets)
-- **Documentation lookup** (up-to-date library docs via Context7)
-- **Config validation** (Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB)
+- **Scoring** Python files (0-100 across 7 categories: complexity, security, maintainability, test coverage, performance, structure, devex)
+- **Security scanning** (Bandit + secret detection with redacted context)
+- **Quality gates** (pass/fail against configurable presets: standard, strict, framework)
+- **Documentation lookup** (up-to-date library docs via Context7 with fuzzy matching and cache)
+- **Config validation** (Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB best practices)
 - **Domain experts** (16 built-in experts with RAG-backed answers, optional vector search)
 - **Project context** (project type detection, tech stack, impact analysis)
-- **Session notes** (persist decisions and constraints across long sessions)
+- **Session management** (persist decisions, constraints, and notes across long sessions)
 - **Quality reports** (JSON, Markdown, or HTML summaries)
+- **Metrics and feedback** (dashboard, usage stats, adaptive learning via feedback)
 - **Session checklist** (track which tools were used so you don't skip required steps)
+- **Pipeline orchestration** (batch validation, workflow prompts, project initialization)
 
 You only see these tools when the host has started the TappsMCP server and attached it to your session.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+# CLAUDE.md — Instructions for AI assistants working on TappsMCP
+
+This file provides context and best practices for AI assistants (Claude Code, Cursor, etc.) working on the **TappsMCP** codebase itself. If you are a consuming project that has TappsMCP installed as a tool, see [AGENTS.md](AGENTS.md) instead.
+
+---
+
+## What is TappsMCP?
+
+TappsMCP is a **Model Context Protocol (MCP) server** that provides deterministic code quality tools to LLMs and AI coding assistants. It is a **toolset designed to help other projects and LLMs produce higher-quality code** by providing structured, repeatable quality analysis instead of relying on prompt injection.
+
+TappsMCP gives any MCP-capable client (Claude Code, Cursor, VS Code Copilot, custom hosts) access to:
+
+- Code scoring (0-100 across 7 categories)
+- Security scanning (Bandit + secret detection)
+- Quality gates (pass/fail against configurable presets)
+- Documentation lookup (Context7 + cache)
+- Config validation (Dockerfile, docker-compose, infra)
+- Domain expert consultation (16 built-in experts with RAG)
+- Project profiling, impact analysis, session management
+- Metrics, dashboards, and adaptive learning
+
+---
+
+## Project structure
+
+```
+src/tapps_mcp/
+  __init__.py, cli.py, server.py              # Entry points and MCP server
+  server_scoring_tools.py                      # Score file, quality gate, quick check
+  server_pipeline_tools.py                     # Pipeline tools (validate_changed, session_start, init)
+  server_metrics_tools.py                      # Dashboard, stats, feedback, research
+  common/                                      # Exceptions, logging, shared models
+  config/                                      # Settings (Pydantic), default.yaml
+  security/                                    # Path validation, IO guardrails, secrets
+  scoring/                                     # Score model, constants, scorer
+  gates/                                       # Gate presets, evaluator
+  tools/                                       # Ruff, mypy, bandit, radon wrappers, parallel executor
+  knowledge/                                   # Context7 client, cache, lookup, fuzzy matcher
+  validators/                                  # Dockerfile, docker-compose, WebSocket, MQTT, InfluxDB
+  experts/                                     # Domain experts, RAG engine, knowledge files (122 .md)
+  project/                                     # Profiler, session notes, impact analysis, reports
+  adaptive/                                    # Adaptive scoring, expert voting, weight distribution
+  metrics/                                     # Collector, dashboard, alerts, trends, OTel, feedback
+  prompts/                                     # Workflow prompt templates
+  distribution/                                # Setup generator (tapps-mcp init), doctor
+  pipeline/                                    # Pipeline orchestration, handoff, initialization
+```
+
+---
+
+## Development commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run the MCP server (stdio)
+uv run tapps-mcp serve
+
+# Run all tests (1675+ tests)
+uv run pytest tests/ -v
+
+# Run with coverage
+uv run pytest tests/ --cov=tapps_mcp --cov-report=term-missing
+
+# Type checking (strict mode)
+uv run mypy --strict src/tapps_mcp/
+
+# Linting and formatting
+uv run ruff check src/
+uv run ruff format --check src/
+```
+
+---
+
+## Code conventions
+
+- **Python 3.12+** required
+- `from __future__ import annotations` at the top of every file
+- Type annotations everywhere — `mypy --strict` must pass
+- Use `structlog` for logging (never `print()` or `logging` directly)
+- Use `pathlib.Path` for all file paths
+- Pydantic v2 models for configuration and data structures
+- `ruff` for both linting and formatting (line length: 100)
+- Async/await for all tool handlers and external I/O
+- All file operations must go through the path validator (`security/path_validator.py`)
+
+---
+
+## Architecture principles
+
+- **MCP-first**: All tools are exposed via MCP `@mcp.tool()` decorators in `server.py`
+- **Deterministic**: Tools produce the same output for the same input — no LLM calls in the tool chain
+- **Graceful degradation**: When external checkers (ruff, mypy, bandit, radon) are missing, fall back to AST-based analysis and mark results as `degraded: true`
+- **Path safety**: All file operations are sandboxed to `TAPPS_MCP_PROJECT_ROOT`
+- **Cache-first**: Context7 lookups use stale-while-revalidate caching
+- **RAG safety**: All retrieved content is checked for prompt injection patterns
+
+---
+
+## Key files to know
+
+| File | Purpose |
+|------|---------|
+| `server.py` | Main MCP server — registers all tools, resources, prompts |
+| `server_scoring_tools.py` | `tapps_score_file`, `tapps_quality_gate`, `tapps_quick_check` |
+| `server_pipeline_tools.py` | `tapps_validate_changed`, `tapps_session_start`, `tapps_init` |
+| `server_metrics_tools.py` | `tapps_dashboard`, `tapps_stats`, `tapps_feedback`, `tapps_research` |
+| `scoring/scorer.py` | Core 7-category scoring engine |
+| `tools/parallel.py` | Parallel execution of ruff, mypy, bandit, radon |
+| `config/settings.py` | All settings with env var overrides (`TAPPS_MCP_*`) |
+| `knowledge/lookup.py` | Context7 documentation lookup with SWR cache |
+| `experts/engine.py` | Expert consultation RAG engine |
+| `pipeline/init.py` | `tapps_init` bootstrap logic |
+| `distribution/setup_generator.py` | `tapps-mcp init` CLI config generation |
+
+---
+
+## Testing
+
+- Tests are in `tests/` with `tests/unit/` and `tests/integration/` subdirectories
+- Use `pytest-asyncio` with `asyncio_mode = "auto"`
+- Coverage target: 80% minimum (`fail_under = 80` in pyproject.toml)
+- When adding a new tool or feature, add corresponding tests
+- Run the full suite before committing: `uv run pytest tests/ -v`
+
+---
+
+## TappsMCP TAPPS pipeline integration
+
+When TappsMCP's own MCP server is available in your session, use it on this codebase:
+
+1. Call `tapps_session_start` first
+2. Use `tapps_quick_check` after editing Python files
+3. Use `tapps_validate_changed` before declaring work complete
+4. Call `tapps_checklist(task_type="feature")` or appropriate type before finishing
+
+---
+
+## Important notes
+
+- TappsMCP is a **tool for other projects** — changes should consider how consuming projects will be affected
+- The `tapps_init` MCP tool bootstraps TappsMCP in consuming projects (creates AGENTS.md, TECH_STACK.md, platform rules)
+- The `tapps-mcp init` CLI generates MCP host configuration for Claude Code, Cursor, or VS Code
+- The `tapps-mcp doctor` CLI diagnoses configuration and connectivity issues
+- All 12 epics are complete (0-11) — see `docs/planning/epics/README.md` for the full history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TappsMCP
 
-Thank you for considering contributing to TappsMCP! This document provides guidelines and instructions for contributing.
+Thank you for considering contributing to TappsMCP! This document provides guidelines and instructions for contributing to this quality toolset for AI coding assistants.
 
 ## Development Setup
 
@@ -20,10 +20,10 @@ uv sync
 ### Running Tests
 
 ```bash
-# All tests
+# All tests (1675+ tests)
 uv run pytest tests/ -v
 
-# With coverage
+# With coverage (80% minimum required)
 uv run pytest tests/ --cov=tapps_mcp --cov-report=term-missing
 
 # Specific test file
@@ -41,6 +41,16 @@ uv run ruff format --check src/
 uv run mypy --strict src/tapps_mcp/
 ```
 
+### Verify Setup
+
+```bash
+# Diagnose configuration
+tapps-mcp doctor
+
+# Start server locally to test
+uv run tapps-mcp serve
+```
+
 ## How to Contribute
 
 ### Reporting Issues
@@ -53,7 +63,7 @@ uv run mypy --strict src/tapps_mcp/
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Make your changes
-4. Run tests and linting
+4. Run tests and linting (`uv run pytest tests/ -v && uv run ruff check src/ && uv run mypy --strict src/tapps_mcp/`)
 5. Commit with a descriptive message
 6. Push and open a PR
 
@@ -65,7 +75,19 @@ uv run mypy --strict src/tapps_mcp/
 - Use `structlog` for logging (not `print()` or `logging`)
 - Use `pathlib.Path` for file paths
 - Pydantic v2 models for data structures
-- `ruff` for linting and formatting
+- `ruff` for linting and formatting (line length: 100)
+- Async/await for tool handlers and external I/O
+- All file operations through the path validator (`security/path_validator.py`)
+
+### Adding a New Tool
+
+1. Add the tool handler in the appropriate `server_*.py` file (or `server.py` for core tools)
+2. Use `@mcp.tool()` decorator with clear docstring (lead with "When to use")
+3. Add `_record_call("tool_name")` at the start of the handler
+4. Register the tool in the checklist task map (`tools/checklist.py`)
+5. Add tests in `tests/unit/` and optionally `tests/integration/`
+6. Update `AGENTS.md` with the new tool's "When to use" entry
+7. Update `README.md` tools reference table
 
 ### Adding Knowledge Files
 
@@ -74,6 +96,7 @@ Expert knowledge files live in `src/tapps_mcp/experts/knowledge/{domain}/`. To a
 1. Create a markdown file in the appropriate domain directory
 2. Follow the existing format (title, sections, code examples)
 3. The file is automatically picked up by the expert system
+4. Delete any existing RAG index for that domain to trigger a rebuild
 
 ### Adding Validators
 
@@ -84,9 +107,18 @@ Config validators live in `src/tapps_mcp/validators/`. To add a new validator:
 3. Register it in the auto-detection logic in `base.py`
 4. Add tests in `tests/unit/`
 
+## Project Context
+
+TappsMCP is a **toolset for other projects** — changes should consider how consuming projects will be affected. Key integration points:
+
+- `tapps_init` bootstraps TappsMCP in consuming projects (creates AGENTS.md, TECH_STACK.md, platform rules)
+- `tapps-mcp init` generates MCP host configuration for Claude Code, Cursor, or VS Code
+- `tapps-mcp doctor` diagnoses configuration and connectivity issues
+- AGENTS.md is the primary AI-facing documentation consumed by other projects
+
 ## Architecture
 
-See [docs/planning/TAPPS_MCP_PLAN.md](docs/planning/TAPPS_MCP_PLAN.md) for the full architecture document.
+See [docs/planning/TAPPS_MCP_PLAN.md](docs/planning/TAPPS_MCP_PLAN.md) for the full architecture document and [CLAUDE.md](CLAUDE.md) for AI assistant instructions when working on this codebase.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TappsMCP
 
-**A Model Context Protocol (MCP) server that gives LLMs—Claude, Cursor, and others—deterministic code quality tools.** Score files, run security scans, enforce quality gates, look up docs, validate configs, and consult domain experts—all through structured tool calls instead of prompt injection.
+**A quality toolset for AI coding assistants.** TappsMCP is an MCP server that gives LLMs and AI-powered IDEs deterministic code quality tools — scoring, security scanning, quality gates, documentation lookup, config validation, and domain expert consultation — all through structured tool calls instead of prompt injection.
+
+**Use TappsMCP in your projects** to help Claude Code, Cursor, VS Code Copilot, and other MCP-capable clients produce higher-quality code with consistent, repeatable standards.
 
 [![CI](https://github.com/tapps-mcp/tapps-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/tapps-mcp/tapps-mcp/actions/workflows/ci.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -15,6 +17,7 @@
 - [Install](#install)
 - [Quick start](#quick-start)
 - [Connecting your AI client](#connecting-your-ai-client)
+- [CLI utilities](#cli-utilities)
 - [Tools reference](#tools-reference)
 - [Configuration](#configuration)
 - [Optional tool dependencies](#optional-tool-dependencies)
@@ -29,7 +32,9 @@
 
 ## What is TappsMCP?
 
-LLMs writing code make repeatable mistakes: wrong APIs, missing tests, security issues, and inconsistent quality. TappsMCP moves **proven quality tooling** out of long system prompts and into a single MCP server. Any MCP-capable client (Cursor, Claude Desktop, custom hosts) can call the same tools and get **structured, deterministic results**—scores, gates, security findings, doc lookups, and expert advice—without burning context on framework instructions.
+TappsMCP is a **quality toolset designed to help other projects and LLMs be the best they can**. LLMs writing code make repeatable mistakes: wrong APIs, missing tests, security issues, and inconsistent quality. TappsMCP moves **proven quality tooling** out of long system prompts and into a single MCP server that any project can install and use.
+
+Any MCP-capable client (Claude Code, Cursor, VS Code Copilot, Claude Desktop, custom hosts) can call the same tools and get **structured, deterministic results** — scores, gates, security findings, doc lookups, and expert advice — without burning context on framework instructions. Install TappsMCP in your project, connect your AI client, and every coding session benefits from consistent quality enforcement.
 
 ---
 
@@ -53,7 +58,7 @@ LLMs writing code make repeatable mistakes: wrong APIs, missing tests, security 
 
 ## Install
 
-Choose one of the following. After installing, see [Quick start](#quick-start) to run the server and [Connecting your AI client](#connecting-your-ai-client) to wire it into Cursor or Claude.
+Choose one of the following. After installing, see [Quick start](#quick-start) to configure your AI client and start the server.
 
 | Method | Requirements | Use when |
 |--------|--------------|----------|
@@ -128,53 +133,101 @@ The server listens at **http://localhost:8000** (MCP at `/mcp`). See [Docker](#d
 
 ## Quick start
 
-After [installing](#install), run the server so your AI client can connect.
+After [installing](#install), set up TappsMCP in your project and connect your AI client.
 
-**stdio (Cursor, Claude Desktop):**
-
-```bash
-tapps-mcp serve
-# or: uv run tapps-mcp serve   (if you installed from source with uv)
-# or: npx tapps-mcp serve      (if using npx)
-```
-
-**HTTP (remote / container):**
+**1. Configure your AI client (auto-detect):**
 
 ```bash
-tapps-mcp serve --transport http --port 8000
+tapps-mcp init                    # detects Claude Code, Cursor, VS Code
+# or: tapps-mcp init --host cursor   # target a specific client
 ```
 
-Then add the server in your client (e.g. [Cursor](#cursor) or [Claude Desktop](#claude-desktop)) and reload. The AI can call tools like `tapps_score_file` and `tapps_quality_gate`.
+**2. Start the server:**
+
+```bash
+tapps-mcp serve                           # stdio (local clients)
+# or: uv run tapps-mcp serve             # if installed from source with uv
+# or: npx tapps-mcp serve                # if using npx
+# or: tapps-mcp serve --transport http    # HTTP (remote / container)
+```
+
+**3. Verify:**
+
+```bash
+tapps-mcp doctor                  # diagnose configuration and connectivity
+```
+
+Then reload your AI client. The AI can call tools like `tapps_score_file` and `tapps_quality_gate`. See [Connecting your AI client](#connecting-your-ai-client) for client-specific details.
 
 ---
 
 ## Connecting your AI client
 
-Point your MCP client at the TappsMCP server so the AI can call the tools.
+Point your MCP client at the TappsMCP server so the AI can call the tools. TappsMCP works with any MCP-capable client.
+
+### Auto-setup with `tapps-mcp init`
+
+The fastest way to configure your client:
+
+```bash
+tapps-mcp init                        # auto-detect installed clients
+tapps-mcp init --host claude-code     # configure Claude Code
+tapps-mcp init --host cursor          # configure Cursor
+tapps-mcp init --host vscode          # configure VS Code
+```
+
+This generates the correct MCP configuration file for your client. Use `tapps-mcp init --check` to verify an existing setup. See [CLI utilities](#cli-utilities) for more options.
+
+### Claude Code
+
+Run `tapps-mcp init --host claude-code` or manually add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "tapps-mcp": {
+      "command": "tapps-mcp",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+For project-level config, use `tapps-mcp init --host claude-code --scope project` to create `.mcp.json` in the project root. For full access without permission prompts, see [docs/CLAUDE_FULL_ACCESS_SETUP.md](docs/CLAUDE_FULL_ACCESS_SETUP.md).
 
 ### Cursor
 
-1. Open **Settings → MCP** (or edit `.cursor/mcp.json` in your project).
-2. Add the server **without Docker** (replace the path with your actual TappMCP repo path):
+1. Run `tapps-mcp init --host cursor` or manually edit `.cursor/mcp.json` in your project:
 
 ```json
 {
   "mcpServers": {
     "tapps-mcp": {
       "command": "uv",
-      "args": ["--directory", "C:\\cursor\\TappMCP", "run", "--no-sync", "tapps-mcp", "serve"]
+      "args": ["--directory", "/path/to/tapps-mcp", "run", "--no-sync", "tapps-mcp", "serve"]
     }
   }
 }
 ```
 
-Use `--no-sync` to avoid "file in use" errors when Cursor starts the server. Docker is optional; see [Docker](#docker) for HTTP/remote.
+Use `--no-sync` to avoid "file in use" errors when Cursor starts the server.
 
-3. Restart or reload Cursor. The AI can then use tools like `tapps_score_file` and `tapps_quality_gate`.
+2. Restart or reload Cursor. The AI can then use tools like `tapps_score_file` and `tapps_quality_gate`.
 
-### For AI assistants
+### VS Code (Copilot)
 
-When TappsMCP is connected, call **`tapps_server_info`** at session start (the response includes a short `recommended_workflow`). Use **`tapps_score_file`** (with `quick: true`) during edits; before declaring work complete, run **`tapps_score_file`** (full), **`tapps_quality_gate`**, and **`tapps_checklist`**. Use **`tapps_lookup_docs`** before writing code that uses an external library. See **[AGENTS.md](AGENTS.md)** for when to use each tool and the full workflow.
+Run `tapps-mcp init --host vscode` or manually edit `.vscode/mcp.json` in your project:
+
+```json
+{
+  "servers": {
+    "tapps-mcp": {
+      "command": "tapps-mcp",
+      "args": ["serve"]
+    }
+  }
+}
+```
 
 ### Claude Desktop
 
@@ -184,8 +237,8 @@ Add to your Claude Desktop config (e.g. `claude_desktop_config.json`):
 {
   "mcpServers": {
     "tapps-mcp": {
-      "command": "uv",
-      "args": ["--directory", "/path/to/tapps-mcp", "run", "tapps-mcp", "serve"]
+      "command": "tapps-mcp",
+      "args": ["serve"]
     }
   }
 }
@@ -193,12 +246,52 @@ Add to your Claude Desktop config (e.g. `claude_desktop_config.json`):
 
 Restart Claude Desktop after changing the config.
 
+### For AI assistants
+
+When TappsMCP is connected, call **`tapps_session_start`** at session start (combines server info + project profile). Use **`tapps_quick_check`** after editing files; before declaring work complete, run **`tapps_validate_changed`** and **`tapps_checklist`**. Use **`tapps_lookup_docs`** before writing code that uses an external library. See **[AGENTS.md](AGENTS.md)** for when to use each tool and the full workflow.
+
 ### Suggested workflow for the AI
 
 1. Call **`tapps_session_start`** at session start to initialize context.
-2. Use **`tapps_quick_check`** (or `tapps_score_file` with `quick: true`) during edit–lint–fix loops.
-3. Use **`tapps_validate_changed`** before marking work complete (validates all changed files).
-4. Call **`tapps_checklist`** to ensure no required steps were skipped.
+2. Use **`tapps_quick_check`** (or `tapps_score_file` with `quick: true`) during edit-lint-fix loops.
+3. Use **`tapps_lookup_docs`** before writing code that uses an external library API.
+4. Use **`tapps_validate_changed`** before marking work complete (validates all changed files).
+5. Call **`tapps_checklist`** to ensure no required steps were skipped.
+
+---
+
+## CLI utilities
+
+TappsMCP includes CLI commands to set up, diagnose, and run the server:
+
+| Command | Purpose |
+|---------|---------|
+| `tapps-mcp serve` | Start the MCP server (stdio or HTTP transport) |
+| `tapps-mcp init` | Generate MCP configuration for Claude Code, Cursor, or VS Code |
+| `tapps-mcp init --check` | Verify existing MCP configuration without writing |
+| `tapps-mcp init --force` | Overwrite existing config without prompting (for CI/scripts) |
+| `tapps-mcp doctor` | Diagnose TappsMCP configuration and connectivity issues |
+
+### `tapps-mcp init` options
+
+```bash
+tapps-mcp init [OPTIONS]
+  --host     claude-code | cursor | vscode | auto   # Target client (default: auto-detect)
+  --scope    user | project                          # Config scope for Claude Code (default: user)
+  --force                                            # Overwrite without prompting
+  --check                                            # Verify only, no writes
+  --rules / --no-rules                               # Generate platform rule files (default: yes)
+  --project-root PATH                                # Project root (default: current dir)
+```
+
+### `tapps-mcp doctor`
+
+Diagnoses common issues: missing dependencies, config problems, connectivity:
+
+```bash
+tapps-mcp doctor
+tapps-mcp doctor --project-root /path/to/project
+```
 
 ---
 
@@ -373,13 +466,13 @@ Quick index:
 
 | Category | Weight | Description |
 |----------|--------|-------------|
-| complexity | 0.20 | Cyclomatic complexity (radon cc / AST fallback) |
-| security | 0.20 | Bandit + pattern heuristics |
-| maintainability | 0.15 | Maintainability index (radon mi / AST fallback) |
-| test_coverage | 0.10 | Heuristic from matching test file existence |
-| performance | 0.15 | AST: nested loops, large functions, deep nesting |
-| structure | 0.10 | Project layout (pyproject.toml, tests/, README, .git) |
-| devex | 0.10 | Developer experience (docs, AGENTS.md, tooling config) |
+| complexity | 0.18 | Cyclomatic complexity (radon cc / AST fallback) |
+| security | 0.27 | Bandit + pattern heuristics |
+| maintainability | 0.24 | Maintainability index (radon mi / AST fallback) |
+| test_coverage | 0.13 | Heuristic from matching test file existence |
+| performance | 0.08 | AST: nested loops, large functions, deep nesting |
+| structure | 0.05 | Project layout (pyproject.toml, tests/, README, .git) |
+| devex | 0.05 | Developer experience (docs, AGENTS.md, tooling config) |
 
 When ruff/mypy/bandit/radon are missing, the server uses AST-based fallbacks and reports `degraded: true` in the response.
 
@@ -398,17 +491,17 @@ log_json: false            # JSON-structured logs
 tool_timeout: 30           # Subprocess timeout in seconds
 ```
 
-Custom scoring weights:
+Custom scoring weights (these are the defaults — adjust to your project's priorities):
 
 ```yaml
 scoring_weights:
-  complexity: 0.20
-  security: 0.20
-  maintainability: 0.15
-  test_coverage: 0.10
-  performance: 0.15
-  structure: 0.10
-  devex: 0.10
+  complexity: 0.18
+  security: 0.27
+  maintainability: 0.24
+  test_coverage: 0.13
+  performance: 0.08
+  structure: 0.05
+  devex: 0.05
 ```
 
 ### Environment variables
@@ -416,7 +509,10 @@ scoring_weights:
 | Variable | Description |
 |----------|-------------|
 | **TAPPS_MCP_PROJECT_ROOT** | Restrict file operations to this directory (recommended for security). If unset, current working directory is used. |
+| **TAPPS_MCP_HOST_PROJECT_ROOT** | Optional. Host path mapping for Docker/remote setups. When set, absolute paths from the IDE are mapped to the project root. |
 | **TAPPS_MCP_CONTEXT7_API_KEY** | Optional. Used by `tapps_lookup_docs` for live Context7 API fetches; cache still works without it. |
+| **TAPPS_MCP_QUALITY_PRESET** | Override quality preset (`standard`, `strict`, `framework`). Default: `standard`. |
+| **TAPPS_MCP_LOG_LEVEL** | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Default: `INFO`. |
 
 ---
 
@@ -459,6 +555,35 @@ docker compose ps
 docker compose logs --tail 20
 curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/
 ```
+
+---
+
+## Bootstrapping TappsMCP in your project
+
+Once TappsMCP is installed and your AI client is connected, use the `tapps_init` MCP tool to bootstrap quality infrastructure in your project:
+
+```
+tapps_init(platform="claude")      # or platform="cursor"
+```
+
+This creates:
+
+| File | Purpose |
+|------|---------|
+| **AGENTS.md** | AI assistant workflow guide (when to call each tool) |
+| **TECH_STACK.md** | Auto-detected project profile (type, frameworks, CI, tests) |
+| **CLAUDE.md** or **.cursor/rules/** | Platform-specific pipeline rules |
+| **docs/TAPPS_HANDOFF.md** | Session handoff template |
+| **docs/TAPPS_RUNLOG.md** | Pipeline run log template |
+
+Optional flags:
+
+- `warm_cache_from_tech_stack=True` — pre-fetch Context7 docs for detected libraries
+- `warm_expert_rag_from_tech_stack=True` — pre-build expert RAG indices for relevant domains
+- `verify_server=True` — check which external checkers are installed
+- `install_missing_checkers=True` — auto-install missing ruff/mypy/bandit/radon
+
+After upgrading TappsMCP, re-run with `overwrite_agents_md=True` and `overwrite_platform_rules=True` to refresh templates. See [docs/UPGRADE_FOR_CONSUMERS.md](docs/UPGRADE_FOR_CONSUMERS.md).
 
 ---
 
@@ -515,18 +640,28 @@ src/tapps_mcp/
 
 ## Docs and roadmap
 
+### For consuming projects
+
 | Doc | Description |
 |-----|-------------|
-| [docs/TAPPS_MCP_SETUP_AND_USE.md](docs/TAPPS_MCP_SETUP_AND_USE.md) | Setup and use summary (Cursor, Claude, tools workflow). |
-| [docs/TAPPS_MCP_SETUP_AND_USE.md#8-troubleshooting](docs/TAPPS_MCP_SETUP_AND_USE.md#8-troubleshooting) | Troubleshooting (e.g. checklist import error, path denied). |
-| [docs/MIGRATION_FROM_TAPPS_AGENTS.md](docs/MIGRATION_FROM_TAPPS_AGENTS.md) | Migrating from tapps-agents: what to remove, keep, configure. |
-| [docs/DOCKER_DEPLOYMENT.md](docs/DOCKER_DEPLOYMENT.md) | Docker build, run, env vars, and client connection. |
+| [AGENTS.md](AGENTS.md) | AI assistant workflow guide — when to use each tool, recommended workflow. |
+| [addenda.md](addenda.md) | Best practices for Claude Code, Cursor, consuming projects, troubleshooting. |
+| [docs/TAPPS_MCP_SETUP_AND_USE.md](docs/TAPPS_MCP_SETUP_AND_USE.md) | Detailed setup and use guide (Cursor, Claude, tools workflow). |
+| [docs/UPGRADE_FOR_CONSUMERS.md](docs/UPGRADE_FOR_CONSUMERS.md) | Upgrade guide for projects that install TappsMCP. |
+| [docs/INIT_AND_UPGRADE_FEATURE_LIST.md](docs/INIT_AND_UPGRADE_FEATURE_LIST.md) | Init and upgrade: `tapps_init` vs `tapps-mcp init`, overwrite flags, upgrade path. |
 | [docs/CLAUDE_FULL_ACCESS_SETUP.md](docs/CLAUDE_FULL_ACCESS_SETUP.md) | Grant Claude Code full access (no permission prompts). |
-| [docs/INIT_AND_UPGRADE_FEATURE_LIST.md](docs/INIT_AND_UPGRADE_FEATURE_LIST.md) | Init and upgrade: tapps_init vs tapps-mcp init, overwrite flags, upgrade path for consuming projects. |
-| [docs/UPGRADE_FOR_CONSUMERS.md](docs/UPGRADE_FOR_CONSUMERS.md) | Short upgrade guide for projects that install TappsMCP. |
+| [docs/MIGRATION_FROM_TAPPS_AGENTS.md](docs/MIGRATION_FROM_TAPPS_AGENTS.md) | Migrating from tapps-agents: what to remove, keep, configure. |
+
+### For TappsMCP developers
+
+| Doc | Description |
+|-----|-------------|
+| [CLAUDE.md](CLAUDE.md) | Instructions for AI assistants working on the TappsMCP codebase itself. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup, coding standards, and how to submit changes. |
+| [docs/ARCHITECTURE_CACHE_AND_RAG.md](docs/ARCHITECTURE_CACHE_AND_RAG.md) | Context7 cache SWR behavior and expert RAG index architecture. |
+| [docs/DOCKER_DEPLOYMENT.md](docs/DOCKER_DEPLOYMENT.md) | Docker build, run, env vars, and client connection. |
 | [docs/planning/TAPPS_MCP_PLAN.md](docs/planning/TAPPS_MCP_PLAN.md) | Architecture and design rationale. |
 | [docs/planning/epics/README.md](docs/planning/epics/README.md) | Epic index, dependency graph, tool delivery timeline. |
-| [docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) | Epic 10+11: Expert + Context7 integration and retrieval optimization (complete). |
 | [CHANGELOG.md](CHANGELOG.md) | Release history following Keep a Changelog format. |
 | [SECURITY.md](SECURITY.md) | Security policy and vulnerability reporting. |
 

--- a/addenda.md
+++ b/addenda.md
@@ -1,0 +1,167 @@
+# Addenda — Best Practices for Using TappsMCP
+
+This document supplements the main [README.md](README.md) and [AGENTS.md](AGENTS.md) with best practices, tips, and guidance for getting the most out of TappsMCP in your projects.
+
+---
+
+## TappsMCP as a quality toolset for your projects
+
+TappsMCP is designed as a **shared quality infrastructure** that any MCP-capable AI assistant can use. Instead of embedding quality rules in system prompts or relying on the LLM's training data, TappsMCP provides **deterministic, tool-based** quality enforcement that produces consistent results regardless of which model or client you use.
+
+### Who benefits
+
+- **AI coding assistants** (Claude Code, Cursor, VS Code Copilot) — get structured quality feedback instead of guessing
+- **Development teams** — enforce consistent quality standards across AI-assisted work
+- **Individual developers** — use TappsMCP tools to validate AI-generated code before committing
+- **CI/CD pipelines** — integrate quality gates into automated workflows
+
+---
+
+## Best practices for Claude Code
+
+### Initial setup
+
+1. Install TappsMCP: `pip install tapps-mcp` or `uv add tapps-mcp`
+2. Run `tapps-mcp init --host claude-code` to generate MCP configuration
+3. Optionally run `tapps-mcp init --host claude-code --scope project` for project-level config (`.mcp.json`)
+4. For full access without permission prompts, see [docs/CLAUDE_FULL_ACCESS_SETUP.md](docs/CLAUDE_FULL_ACCESS_SETUP.md)
+
+### Session workflow
+
+```
+1. tapps_session_start         → Initialize context (server info + project profile)
+2. tapps_lookup_docs           → Before using any external library API
+3. tapps_quick_check           → After each file edit (fast feedback)
+4. tapps_validate_changed      → Before declaring work complete (all changed files)
+5. tapps_checklist             → Final check that no required steps were skipped
+```
+
+### Tips
+
+- Set `TAPPS_MCP_PROJECT_ROOT` to your project directory for path safety
+- Use `.tapps-mcp.yaml` in your project root to configure quality presets
+- Call `tapps_init` with `platform="claude"` to create a CLAUDE.md with pipeline rules
+- After upgrading TappsMCP, run `tapps_init(overwrite_agents_md=True, overwrite_platform_rules=True)` to refresh templates
+
+---
+
+## Best practices for Cursor
+
+### Initial setup
+
+1. Install TappsMCP: `pip install tapps-mcp` or from source with `uv sync`
+2. Add the MCP server to Cursor:
+   - **Settings > MCP** or edit `.cursor/mcp.json` in your project
+   - Use `--no-sync` with uv to avoid file lock errors:
+     ```json
+     {
+       "mcpServers": {
+         "tapps-mcp": {
+           "command": "uv",
+           "args": ["--directory", "/path/to/tapps-mcp", "run", "--no-sync", "tapps-mcp", "serve"]
+         }
+       }
+     }
+     ```
+3. Run `tapps-mcp init --host cursor` to auto-generate the config
+4. Call `tapps_init(platform="cursor")` to create `.cursor/rules/tapps-pipeline.md`
+
+### Tips
+
+- Use only **one** transport (stdio or HTTP) — not both
+- If using Docker, connect via `http://localhost:8000/mcp` (HTTP transport)
+- If Cursor shows "Error" for tapps-mcp, check: correct `serve` subcommand, `--no-sync` flag, PATH resolution
+- Restart Cursor after config changes
+
+---
+
+## Best practices for consuming projects
+
+### First-time setup
+
+1. Install TappsMCP in your project environment
+2. Call `tapps_init` (via AI or script) to bootstrap:
+   - Creates `AGENTS.md` with AI workflow guidance
+   - Creates `TECH_STACK.md` with detected project profile
+   - Optionally warms Context7 cache and expert RAG indices
+   - Generates platform rules (CLAUDE.md or .cursor/rules/)
+
+### Upgrading TappsMCP
+
+After `pip install -U tapps-mcp`:
+
+| What to refresh | How |
+|-----------------|-----|
+| AGENTS.md (workflow) | `tapps_init(overwrite_agents_md=True)` |
+| Platform rules | `tapps_init(platform="cursor", overwrite_platform_rules=True)` |
+| TECH_STACK.md and caches | `tapps_init()` (default, always refreshes) |
+| MCP host config | `tapps-mcp init --force` |
+
+### Quality presets
+
+| Preset | Threshold | Best for |
+|--------|-----------|----------|
+| `standard` | Overall >= 70 | General development, default |
+| `strict` | Overall >= 80, security >= 8, maintainability >= 7 | Production code, security-sensitive |
+| `framework` | Overall >= 75, security >= 8.5, maintainability >= 7.5 | Framework/library code |
+
+Configure in `.tapps-mcp.yaml`:
+
+```yaml
+quality_preset: standard
+```
+
+---
+
+## External tool dependencies
+
+TappsMCP works without these, but produces best results with them installed:
+
+| Tool | Purpose | Install | Without it |
+|------|---------|---------|------------|
+| **ruff** | Linting + formatting | `pip install ruff` | Limited lint analysis |
+| **mypy** | Type checking | `pip install mypy` | No type error detection |
+| **bandit** | Security scanning | `pip install bandit` | Heuristic-only security scoring |
+| **radon** | Complexity metrics | `pip install radon` | AST-based complexity fallback |
+
+Install all at once: `pip install ruff mypy bandit radon`
+
+For semantic expert search (optional): `pip install tapps-mcp[rag]`
+
+---
+
+## Environment variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `TAPPS_MCP_PROJECT_ROOT` | Restrict file operations to this directory | Current working directory |
+| `TAPPS_MCP_HOST_PROJECT_ROOT` | Host path mapping for Docker/remote setups | Not set |
+| `TAPPS_MCP_CONTEXT7_API_KEY` | Enable live Context7 documentation lookups | Not set (cache-only) |
+| `TAPPS_MCP_QUALITY_PRESET` | Override quality preset | `standard` |
+| `TAPPS_MCP_LOG_LEVEL` | Logging verbosity | `INFO` |
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| All tools fail with `No module named 'tapps_mcp.tools.checklist'` | Install via pip/uv (not standalone binary): `pip install tapps-mcp` |
+| Path denied errors | Set `TAPPS_MCP_PROJECT_ROOT` to the project directory |
+| `tapps_lookup_docs` returns empty | Set `TAPPS_MCP_CONTEXT7_API_KEY` for live API fetches; cache works without it |
+| Cursor shows "Error" for tapps-mcp | Ensure args end with `serve`, add `--no-sync` if using uv |
+| Scoring shows `degraded: true` | Install missing checkers: `pip install ruff mypy bandit radon` |
+| Docker: host paths rejected | Set `TAPPS_MCP_HOST_PROJECT_ROOT` to the host path the IDE uses |
+
+---
+
+## Further reading
+
+- [README.md](README.md) — Full project documentation and tool reference
+- [AGENTS.md](AGENTS.md) — AI assistant workflow guide
+- [CLAUDE.md](CLAUDE.md) — Instructions for working on TappsMCP itself
+- [docs/TAPPS_MCP_SETUP_AND_USE.md](docs/TAPPS_MCP_SETUP_AND_USE.md) — Detailed setup guide
+- [docs/DOCKER_DEPLOYMENT.md](docs/DOCKER_DEPLOYMENT.md) — Docker deployment guide
+- [docs/UPGRADE_FOR_CONSUMERS.md](docs/UPGRADE_FOR_CONSUMERS.md) — Upgrade guide for consuming projects
+- [docs/ARCHITECTURE_CACHE_AND_RAG.md](docs/ARCHITECTURE_CACHE_AND_RAG.md) — Cache and RAG architecture
+- [CHANGELOG.md](CHANGELOG.md) — Release history

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: tappmcp:local
-    container_name: tappmcp-mcp
+    image: tappsmcp:local
+    container_name: tappsmcp-mcp
     ports:
       - "8000:8000"
     environment:
       TAPPS_MCP_PROJECT_ROOT: /workspace
-      # Optional: set to the host path Cursor uses (e.g. C:\cursor\TappMCP) so host paths are accepted
-      # TAPPS_MCP_HOST_PROJECT_ROOT: "C:\\cursor\\TappMCP"
+      # Optional: set to the host path Cursor uses (e.g. C:\cursor\TappsMCP) so host paths are accepted
+      # TAPPS_MCP_HOST_PROJECT_ROOT: "C:\\cursor\\TappsMCP"
       TAPPS_MCP_QUALITY_PRESET: standard
       TAPPS_MCP_LOG_LEVEL: INFO
     volumes:

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -1,6 +1,6 @@
-# TappMCP: Docker Deployment
+# TappsMCP: Docker Deployment
 
-Run TappMCP as a **local Docker MCP server** using Streamable HTTP. The server listens on port **8000** and exposes the MCP endpoint at **`/mcp`**.
+Run TappsMCP as a **local Docker MCP server** using Streamable HTTP. The server listens on port **8000** and exposes the MCP endpoint at **`/mcp`**.
 
 ---
 
@@ -13,8 +13,8 @@ Run TappMCP as a **local Docker MCP server** using Streamable HTTP. The server l
 ## Quick Start
 
 ```bash
-# From the TappMCP repo root
-cd c:\cursor\TappMCP   # or your path
+# From the TappsMCP repo root
+cd c:\cursor\TappsMCP   # or your path
 
 # Build and start
 docker compose up --build -d
@@ -63,44 +63,44 @@ The MCP server is available at **http://localhost:8000** (Streamable HTTP endpoi
 
 ### Mounting a project (optional)
 
-To let TappMCP score files from a host directory, mount it at `/workspace`:
+To let TappsMCP score files from a host directory, mount it at `/workspace`:
 
 ```yaml
 volumes:
   - /path/to/your/project:/workspace:ro
 ```
 
-The default `docker-compose.yml` mounts the **current directory** (TappMCP repo) as `/workspace:ro`. To score a different project, change the volume to that path.
+The default `docker-compose.yml` mounts the **current directory** (TappsMCP repo) as `/workspace:ro`. To score a different project, change the volume to that path.
 
 ---
 
-## Using TappMCP Docker from another project
+## Using TappsMCP Docker from another project
 
 To use the MCP server for a **different project** (e.g. `C:\projects\myapp`):
 
 ### 1. Start the container with that project mounted
 
-Run Docker from the TappMCP repo but mount the **other project** as `/workspace` so the server can read its files:
+Run Docker from the TappsMCP repo but mount the **other project** as `/workspace` so the server can read its files:
 
 ```bash
-# From the TappMCP repo
-cd c:\cursor\TappMCP
+# From the TappsMCP repo
+cd c:\cursor\TappsMCP
 
 # Override the volume for this run (Windows example)
 docker compose run -d -p 8000:8000 -v "C:\projects\myapp:/workspace:ro" tapps-mcp
 ```
 
-Or create a **docker-compose.override.yml** in the TappMCP repo that overrides the volume:
+Or create a **docker-compose.override.yml** in the TappsMCP repo that overrides the volume:
 
 ```yaml
-# docker-compose.override.yml (in TappMCP repo)
+# docker-compose.override.yml (in TappsMCP repo)
 services:
   tapps-mcp:
     volumes:
       - C:\projects\myapp:/workspace:ro
 ```
 
-Then from the TappMCP repo: `docker compose up -d`. The container will see the other project at `/workspace`.
+Then from the TappsMCP repo: `docker compose up -d`. The container will see the other project at `/workspace`.
 
 **Optional — accept host paths from Cursor:** Set `TAPPS_MCP_HOST_PROJECT_ROOT` to the same path the IDE uses (e.g. `C:\projects\myapp`). Then Cursor can send absolute paths like `C:\projects\myapp\src\main.py` and the server will map them to `/workspace/src/main.py`. Example override:
 
@@ -147,8 +147,8 @@ docker compose down
 ## Build only (no compose)
 
 ```bash
-docker build -t tappmcp:local .
-docker run --rm -p 8000:8000 -e TAPPS_MCP_PROJECT_ROOT=/workspace tappmcp:local
+docker build -t tappsmcp:local .
+docker run --rm -p 8000:8000 -e TAPPS_MCP_PROJECT_ROOT=/workspace tappsmcp:local
 ```
 
 ---
@@ -178,6 +178,6 @@ docker run --rm -p 8000:8000 -e TAPPS_MCP_PROJECT_ROOT=/workspace tappmcp:local
 
 | File | Purpose |
 |------|---------|
-| `Dockerfile` | Builds the TappMCP image (Python 3.12, deps, ruff/mypy/bandit/radon) |
+| `Dockerfile` | Builds the TappsMCP image (Python 3.12, deps, ruff/mypy/bandit/radon) |
 | `docker-compose.yml` | Runs the server, port 8000, optional volume, healthcheck |
 | `.dockerignore` | Keeps build context small (excludes tests, docs, .venv, etc.) |

--- a/docs/FEEDBACK_ISSUES_PLAN.md
+++ b/docs/FEEDBACK_ISSUES_PLAN.md
@@ -93,7 +93,7 @@ Affected tools include `tapps_list_experts`, `tapps_consult_expert`, `tapps_serv
 
 ## Out of Scope (for this plan)
 
-- Changes to the Site24x7 project itself (only TappMCP repo changes are in scope).
+- Changes to the Site24x7 project itself (only TappsMCP repo changes are in scope).
 - Adding new features beyond “checklist optional” and “clear error when checklist is unavailable.”
 
 ---

--- a/docs/INIT_AND_UPGRADE_FEATURE_LIST.md
+++ b/docs/INIT_AND_UPGRADE_FEATURE_LIST.md
@@ -54,12 +54,15 @@ So “upgrading” pipeline artifacts and caches is done by **calling `tapps_ini
 |--------|-------------------|--------------|
 | **Host selection** | `--host claude-code \| cursor \| vscode \| auto` | Target MCP host. `auto` detects installed hosts (`.claude` dir, Cursor/VS Code settings dirs) and uses the first detected. |
 | **Project root** | `--project-root PATH` | Project root; used for Cursor/VS Code config paths (project-level `.cursor/mcp.json` or `.vscode/mcp.json`). Default: current directory. |
+| **Config scope** | `--scope user \| project` | For Claude Code: `user` writes to `~/.claude.json`, `project` writes to `.mcp.json` in the project root. Default: `user`. |
 | **Generate config** | (default, no `--check`) | Writes or merges the `tapps-mcp` server entry into the host’s config file. Preserves other servers; only adds/updates the `tapps-mcp` entry. |
 | **Verify config** | `--check` | Checks that the host’s config file exists and contains a valid `tapps-mcp` server entry; no writes. |
+| **Platform rules** | `--rules / --no-rules` | Generate platform rule files (CLAUDE.md or .cursor/rules/tapps-pipeline.md) alongside MCP config. Default: `--rules`. |
 | **Host detection** | (when `--host auto`) | Detects Claude Code (`~/.claude`), Cursor (platform-specific App Data / `.config`), VS Code (Code app data). |
-| **Config paths** | (per host) | **Claude Code:** `~/.claude.json`. **Cursor:** `project_root/.cursor/mcp.json`. **VS Code:** `project_root/.vscode/mcp.json`. |
+| **Config paths** | (per host) | **Claude Code:** `~/.claude.json` (user) or `.mcp.json` (project). **Cursor:** `project_root/.cursor/mcp.json`. **VS Code:** `project_root/.vscode/mcp.json`. |
 | **Server entry** | (merged into config) | Adds `tapps-mcp` with `command: "tapps-mcp"`, `args: ["serve"]` under `mcpServers` (Claude/Cursor) or `servers` (VS Code). |
 | **Force overwrite** | `--force` | Overwrite existing tapps-mcp entry without prompting. Use when upgrading or in non-interactive scripts. |
+| **Diagnostics** | `tapps-mcp doctor` | Separate command that diagnoses TappsMCP configuration, connectivity, and missing dependencies. |
 
 ### Idempotency / “upgrade” behavior
 

--- a/docs/MIGRATION_FROM_TAPPS_AGENTS.md
+++ b/docs/MIGRATION_FROM_TAPPS_AGENTS.md
@@ -6,46 +6,64 @@ If you were using **tapps-agents** (e.g. `.tapps-agents/`, experts config, knowl
 
 ## What to remove or stop using
 
-- **tapps-agents runtime and config**  
+- **tapps-agents runtime and config**
   Stop relying on the old agent-specific runtime. Remove or archive:
   - `.tapps-agents/` (if present in your project)
   - Any agents-specific config that pointed at tapps-agents (e.g. Cursor/Claude config that invoked the old stack)
-- **Duplicate MCP entries**  
-  In Cursor/Claude MCP settings, remove the old tapps-agents server entry so only **tapps-mcp** is configured.
+- **Duplicate MCP entries**
+  In your MCP host settings (Claude Code, Cursor, VS Code), remove the old tapps-agents server entry so only **tapps-mcp** is configured.
 
 ---
 
 ## What to keep
 
-- **Project layout and quality expectations**  
+- **Project layout and quality expectations**
   Your repo structure, test layout, and quality bar stay the same. TappsMCP tools (scoring, gates, security scan, checklist) replace the previous quality flow.
-- **File-based knowledge you care about**  
-  Any markdown docs, rules, or guidelines that lived under tapps-agents and that you still want can be kept as normal files. TappsMCP has its own expert knowledge base (in the repo under `src/tapps_mcp/experts/knowledge/`) and does not read legacy `.tapps-agents` knowledge by default; you can reuse content by copying into your project or into TappsMCP’s knowledge layout if you customize it.
+- **File-based knowledge you care about**
+  Any markdown docs, rules, or guidelines that lived under tapps-agents and that you still want can be kept as normal files. TappsMCP has its own expert knowledge base (in the repo under `src/tapps_mcp/experts/knowledge/`) and does not read legacy `.tapps-agents` knowledge by default; you can reuse content by copying into your project or into TappsMCP's knowledge layout if you customize it.
 
 ---
 
 ## What to configure
 
-1. **MCP host → TappsMCP**  
+1. **Auto-setup (recommended)**
+   Run `tapps-mcp init` to auto-detect your MCP host and generate configuration:
+   ```bash
+   tapps-mcp init                        # auto-detect
+   tapps-mcp init --host claude-code     # Claude Code
+   tapps-mcp init --host cursor          # Cursor
+   tapps-mcp init --host vscode          # VS Code
+   ```
+
+2. **Manual setup**
    Point your IDE/client at the TappsMCP server instead of tapps-agents:
-   - **Cursor:** In **Settings → Tools & MCP** or project `.cursor/mcp.json`, add the `tapps-mcp` server. Use either:
+   - **Claude Code:** `tapps-mcp init --host claude-code` or add to `~/.claude.json`
+   - **Cursor:** In **Settings > MCP** or project `.cursor/mcp.json`, add the `tapps-mcp` server. Use either:
      - **HTTP:** `"url": "http://localhost:8000/mcp"` when running TappsMCP in Docker, or
-     - **stdio:** `"command": "uv"` (or `"tapps-mcp"` if on PATH) with `"args": ["run", "tapps-mcp", "serve"]` (and `--directory` if needed).  
+     - **stdio:** `"command": "tapps-mcp"` with `"args": ["serve"]` (or use `uv` with `--directory`)
+   - **VS Code:** `tapps-mcp init --host vscode` or edit `.vscode/mcp.json`
+
    See [TAPPS_MCP_SETUP_AND_USE.md](TAPPS_MCP_SETUP_AND_USE.md) for full examples.
-2. **Project root (recommended)**  
+
+3. **Project root (recommended)**
    Set `TAPPS_MCP_PROJECT_ROOT` to the project you want the AI to analyze, or rely on the default (current working directory). For Docker or when the host path differs, set `TAPPS_MCP_HOST_PROJECT_ROOT` as in the setup doc.
-3. **Optional project config**  
+
+4. **Optional project config**
    Add `.tapps-mcp.yaml` in the project root to set `quality_preset`, `log_level`, `tool_timeout`, etc.
+
+5. **Bootstrap pipeline (optional)**
+   Call `tapps_init` via your AI assistant to create AGENTS.md, TECH_STACK.md, and platform rules in your project.
 
 ---
 
 ## Quick checklist
 
-- [ ] TappsMCP installed (pip/uv or Docker) and server runs (`tapps-mcp serve` or Docker).
-- [ ] Old tapps-agents MCP/server entry removed from Cursor/Claude.
-- [ ] New tapps-mcp entry added in MCP config (url or command/args).
+- [ ] TappsMCP installed (`pip install tapps-mcp` or `uv sync` or Docker).
+- [ ] Old tapps-agents MCP/server entry removed from your client.
+- [ ] New tapps-mcp entry added via `tapps-mcp init` or manually.
+- [ ] Verified with `tapps-mcp doctor`.
 - [ ] `TAPPS_MCP_PROJECT_ROOT` set if needed.
 - [ ] Optional: `.tapps-mcp.yaml` in project root.
-- [ ] Session workflow: start with `tapps_server_info` and `tapps_project_profile`; use `tapps_checklist` before declaring work complete.
+- [ ] Session workflow: start with `tapps_session_start`; use `tapps_checklist` before declaring work complete.
 
-For install and troubleshooting (including the “checklist module not found” error when using a binary), see [TAPPS_MCP_SETUP_AND_USE.md](TAPPS_MCP_SETUP_AND_USE.md).
+For install and troubleshooting (including the "checklist module not found" error when using a binary), see [TAPPS_MCP_SETUP_AND_USE.md](TAPPS_MCP_SETUP_AND_USE.md).

--- a/docs/TAPPS_MCP_SETUP_AND_USE.md
+++ b/docs/TAPPS_MCP_SETUP_AND_USE.md
@@ -1,6 +1,6 @@
-# TappMCP: Setup and Use Summary
+# TappsMCP: Setup and Use Summary
 
-TappMCP is an **MCP (Model Context Protocol) server** that exposes **code quality tools** to LLMs (Claude, Cursor, etc.): file scoring, security scanning, quality gates, and checklists. This doc is a short guide to set it up and use it.
+TappsMCP is an **MCP (Model Context Protocol) server** that exposes **code quality tools** to LLMs (Claude, Cursor, etc.): file scoring, security scanning, quality gates, and checklists. This doc is a short guide to set it up and use it.
 
 ---
 
@@ -18,7 +18,7 @@ TappMCP is an **MCP (Model Context Protocol) server** that exposes **code qualit
 
 ```bash
 # Clone (or open) the repo
-cd c:\cursor\TappMCP   # or your path
+cd c:\cursor\TappsMCP   # or your path
 
 # Install dependencies with uv
 uv sync
@@ -65,6 +65,42 @@ tool_timeout: 30
 
 ---
 
+## 2b. Auto-setup with `tapps-mcp init`
+
+The fastest way to configure your AI client:
+
+```bash
+tapps-mcp init                        # auto-detect installed clients
+tapps-mcp init --host claude-code     # configure Claude Code
+tapps-mcp init --host cursor          # configure Cursor
+tapps-mcp init --host vscode          # configure VS Code
+tapps-mcp init --check                # verify existing setup
+tapps-mcp doctor                      # diagnose connectivity issues
+```
+
+This generates the correct MCP configuration file and optionally creates platform rule files. Use `--force` to overwrite existing config without prompting.
+
+---
+
+## 2c. Use with Claude Code
+
+Run `tapps-mcp init --host claude-code` or manually add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "tapps-mcp": {
+      "command": "tapps-mcp",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+For project-level config, use `tapps-mcp init --host claude-code --scope project` to create `.mcp.json` in the project root. For full access without permission prompts, see [CLAUDE_FULL_ACCESS_SETUP.md](CLAUDE_FULL_ACCESS_SETUP.md).
+
+---
+
 ## 3. Use with Cursor
 
 1. **Cursor MCP config**  
@@ -93,7 +129,7 @@ tool_timeout: 30
      "mcpServers": {
        "tapps-mcp": {
          "command": "uv",
-         "args": ["--directory", "C:\\cursor\\TappMCP", "run", "--no-sync", "tapps-mcp", "serve"],
+         "args": ["--directory", "C:\\cursor\\TappsMCP", "run", "--no-sync", "tapps-mcp", "serve"],
          "env": {
            "TAPPS_MCP_CONTEXT7_API_KEY": "your-context7-api-key"
          }
@@ -102,23 +138,23 @@ tool_timeout: 30
    }
    ```
 
-   - Replace `C:\cursor\TappMCP` with your actual TappMCP repo path.
+   - Replace `C:\cursor\TappsMCP` with your actual TappsMCP repo path.
    - **`--no-sync`** makes `uv run` skip syncing the venv, which avoids “file is being used by another process” when Cursor starts the server.
    - The subcommand must be **`serve`** (not `serv`).
    - Set `TAPPS_MCP_CONTEXT7_API_KEY` so `tapps_lookup_docs` can fetch live docs; omit `env` to use cache-only.
 
 2. **Restart or reload Cursor** so it picks up the new MCP server.
 
-3. In chat/composer, the AI can call TappMCP tools (e.g. `tapps_score_file`, `tapps_quality_gate`) once the server is connected.
+3. In chat/composer, the AI can call TappsMCP tools (e.g. `tapps_score_file`, `tapps_quality_gate`) once the server is connected.
 
 ### If you see two "tapps-mcp" entries (one Error, one Disabled)
 
-Use **only one** transport. If you run TappMCP in Docker, use the **url** config (Option A) and remove or disable any **stdio** (command/args) entry for tapps-mcp from **Settings → Tools & MCP**. Duplicate entries often come from having both a project `.cursor/mcp.json` and a user-level MCP config; keep a single tapps-mcp entry that matches how you run the server (Docker → url, local → command/args).
+Use **only one** transport. If you run TappsMCP in Docker, use the **url** config (Option A) and remove or disable any **stdio** (command/args) entry for tapps-mcp from **Settings → Tools & MCP**. Duplicate entries often come from having both a project `.cursor/mcp.json` and a user-level MCP config; keep a single tapps-mcp entry that matches how you run the server (Docker → url, local → command/args).
 
 ### If Cursor shows "Error" for tapps-mcp
 
 - **Wrong subcommand:** The args must end with **`serve`** (not `serv`). In **Settings → Tools & MCP**, set the args to include `tapps-mcp` and **`serve`**.
-- **"File is being used by another process" (uv):** Add **`--no-sync`** to the args so uv doesn’t sync the venv on start, e.g. `["--directory", "C:\\cursor\\TappMCP", "run", "--no-sync", "tapps-mcp", "serve"]`. The command must be a PATH command (e.g. `uv`), not a local file path.
+- **"File is being used by another process" (uv):** Add **`--no-sync`** to the args so uv doesn’t sync the venv on start, e.g. `["--directory", "C:\\cursor\\TappsMCP", "run", "--no-sync", "tapps-mcp", "serve"]`. The command must be a PATH command (e.g. `uv`), not a local file path.
 - **Show Output:** In **Settings → Tools & MCP**, click **"Error - Show Output"** next to tapps-mcp to see the exact error.
 
 ---
@@ -132,7 +168,7 @@ In **Claude Desktop** config (e.g. `claude_desktop_config.json`):
   "mcpServers": {
     "tapps-mcp": {
       "command": "uv",
-      "args": ["--directory", "C:\\cursor\\TappMCP", "run", "--no-sync", "tapps-mcp", "serve"]
+      "args": ["--directory", "C:\\cursor\\TappsMCP", "run", "--no-sync", "tapps-mcp", "serve"]
     }
   }
 }
@@ -146,31 +182,36 @@ Restart Claude Desktop after changing the config.
 
 | Tool | Purpose |
 |------|--------|
-| **tapps_server_info** | Server version, available tools, which checkers (ruff, mypy, etc.) are installed. Call once at session start. |
+| **tapps_session_start** | **FIRST call** — combines server info + project profile. Initialize context for all subsequent tools. |
+| **tapps_server_info** | Server version, available tools, which checkers (ruff, mypy, etc.) are installed. |
 | **tapps_score_file** | Score a Python file 0-100 (complexity, security, maintainability, etc.). Use `quick: true` for fast checks, full for final pass. |
+| **tapps_quick_check** | Fast score + gate + basic security in one call. Use after each file edit. |
 | **tapps_security_scan** | Security scan (e.g. bandit + secret detection). |
 | **tapps_quality_gate** | Pass/fail vs thresholds (e.g. overall >= 70 for `standard`). Use before "done". |
+| **tapps_validate_changed** | Score + gate + security scan all changed files (auto-detects via git diff). |
 | **tapps_lookup_docs** | Fetch current library docs via Context7. Use before writing code that calls library APIs. |
 | **tapps_validate_config** | Validate Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB configs against best practices. |
 | **tapps_consult_expert** | Ask a domain expert (16 domains) and get RAG-backed guidance with confidence scores. |
+| **tapps_research** | Combined expert + docs lookup in one call (auto-supplements with Context7). |
 | **tapps_list_experts** | List available expert domains and their knowledge base status. |
 | **tapps_project_profile** | Detect project type, tech stack, and structure. Call at session start for context-aware analysis. |
 | **tapps_session_notes** | Save/retrieve key decisions and constraints across a session. |
 | **tapps_impact_analysis** | Analyze what depends on a file and what could break from changes. |
 | **tapps_report** | Generate a quality report (JSON, Markdown, or HTML) for scored files. |
-| **tapps_checklist** | See which TappMCP tools were used this session and what's missing. Use before "done". |
-| **tapps_dashboard** | View metrics dashboard: execution stats, expert performance, alerts, trends. Supports json, markdown, html output. |
+| **tapps_checklist** | See which TappsMCP tools were used this session and what's missing. Use before "done". |
+| **tapps_dashboard** | View metrics dashboard: execution stats, expert performance, alerts, trends. |
 | **tapps_stats** | Retrieve usage statistics: call counts, success rates, durations, gate pass rates. |
 | **tapps_feedback** | Submit feedback on tool results to improve adaptive scoring and expert weights. |
-| **tapps_init** | Initialize a pipeline run: profile the project, set context, plan the workflow stages. |
+| **tapps_init** | Bootstrap TappsMCP in a project: create AGENTS.md, TECH_STACK.md, platform rules, warm caches. |
+| **tapps_workflow** | Generate recommended tool call order for a specific task type. |
 
 **Suggested workflow for the AI:**
 
-1. Call **tapps_server_info** and **tapps_project_profile** at session start.
+1. Call **tapps_session_start** at session start (combines server info + project profile).
 2. Use **tapps_lookup_docs** before writing code that uses an external library.
 3. Use **tapps_session_notes** to record key decisions during the session.
-4. Use **tapps_score_file** (quick) during edit-lint-fix loops.
-5. Use **tapps_score_file** (full) and **tapps_quality_gate** before marking work complete.
+4. Use **tapps_quick_check** (or `tapps_score_file` with `quick: true`) during edit-lint-fix loops.
+5. Use **tapps_validate_changed** before marking work complete (validates all changed files).
 6. Call **tapps_checklist** to ensure no required steps were skipped.
 
 ---
@@ -193,13 +234,13 @@ Restart Claude Desktop after changing the config.
 | Run tests | `uv run pytest tests/` |
 | Lint | `uv run ruff check src/` |
 | **Docker** | `docker compose up --build -d` → http://localhost:8000 |
-| **Use Docker from another project** | Mount that project at `/workspace`, connect Cursor to http://localhost:8000/mcp (HTTP/SSE). See [DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md#using-tappmcp-docker-from-another-project). |
+| **Use Docker from another project** | Mount that project at `/workspace`, connect Cursor to http://localhost:8000/mcp (HTTP/SSE). See [DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md#using-tappsmcp-docker-from-another-project). |
 | Project config | `.tapps-mcp.yaml` in project root |
 | Cursor MCP config | Cursor Settings → MCP or `.cursor/mcp.json` |
 | Docker deployment | [docs/DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md) |
 | Init and upgrade (tapps_init, tapps-mcp init) | [docs/INIT_AND_UPGRADE_FEATURE_LIST.md](INIT_AND_UPGRADE_FEATURE_LIST.md) |
 | Upgrade guide for consuming projects | [docs/UPGRADE_FOR_CONSUMERS.md](UPGRADE_FOR_CONSUMERS.md) |
-| Epic 10 (planned): Expert + Context7 | [docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) |
+| Epic 10+11 (complete): Expert + Context7 | [docs/planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md](planning/TAPPS_MCP_IMPROVEMENT_IMPLEMENTATION_PLAN.md) |
 | Full plan / roadmap | [docs/planning/TAPPS_MCP_PLAN.md](planning/TAPPS_MCP_PLAN.md) |
 | Claude full access (no prompts) | [docs/CLAUDE_FULL_ACCESS_SETUP.md](CLAUDE_FULL_ACCESS_SETUP.md) |
 | **Cache & RAG architecture** | [docs/ARCHITECTURE_CACHE_AND_RAG.md](ARCHITECTURE_CACHE_AND_RAG.md) — SWR, TTL, index rebuild |
@@ -219,7 +260,9 @@ Restart Claude Desktop after changing the config.
 
 ## Summary
 
-1. **Setup:** `uv sync` in TappMCP repo, then run `uv run tapps-mcp serve`.
-2. **Use in Cursor/Claude:** Add the server to MCP config with `uv` + path to TappMCP + `run tapps-mcp serve`.
-3. **Use the tools:** Have the AI call `tapps_server_info` first, then `tapps_score_file` / `tapps_quality_gate` / `tapps_checklist` as in the workflow above.
-4. **Optional:** Install ruff/mypy/bandit/radon for best scoring; set `TAPPS_MCP_PROJECT_ROOT` and `.tapps-mcp.yaml` as needed.
+1. **Install:** `pip install tapps-mcp` or `uv sync` in the TappsMCP repo.
+2. **Configure your client:** `tapps-mcp init` (auto-detect) or manually add to MCP config.
+3. **Verify:** `tapps-mcp doctor` to diagnose any issues.
+4. **Run:** `tapps-mcp serve` to start the server (stdio for local clients, `--transport http` for remote).
+5. **Use the tools:** Have the AI call `tapps_session_start` first, then `tapps_quick_check` during edits, `tapps_validate_changed` + `tapps_checklist` before declaring work complete.
+6. **Optional:** Install ruff/mypy/bandit/radon for best scoring; set `TAPPS_MCP_PROJECT_ROOT` and `.tapps-mcp.yaml` as needed.

--- a/docs/UPGRADE_FOR_CONSUMERS.md
+++ b/docs/UPGRADE_FOR_CONSUMERS.md
@@ -23,7 +23,7 @@ Use the **`tapps_init`** MCP tool (via your AI assistant or a script) with:
 | `overwrite_platform_rules=True` | Refresh platform rule files (CLAUDE.md, .cursor/rules) |
 | `platform="cursor"` or `"claude"` | Which platform rules to generate |
 
-**Example (ask your AI):**  
+**Example (ask your AI):**
 *"Call tapps_init with overwrite_agents_md=True, overwrite_platform_rules=True, and platform=cursor to refresh to the latest TappsMCP templates."*
 
 ---
@@ -33,18 +33,29 @@ Use the **`tapps_init`** MCP tool (via your AI assistant or a script) with:
 If the MCP server entry or startup command changed, run:
 
 ```bash
-tapps-mcp init --force --host cursor
+tapps-mcp init --force --host cursor        # for Cursor
+tapps-mcp init --force --host claude-code   # for Claude Code
+tapps-mcp init --force --host vscode        # for VS Code
 ```
 
 `--force` overwrites the existing tapps-mcp entry without prompting.
 
 ---
 
-## 4. Re-run init for caches and TECH_STACK
+## 4. Verify the upgrade
+
+```bash
+tapps-mcp doctor                  # diagnose configuration and connectivity
+tapps-mcp init --check            # verify MCP config is correct
+```
+
+---
+
+## 5. Re-run init for caches and TECH_STACK
 
 A normal `tapps_init` run (without overwrite flags) will:
 
-- Refresh TECH_STACK.md
+- Refresh TECH_STACK.md with current project profile
 - Warm Context7 cache for detected libraries
 - Warm expert RAG indices for relevant domains
 
@@ -54,9 +65,11 @@ A normal `tapps_init` run (without overwrite flags) will:
 
 | What | How |
 |------|-----|
+| Upgrade the package | `pip install -U tapps-mcp` |
 | Get latest AGENTS.md and workflow | `tapps_init(overwrite_agents_md=True)` |
 | Get latest platform rules | `tapps_init(overwrite_platform_rules=True, platform="cursor")` or `platform="claude"` |
 | Refresh MCP config | `tapps-mcp init --force` |
 | Refresh caches and TECH_STACK | `tapps_init()` (default) |
+| Verify upgrade | `tapps-mcp doctor` |
 
 See [INIT_AND_UPGRADE_FEATURE_LIST.md](INIT_AND_UPGRADE_FEATURE_LIST.md) for the full init and upgrade behavior.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,8 @@
 # tapps-mcp
 
-npm wrapper for the [TappsMCP](https://github.com/tapps-mcp/tapps-mcp) Python MCP server.
+npm wrapper for the [TappsMCP](https://github.com/tapps-mcp/tapps-mcp) Python MCP server — a quality toolset for AI coding assistants.
+
+TappsMCP gives Claude Code, Cursor, VS Code Copilot, and other MCP-capable clients deterministic code quality tools: scoring, security scanning, quality gates, documentation lookup, config validation, and domain expert consultation.
 
 ## Usage
 
@@ -15,6 +17,15 @@ npm install -g tapps-mcp
 tapps-mcp serve
 ```
 
+### Available commands
+
+```bash
+tapps-mcp serve                    # Start the MCP server (stdio)
+tapps-mcp serve --transport http   # Start with HTTP transport
+tapps-mcp init                     # Generate MCP config for your AI client
+tapps-mcp doctor                   # Diagnose configuration issues
+```
+
 ## Requirements
 
 - Node.js 18+
@@ -27,5 +38,13 @@ This is a thin wrapper that:
 1. Checks for Python 3.12+
 2. Installs the `tapps-mcp` Python package if needed
 3. Forwards all arguments to the `tapps-mcp` CLI
+
+## Optional dependencies
+
+For best results, install these Python tools: `pip install ruff mypy bandit radon`
+
+For semantic expert search: `pip install tapps-mcp[rag]`
+
+## Documentation
 
 For full documentation, see [tapps-mcp on GitHub](https://github.com/tapps-mcp/tapps-mcp).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tapps-mcp"
 version = "0.2.1"
-description = "MCP server providing code quality tools extracted from TappsCodingAgents"
+description = "MCP server providing deterministic code quality tools for AI coding assistants"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"

--- a/scripts/verify_http_server.py
+++ b/scripts/verify_http_server.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Verify TappMCP HTTP server at localhost:8000 using Playwright.
+"""Verify TappsMCP HTTP server at localhost:8000 using Playwright.
 
 Usage:
     python scripts/verify_http_server.py [--url URL]
     uv run python scripts/verify_http_server.py
 
-Expects server to return 200 at / with body containing "TappMCP is running".
+Expects server to return 200 at / with body containing "TappsMCP is running".
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import sys
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Verify TappMCP HTTP server with Playwright")
+    parser = argparse.ArgumentParser(description="Verify TappsMCP HTTP server with Playwright")
     parser.add_argument("--url", default="http://localhost:8000", help="Base URL of the server")
     parser.add_argument(
         "--headless", action="store_true", default=True, help="Run browser headless"
@@ -51,10 +51,10 @@ def main() -> int:
 
     body_text = content.get("body", "")
     title = content.get("title", "")
-    if "TappMCP" not in body_text and "TappMCP" not in title:
+    if "TappsMCP" not in body_text and "TappsMCP" not in title:
         print(f"Unexpected response. Body snippet: {body_text[:200]!r}")
         return 1
-    print("OK: TappMCP HTTP server is running and returning the expected page.")
+    print("OK: TappsMCP HTTP server is running and returning the expected page.")
     return 0
 
 

--- a/src/tapps_mcp/experts/adaptive_domain_detector.py
+++ b/src/tapps_mcp/experts/adaptive_domain_detector.py
@@ -117,9 +117,13 @@ class AdaptiveDomainDetector:
         if consultation_history:
             suggestions.extend(self._detect_from_consultation_gaps(consultation_history))
 
-        # Filter out already-known domains.
+        # Filter out already-known domains for prompt/code suggestions.
+        # Consultation gap suggestions intentionally reference existing domains.
         known = self._get_existing_domains()
-        suggestions = [s for s in suggestions if s.domain not in known]
+        suggestions = [
+            s for s in suggestions
+            if s.domain not in known or s.source == "consultation_gap"
+        ]
 
         # Deduplicate by domain (keep highest confidence).
         seen: dict[str, DomainSuggestion] = {}

--- a/src/tapps_mcp/experts/rag.py
+++ b/src/tapps_mcp/experts/rag.py
@@ -309,7 +309,7 @@ def _score_line(line: str, keywords: set[str]) -> float:
 
     stripped = line.strip()
     if stripped.startswith("#"):
-        level = len(line) - len(line.lstrip("#"))
+        level = len(stripped) - len(stripped.lstrip("#"))
         base *= 2.0 - level * 0.2
     if stripped.startswith("```"):
         base *= 1.4
@@ -344,7 +344,7 @@ def _extract_keywords(query: str) -> set[str]:
     """Normalise *query* into a set of keywords."""
     clean = re.sub(r"[^\w\s-]", " ", query.lower())
     _min_keyword_len = 2
-    return {w for w in clean.split() if len(w) > _min_keyword_len and w not in _STOP_WORDS}
+    return {w for w in clean.split() if len(w) >= _min_keyword_len and w not in _STOP_WORDS}
 
 
 def _deduplicate(

--- a/src/tapps_mcp/knowledge/cache.py
+++ b/src/tapps_mcp/knowledge/cache.py
@@ -232,8 +232,9 @@ class KBCache:
             if not lib_dir.is_dir():
                 continue
             for f in lib_dir.iterdir():
+                if f.suffix == ".md":
+                    count += 1
                 f.unlink(missing_ok=True)
-                count += 1
             lib_dir.rmdir()
         return count
 

--- a/src/tapps_mcp/server.py
+++ b/src/tapps_mcp/server.py
@@ -49,7 +49,7 @@ _MIN_DRIVE_PATH_LEN = 2
 def _normalize_path_for_mapping(path: str) -> str:
     """Normalize a path string for host-root prefix comparison (cross-platform)."""
     s = path.strip().replace("\\", "/")
-    if s and s[1:2] == ":" and len(s) > _MIN_DRIVE_PATH_LEN and s[2:3] == "/":
+    if s and s[1:2] == ":" and len(s) >= _MIN_DRIVE_PATH_LEN:
         s = s[0].lower() + s[1:]
     return s.rstrip("/") or "/"
 

--- a/src/tapps_mcp/server.py
+++ b/src/tapps_mcp/server.py
@@ -958,8 +958,8 @@ def run_server(
 
         def _root(_request: Request) -> HTMLResponse:
             return HTMLResponse(
-                "<!DOCTYPE html><html><head><title>TappMCP</title></head><body>"
-                "<h1>TappMCP is running</h1><p>MCP endpoint: <a href='/mcp'>/mcp</a></p>"
+                "<!DOCTYPE html><html><head><title>TappsMCP</title></head><body>"
+                "<h1>TappsMCP is running</h1><p>MCP endpoint: <a href='/mcp'>/mcp</a></p>"
                 "<p>Version: " + __version__ + "</p></body></html>",
                 status_code=200,
             )

--- a/tests/integration/test_expert_pipeline.py
+++ b/tests/integration/test_expert_pipeline.py
@@ -138,13 +138,13 @@ class TestDomainDetectionFromProject:
     """Tests domain detection against real project structures."""
 
     def test_detect_from_tapps_mcp_project(self) -> None:
-        """Detect domains from TappMCP's own project root."""
+        """Detect domains from TappsMCP's own project root."""
         from pathlib import Path
 
         project_root = Path(__file__).parent.parent.parent
         results = DomainDetector.detect_from_project(project_root)
         domains = [r.domain for r in results]
-        # TappMCP has pyproject.toml → code-quality-analysis.
+        # TappsMCP has pyproject.toml → code-quality-analysis.
         assert "code-quality-analysis" in domains
 
     def test_detect_from_project_with_tests(self, tmp_path: Path) -> None:

--- a/tests/unit/test_expert_rag.py
+++ b/tests/unit/test_expert_rag.py
@@ -22,8 +22,8 @@ class TestExtractKeywords:
 
     def test_short_words_removed(self) -> None:
         kw = _extract_keywords("do it or go")
-        # All <= 2 chars or stop words.
-        assert kw == set()
+        # "do", "it", "or" are stop words; "go" (2 chars) meets min keyword length.
+        assert kw == {"go"}
 
     def test_preserves_compound_terms(self) -> None:
         kw = _extract_keywords("performance-optimization bottleneck")


### PR DESCRIPTION
1. rag.py _score_line: use `stripped` instead of `line` for header level
   calculation — leading whitespace caused incorrect level (always 0),
   applying maximum header boost regardless of actual depth.

2. cache.py clear(): count only .md files instead of all files (.md,
   .meta.json, .lock) so the return value reflects actual entry count,
   not 3x inflated file count.

3. server.py _normalize_path_for_mapping: remove overly restrictive
   s[2:3] == "/" check so bare Windows drive paths like "C:" get their
   drive letter lowercased, preventing host-path mapping mismatches.

4. rag.py _extract_keywords: change len(w) > _min_keyword_len to >= so
   2-character technical terms (go, io, db, js) are included, matching
   the intent of _min_keyword_len = 2.

5. adaptive_domain_detector.py detect_domains: exempt consultation_gap
   suggestions from the known-domain filter — gap detection targets
   registered domains with low confidence, so filtering them out made
   the entire consultation gap branch dead code.

https://claude.ai/code/session_015EtBPcNUfagjjgYRBVRCWG