### PR TITLE
Fix Docker/scan workflow SARIF upload failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   packages: write
   contents: read
+  actions: read
   security-events: write
 
 jobs:
@@ -70,14 +71,21 @@ jobs:
           tags: tapps-mcp:scan
           cache-from: type=gha
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.34.0
         with:
           image-ref: tapps-mcp:scan
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
-      - name: Upload Trivy scan results
+      - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
         if: always()
+        continue-on-error: true
         with:
           sarif_file: trivy-results.sarif
+      - name: Upload Trivy scan results as artifact
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: trivy-scan-results
+          path: trivy-results.sarif


### PR DESCRIPTION
- Pin aquasecurity/trivy-action to @0.34.0 instead of unstable @master
- Add continue-on-error: true to upload-sarif step so it doesn't fail
  the workflow when GitHub Code Security is not enabled on the repo
- Add actions: read permission required for private repo SARIF uploads
- Add fallback artifact upload for scan results accessibility

https://claude.ai/code/session_012whJvLoYKAFV2iV9vpw87u