### PR TITLE
fix: pin pip versions in Dockerfile and add hadolint config

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+---
+# Hadolint configuration for TappsMCP
+# https://github.com/hadolint/hadolint#configure
+
+ignored:
+  # Pinning apt packages to exact versions is fragile in slim images —
+  # the available version string changes with every base-image rebuild.
+  - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.12-slim AS builder
 WORKDIR /build
 
 # Install build deps
-RUN pip install --no-cache-dir hatchling
+RUN pip install --no-cache-dir hatchling==1.28.0
 
 # Copy project files
 COPY pyproject.toml uv.lock README.md ./
@@ -31,7 +31,7 @@ WORKDIR /app
 # Install system deps and external checkers
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
-    && pip install --no-cache-dir ruff mypy bandit radon \
+    && pip install --no-cache-dir ruff==0.15.0 mypy==1.19.1 bandit==1.9.3 radon==6.0.1 \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The Docker GitHub Action lint-dockerfile gate was failing because
hadolint flagged unpinned pip installs (DL3013) and unpinned apt
packages (DL3008). Pin hatchling, ruff, mypy, bandit, and radon to
specific versions and add .hadolint.yaml to ignore DL3008 (apt
pinning is fragile in slim images).

https://claude.ai/code/session_011QqPV6B1fovdQkBJFewGod