### PR TITLE
feat: enable impact analysis by default and optimize graph reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ You only see these tools when the host has started the TappsMCP server and attac
 | **tapps_quick_check** | **After editing any Python file** - quick score + gate + basic security in one fast call. |
 | **tapps_security_scan** | When the change is **security-sensitive** or before a security-focused review. |
 | **tapps_quality_gate** | **Before declaring work complete** - ensures the file passes the configured quality preset. Do not consider work done until this passes (or the user accepts the risk). |
-| **tapps_validate_changed** | **Before declaring multi-file work complete** - auto-detects changed files via git diff and runs score + gate on each. **Default is quick (ruff-only, under ~10s).** Pass `quick: false` for full validation (mypy, bandit, radon, vulture, 1–5+ min). Sends progress notifications when the client supports them. |
+| **tapps_validate_changed** | **Before declaring multi-file work complete** - auto-detects changed files via git diff and runs score + gate on each. **Default is quick mode** (ruff-only, under ~10s). Includes impact analysis by default (`include_impact=True`). Pass `quick: false` for full validation (mypy, bandit, radon, vulture, 1–5+ min). Sends progress notifications when the client supports them. |
 | **tapps_lookup_docs** | **Before writing code** that uses an external library - use the returned docs to avoid hallucinated APIs. |
 | **tapps_validate_config** | When **adding or changing** Dockerfile, docker-compose, or infra config. |
 | **tapps_consult_expert** | When making **domain-specific decisions** (security, testing, APIs, database, etc.) and you want authoritative, RAG-backed guidance. Pass `domain` when context makes it obvious (e.g. editing a test file -> `domain="testing-strategies"`). |
@@ -59,7 +59,7 @@ You only see these tools when the host has started the TappsMCP server and attac
 | **tapps_dead_code** | When you want to **find unused code** in a Python file - detects unused functions, classes, imports, and variables with confidence scoring. Use during refactoring or code review. |
 | **tapps_dependency_scan** | When you want to **check for vulnerable dependencies** - scans pip packages for known CVEs using pip-audit. Use before releases or security reviews. |
 | **tapps_dependency_graph** | When you want to **understand module dependencies** - builds import graph, detects circular imports, and calculates coupling metrics. Use before refactoring or when investigating import errors. |
-| **tapps_workflow** | When you want the **recommended tool call order** for a specific task type (general, feature, bugfix, refactor, security, review). |
+| **tapps_workflow** | *(MCP prompt, not a tool)* When you want the **recommended tool call order** for a specific task type (general, feature, bugfix, refactor, security, review). |
 | **tapps_init** | At **pipeline bootstrap** - creates AGENTS.md, TECH_STACK.md, platform rules, optionally warms caches. Call once per project (or when upgrading). |
 | **tapps_upgrade** | After a **TappsMCP version update** - validates and refreshes AGENTS.md, platform rules, hooks, agents, skills, and settings. Preserves custom command paths (e.g. PyInstaller exe). Use `dry_run: true` to preview. |
 | **tapps_doctor** | When **diagnosing configuration issues** - checks binary availability, MCP configs, platform rules, generated files, hooks, and installed quality tools. Returns per-check pass/fail with remediation hints. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ uv run tapps-mcp upgrade --dry-run  # preview generated file updates
 
 ### Server module split
 
-The MCP server is split across four files to stay under complexity limits. All share the same `mcp` FastMCP instance created in `server.py`:
+The MCP server is split across five files to stay under complexity limits. All share the same `mcp` FastMCP instance created in `server.py`:
 
-- **`server.py`** — Creates the `FastMCP("TappsMCP")` instance, registers MCP resources/prompts, and imports the other three modules which register their tools on the shared `mcp` object.
+- **`server.py`** — Creates the `FastMCP("TappsMCP")` instance, registers MCP resources/prompts, and 14 tools (`tapps_server_info`, `tapps_security_scan`, `tapps_lookup_docs`, `tapps_validate_config`, `tapps_consult_expert`, `tapps_list_experts`, `tapps_checklist`, `tapps_project_profile`, `tapps_session_notes`, `tapps_impact_analysis`, `tapps_report`, `tapps_dead_code`, `tapps_dependency_scan`, `tapps_dependency_graph`). Imports the other three modules which register their tools on the shared `mcp` object.
 - **`server_scoring_tools.py`** — `tapps_score_file`, `tapps_quality_gate`, `tapps_quick_check`
 - **`server_pipeline_tools.py`** — `tapps_validate_changed`, `tapps_session_start`, `tapps_init`, `tapps_upgrade`, `tapps_doctor`
 - **`server_metrics_tools.py`** — `tapps_dashboard`, `tapps_stats`, `tapps_feedback`, `tapps_research`

--- a/README.md
+++ b/README.md
@@ -356,10 +356,10 @@ Quick index:
 | **tapps_dead_code** | Scan a Python file for unused functions, classes, imports, and variables (Vulture). |
 | **tapps_dependency_scan** | Scan project dependencies for known vulnerabilities (pip-audit). |
 | **tapps_dependency_graph** | Build import graph, detect circular imports, and calculate coupling metrics. |
-| **tapps_init** | Initialize a pipeline run: profile the project, set context, and plan the workflow. |
+| **tapps_init** | Bootstrap TappsMCP in a project: create AGENTS.md, TECH_STACK.md, platform rules, warm caches. |
 | **tapps_upgrade** | Validate and refresh all generated files (AGENTS.md, rules, hooks) after upgrading TappsMCP. |
 | **tapps_doctor** | Diagnose configuration, rules, hooks, and connectivity — returns per-check pass/fail with hints. |
-| **tapps_workflow** | *(MCP prompt)* Generate tool call order and recommendations for a specific task type. |
+| **tapps_workflow** | *(MCP prompt, not a tool)* Recommended tool call order for a specific task type. |
 
 ---
 
@@ -413,9 +413,9 @@ Quick index:
 
 ### tapps_validate_changed
 
-**What it does:** Detects changed Python files (via `git diff` against a base ref) or accepts an explicit comma-separated list. Runs full score + quality gate + security scan on each file. Returns per-file results with pass/fail status and aggregated summary.
+**What it does:** Detects changed Python files (via `git diff` against a base ref) or accepts an explicit comma-separated list. Default is `quick=True` (ruff-only scoring, under ~10s). Pass `quick=False` for full validation (ruff, mypy, bandit, radon). Includes impact analysis by default (`include_impact=True`) showing blast radius of changes. Returns per-file results with pass/fail status, impact summary, and aggregated summary.
 
-**Why use it:** Required before declaring multi-file work complete. Auto-detects what changed so you don't have to specify each file. Ensures no changed file slips through without quality validation.
+**Why use it:** Required before declaring multi-file work complete. Auto-detects what changed so you don't have to specify each file. Ensures no changed file slips through without quality validation. Impact analysis helps understand downstream effects of changes.
 
 ---
 
@@ -485,7 +485,7 @@ Quick index:
 
 ### tapps_impact_analysis
 
-**What it does:** Analyzes a Python file to determine its impact on the codebase. Returns the file's imports, what other files import it (dependents), exported symbols, and a dependency depth estimate. Accepts an optional `change_description` to scope the analysis.
+**What it does:** Analyzes a Python file to determine its blast radius. Builds an import graph, identifies direct dependents (files that import the changed file), transitive dependents (multi-hop), and affected test files. Returns severity assessment, total affected count, and recommendations. Accepts an optional `change_type` parameter (`"added"`, `"modified"`, or `"removed"`) to adjust severity assessment.
 
 **Why use it:** Before modifying a file, understand what else could break. Use when refactoring, renaming, or changing public APIs so the AI knows which downstream files may need updates.
 

--- a/docs/TAPPS_MCP_SETUP_AND_USE.md
+++ b/docs/TAPPS_MCP_SETUP_AND_USE.md
@@ -195,7 +195,7 @@ Restart Claude Desktop after changing the config.
 | **tapps_quick_check** | Fast score + gate + basic security in one call. Use after each file edit. |
 | **tapps_security_scan** | Security scan (e.g. bandit + secret detection). |
 | **tapps_quality_gate** | Pass/fail vs thresholds (e.g. overall >= 70 for `standard`). Use before "done". |
-| **tapps_validate_changed** | Score + gate + security scan all changed files (auto-detects via git diff). |
+| **tapps_validate_changed** | Score + gate all changed files (auto-detects via git diff). Default quick mode (ruff-only). Includes impact analysis. |
 | **tapps_lookup_docs** | Fetch current library docs via Context7. Use before writing code that calls library APIs. |
 | **tapps_validate_config** | Validate Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB configs against best practices. |
 | **tapps_consult_expert** | Ask a domain expert (16 domains) and get RAG-backed guidance with confidence scores. |

--- a/docs/planning/P0_P1_P2_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/P0_P1_P2_IMPLEMENTATION_PLAN.md
@@ -39,7 +39,7 @@
 
 ### Changes
 1. Add `security_depth: str = "basic"` param (basic/full)
-2. Add `include_impact: bool = False` param
+2. Add `include_impact: bool = True` param (default on; opt-out with False)
 3. Change security gate: `security_depth="full"` overrides `quick` gate
 4. Add basic secret-scan-only path for `quick=True` + `include_security=True`
 5. After scoring, optionally run impact analysis (pre-build graph once, share across files)

--- a/src/tapps_mcp/project/impact_analyzer.py
+++ b/src/tapps_mcp/project/impact_analyzer.py
@@ -86,12 +86,27 @@ def _build_import_graph(
 # ---------------------------------------------------------------------------
 
 
+def build_import_graph(
+    project_root: Path,
+    *,
+    max_files: int = 2000,
+) -> dict[str, set[str]]:
+    """Build and return the project import graph.
+
+    Public wrapper around :func:`_build_import_graph` so callers (e.g.
+    ``tapps_validate_changed``) can build the graph once and pass it to
+    multiple :func:`analyze_impact` calls.
+    """
+    return _build_import_graph(project_root, max_files=max_files)
+
+
 def analyze_impact(
     file_path: Path,
     project_root: Path,
     change_type: str = "modified",
     *,
     max_depth: int = 3,
+    graph: dict[str, set[str]] | None = None,
 ) -> ImpactReport:
     """Analyse the blast radius of changing *file_path*.
 
@@ -100,6 +115,9 @@ def analyze_impact(
         project_root: Root of the project tree.
         change_type: ``"added"``, ``"modified"``, or ``"removed"``.
         max_depth: Maximum transitive depth to follow.
+        graph: Pre-built import graph (from :func:`build_import_graph`).
+            When ``None`` the graph is built on each call — pass a shared
+            graph when analysing multiple files to avoid redundant work.
 
     Returns:
         An :class:`ImpactReport` with affected files.
@@ -110,7 +128,8 @@ def analyze_impact(
         change_type=change_type,
     )
 
-    graph = _build_import_graph(project_root)
+    if graph is None:
+        graph = _build_import_graph(project_root)
     changed_module = _module_for_file(file_path, project_root)
 
     direct: list[FileImpact] = []

--- a/src/tapps_mcp/prompts/agents_template.md
+++ b/src/tapps_mcp/prompts/agents_template.md
@@ -41,7 +41,7 @@ You only see these tools when the host has started the TappsMCP server and attac
 | **tapps_quick_check** | **After editing any Python file** - quick score + gate + basic security in one fast call. |
 | **tapps_security_scan** | When the change is **security-sensitive** or before a security-focused review. |
 | **tapps_quality_gate** | **Before declaring work complete** - ensures the file passes the configured quality preset. Do not consider work done until this passes (or the user accepts the risk). |
-| **tapps_validate_changed** | **Before declaring multi-file work complete** - auto-detects changed files via git diff and runs score + gate + security on each. |
+| **tapps_validate_changed** | **Before declaring multi-file work complete** - auto-detects changed files via git diff and runs score + gate on each. **Default is quick mode** (ruff-only, under ~10s). Includes impact analysis by default. Pass `quick=false` for full validation. |
 | **tapps_lookup_docs** | **Before writing code** that uses an external library - use the returned docs to avoid hallucinated APIs. |
 | **tapps_validate_config** | When **adding or changing** Dockerfile, docker-compose, or infra config. |
 | **tapps_consult_expert** | When making **domain-specific decisions** (security, testing, APIs, database, etc.) and you want authoritative, RAG-backed guidance. Pass `domain` when context makes it obvious (e.g. editing a test file -> `domain="testing-strategies"`). |

--- a/src/tapps_mcp/server_pipeline_tools.py
+++ b/src/tapps_mcp/server_pipeline_tools.py
@@ -99,7 +99,7 @@ async def tapps_validate_changed(
     include_security: bool = True,
     quick: bool = True,
     security_depth: str = "basic",
-    include_impact: bool = False,
+    include_impact: bool = True,
     ctx: Context[Any, Any, Any] | None = None,
 ) -> dict[str, Any]:
     """REQUIRED before declaring work complete on multi-file changes.
@@ -121,7 +121,7 @@ async def tapps_validate_changed(
         quick: If True (default), ruff-only scoring for speed. If False, full validation.
         security_depth: Security scan depth - "basic" (default) or "full". When "full",
             security scan runs even in quick mode.
-        include_impact: Whether to run impact analysis on changed files (default: False).
+        include_impact: Whether to run impact analysis on changed files (default: True).
         ctx: Optional MCP context (injected by host); used for progress notifications.
     """
     from tapps_mcp.server import _record_call, _record_execution, _validate_file_path, _with_nudges
@@ -275,16 +275,18 @@ async def tapps_validate_changed(
     all_passed = all(r.get("gate_passed", False) for r in results)
     total_sec = sum(r.get("security_issues", 0) for r in results)
 
-    # Impact analysis (opt-in)
+    # Impact analysis (on by default; build the import graph once and reuse)
     impact_data: dict[str, Any] | None = None
     if include_impact and paths:
         try:
-            from tapps_mcp.project.impact_analyzer import analyze_impact
+            from tapps_mcp.project.impact_analyzer import analyze_impact, build_import_graph
+
+            import_graph = build_import_graph(settings.project_root)
 
             impact_results: list[dict[str, Any]] = []
             for p in paths:
                 try:
-                    report = analyze_impact(p, settings.project_root)
+                    report = analyze_impact(p, settings.project_root, graph=import_graph)
                     impact_results.append({
                         "file": str(p),
                         "severity": report.severity,

--- a/tests/unit/test_impact_analyzer.py
+++ b/tests/unit/test_impact_analyzer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tapps_mcp.project.impact_analyzer import analyze_impact
+from tapps_mcp.project.impact_analyzer import analyze_impact, build_import_graph
 from tapps_mcp.project.models import ImpactReport
 
 
@@ -186,6 +186,52 @@ class TestRecommendations:
         assert report.test_files, "Expected at least one test file"
         recs_lower = " ".join(report.recommendations).lower()
         assert "re-run" in recs_lower or "rerun" in recs_lower
+
+
+class TestBuildImportGraph:
+    """Tests for the public build_import_graph helper."""
+
+    def test_returns_graph(self, tmp_path: Path) -> None:
+        """build_import_graph returns a dict mapping modules to importing files."""
+        _write_file(tmp_path / "pkg" / "__init__.py", "")
+        _write_file(tmp_path / "pkg" / "core.py", "x = 1\n")
+        _write_file(
+            tmp_path / "pkg" / "consumer.py",
+            "from pkg.core import x\n",
+        )
+
+        graph = build_import_graph(tmp_path)
+
+        assert isinstance(graph, dict)
+        assert "pkg.core" in graph
+        assert str(tmp_path / "pkg" / "consumer.py") in graph["pkg.core"]
+
+    def test_graph_reuse_gives_same_results(self, tmp_path: Path) -> None:
+        """Passing a prebuilt graph to analyze_impact produces the same results."""
+        _write_file(tmp_path / "pkg" / "__init__.py", "")
+        _write_file(tmp_path / "pkg" / "core.py", "x = 1\n")
+        _write_file(
+            tmp_path / "pkg" / "consumer.py",
+            "from pkg.core import x\n",
+        )
+
+        # Without prebuilt graph
+        report_auto = analyze_impact(
+            file_path=tmp_path / "pkg" / "core.py",
+            project_root=tmp_path,
+        )
+
+        # With prebuilt graph
+        graph = build_import_graph(tmp_path)
+        report_reuse = analyze_impact(
+            file_path=tmp_path / "pkg" / "core.py",
+            project_root=tmp_path,
+            graph=graph,
+        )
+
+        assert report_auto.severity == report_reuse.severity
+        assert report_auto.total_affected == report_reuse.total_affected
+        assert len(report_auto.direct_dependents) == len(report_reuse.direct_dependents)
 
 
 class TestSkipDirs:

--- a/tests/unit/test_validate_changed_p0.py
+++ b/tests/unit/test_validate_changed_p0.py
@@ -182,7 +182,7 @@ class TestValidateChangedP0:
 
     @pytest.mark.asyncio
     async def test_include_impact_false_no_summary(self, tmp_path: Path) -> None:
-        """include_impact=False (default) should NOT include impact_summary."""
+        """include_impact=False should NOT include impact_summary."""
         from tapps_mcp.server_pipeline_tools import tapps_validate_changed
 
         f = tmp_path / "test.py"

--- a/tests/unit/test_validate_changed_p0.py
+++ b/tests/unit/test_validate_changed_p0.py
@@ -154,6 +154,10 @@ class TestValidateChangedP0:
             patch("tapps_mcp.scoring.scorer.CodeScorer", return_value=scorer),
             patch("tapps_mcp.gates.evaluator.evaluate_gate", return_value=mock_gate),
             patch(
+                "tapps_mcp.project.impact_analyzer.build_import_graph",
+                return_value={},
+            ),
+            patch(
                 "tapps_mcp.project.impact_analyzer.analyze_impact",
                 return_value=mock_report,
             ) as mock_analyze,
@@ -223,6 +227,10 @@ class TestValidateChangedP0:
             patch("tapps_mcp.scoring.scorer.CodeScorer", return_value=scorer),
             patch("tapps_mcp.gates.evaluator.evaluate_gate", return_value=mock_gate),
             patch(
+                "tapps_mcp.project.impact_analyzer.build_import_graph",
+                return_value={},
+            ),
+            patch(
                 "tapps_mcp.project.impact_analyzer.analyze_impact",
                 side_effect=RuntimeError("graph build failed"),
             ),
@@ -248,7 +256,11 @@ class TestValidateChangedP0:
 
     @pytest.mark.asyncio
     async def test_backward_compat_no_new_params(self, tmp_path: Path) -> None:
-        """Calling with no new params should produce the same shape as before."""
+        """Calling with no new params should produce the same shape as before.
+
+        Since include_impact now defaults to True, the response includes
+        impact_summary with default values.
+        """
         from tapps_mcp.server_pipeline_tools import tapps_validate_changed
 
         f = tmp_path / "test.py"
@@ -256,12 +268,21 @@ class TestValidateChangedP0:
 
         scorer = _mock_scorer()
         mock_gate = MagicMock(passed=True, failures=[])
+        mock_report = _mock_impact_report(str(f), severity="low", direct=0, transitive=0, tests=0)
 
         with (
             patch("tapps_mcp.server_pipeline_tools.load_settings") as mock_settings,
             patch("tapps_mcp.server._validate_file_path", side_effect=Path),
             patch("tapps_mcp.scoring.scorer.CodeScorer", return_value=scorer),
             patch("tapps_mcp.gates.evaluator.evaluate_gate", return_value=mock_gate),
+            patch(
+                "tapps_mcp.project.impact_analyzer.build_import_graph",
+                return_value={},
+            ),
+            patch(
+                "tapps_mcp.project.impact_analyzer.analyze_impact",
+                return_value=mock_report,
+            ),
         ):
             mock_settings.return_value.project_root = tmp_path
             mock_settings.return_value.tool_timeout = 30
@@ -276,5 +297,53 @@ class TestValidateChangedP0:
         assert "total_security_issues" in data
         assert "results" in data
         assert "summary" in data
-        # No impact_summary when include_impact defaults to False
-        assert "impact_summary" not in data
+        # include_impact defaults to True so impact_summary is present
+        assert "impact_summary" in data
+
+    @pytest.mark.asyncio
+    async def test_graph_reuse_builds_once(self, tmp_path: Path) -> None:
+        """When include_impact=True and multiple files are validated,
+        build_import_graph should be called exactly once (graph reuse).
+        """
+        from tapps_mcp.server_pipeline_tools import tapps_validate_changed
+
+        f1 = tmp_path / "a.py"
+        f2 = tmp_path / "b.py"
+        f1.write_text("x = 1\n", encoding="utf-8")
+        f2.write_text("y = 2\n", encoding="utf-8")
+
+        scorer = _mock_scorer()
+        mock_gate = MagicMock(passed=True, failures=[])
+        mock_report = _mock_impact_report(severity="low", direct=0, transitive=0, tests=0)
+
+        with (
+            patch("tapps_mcp.server_pipeline_tools.load_settings") as mock_settings,
+            patch("tapps_mcp.server._validate_file_path", side_effect=Path),
+            patch("tapps_mcp.scoring.scorer.CodeScorer", return_value=scorer),
+            patch("tapps_mcp.gates.evaluator.evaluate_gate", return_value=mock_gate),
+            patch(
+                "tapps_mcp.project.impact_analyzer.build_import_graph",
+                return_value={},
+            ) as mock_build,
+            patch(
+                "tapps_mcp.project.impact_analyzer.analyze_impact",
+                return_value=mock_report,
+            ) as mock_analyze,
+        ):
+            mock_settings.return_value.project_root = tmp_path
+            mock_settings.return_value.tool_timeout = 30
+            mock_settings.return_value.dependency_scan_enabled = False
+
+            result = await tapps_validate_changed(
+                file_paths=f"{f1},{f2}",
+                quick=True,
+                include_impact=True,
+            )
+
+        assert result["success"] is True
+        # Graph built exactly once, not once per file
+        mock_build.assert_called_once()
+        # analyze_impact called once per file, each receiving the shared graph
+        assert mock_analyze.call_count == 2
+        for call in mock_analyze.call_args_list:
+            assert call.kwargs.get("graph") == {}


### PR DESCRIPTION
Flip include_impact default from False to True in tapps_validate_changed
so callers get blast-radius info without opting in. Build the import
graph once via new public build_import_graph() and pass it to each
analyze_impact() call, eliminating O(N) redundant full-project AST
scans when validating N files.

- Add build_import_graph() public API to impact_analyzer.py
- Add graph kwarg to analyze_impact() (None → auto-build for compat)
- Update server_pipeline_tools.py to build once, pass shared graph
- Update docstring to reflect new default
- Add graph-reuse test (build_import_graph called once for multi-file)
- Add build_import_graph unit tests in test_impact_analyzer.py
- Update backward-compat test for new default behavior

https://claude.ai/code/session_018tjWdDhR4YeuEs3NYBkiHC