### PR TITLE
Fix ruff format violation in adaptive_domain_detector.py

### DIFF
--- a/src/tapps_mcp/experts/adaptive_domain_detector.py
+++ b/src/tapps_mcp/experts/adaptive_domain_detector.py
@@ -121,8 +121,7 @@ class AdaptiveDomainDetector:
         # Consultation gap suggestions intentionally reference existing domains.
         known = self._get_existing_domains()
         suggestions = [
-            s for s in suggestions
-            if s.domain not in known or s.source == "consultation_gap"
+            s for s in suggestions if s.domain not in known or s.source == "consultation_gap"
         ]
 
         # Deduplicate by domain (keep highest confidence).


### PR DESCRIPTION
Reformatted list comprehension to keep the `if` clause on the same line
as the `for` clause, satisfying `ruff format --check`.

https://claude.ai/code/session_011Cb5cdfXHstiZdppS1Cm6u