### PR TITLE
docs: update expert counts, scoring categories, knowledge tree, and 2026 info

### DIFF
--- a/.cursor/rules/tapps-expert-consultation.mdc
+++ b/.cursor/rules/tapps-expert-consultation.mdc
@@ -9,12 +9,13 @@ description: >-
 
 Call `tapps_consult_expert(question)` for domain guidance.
 
-## Available Expert Domains
+## Available Expert Domains (17)
 
-- security, performance, architecture, testing
-- documentation, accessibility, devops, database
-- api, frontend, backend, data-science
-- ml, cloud, mobile, embedded
+- security, performance-optimization, testing-strategies, code-quality-analysis
+- software-architecture, development-workflow, data-privacy-compliance
+- accessibility, user-experience, documentation-knowledge-management
+- ai-frameworks, agent-learning, observability-monitoring
+- api-design-integration, cloud-infrastructure, database-data-management, github
 
 ## Usage
 

--- a/.cursor/rules/tapps-python-quality.mdc
+++ b/.cursor/rules/tapps-python-quality.mdc
@@ -11,13 +11,13 @@ When Python files are referenced, enforce these quality standards:
 
 TappsMCP scores Python code across 7 categories (0-100 each):
 
-1. **Correctness** - Logic errors, type safety, edge cases
-2. **Security** - Vulnerabilities, injection risks, secrets
-3. **Maintainability** - Complexity, naming, structure
-4. **Performance** - Efficiency, resource usage, scaling
-5. **Documentation** - Docstrings, comments, clarity
-6. **Testing** - Coverage, edge cases, assertions
-7. **Style** - PEP 8, formatting, consistency
+1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
+2. **Security** - Bandit + pattern heuristics
+3. **Maintainability** - Maintainability index (radon mi / AST fallback)
+4. **Test Coverage** - Heuristic from matching test file existence
+5. **Performance** - Nested loops, large functions, deep nesting
+6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
+7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
 
 ## Actions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ TappsMCP is an MCP server that provides a comprehensive quality toolset for your
 - **Circular dependency detection** (import graph analysis, cycle detection, coupling metrics)
 - **Documentation lookup** (up-to-date library docs via Context7 with multi-provider fallback and cache)
 - **Config validation** (Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB best practices)
-- **Domain experts** (16 built-in experts with RAG-backed answers, optional vector search)
+- **Domain experts** (17 built-in experts with RAG-backed answers, optional vector search)
 - **Project context** (project type detection, tech stack, impact analysis)
 - **Session management** (persist decisions, constraints, and notes across long sessions)
 - **Quality reports** (JSON, Markdown, or HTML summaries)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ All file I/O goes through `security/path_validator.py`, which sandboxes operatio
 
 ### Expert system
 
-16 domain experts in `experts/` with 119 curated knowledge markdown files under `experts/knowledge/`. The `experts/engine.py` uses keyword-based RAG (or optional vector RAG with faiss). All retrieved content passes through `knowledge/rag_safety.py` for prompt injection filtering.
+17 domain experts in `experts/` with 135+ curated knowledge markdown files under `experts/knowledge/`. The `experts/engine.py` uses keyword-based RAG (or optional vector RAG with faiss). All retrieved content passes through `knowledge/rag_safety.py` for prompt injection filtering.
 
 ### Platform generation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Any MCP-capable client (Claude Code, Cursor, VS Code Copilot, Claude Desktop, cu
 - **Structured outputs** — Machine-parseable JSON (`structuredContent`) alongside human-readable text for 6 tools: `tapps_score_file`, `tapps_quality_gate`, `tapps_quick_check`, `tapps_security_scan`, `tapps_validate_changed`, `tapps_validate_config` (MCP 2025-11-25).
 - **Documentation lookup** — Up-to-date library docs via [Context7](https://context7.com) with multi-provider fallback (llms.txt), fuzzy matching, and local cache.
 - **Config validation** — Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB patterns against best practices.
-- **Domain experts** — 16 built-in experts (security, testing, APIs, etc.) with RAG-backed answers and confidence scores.
+- **Domain experts** — 17 built-in experts (security, testing, APIs, GitHub, etc.) with RAG-backed answers and confidence scores.
 - **Project context** — Detect project type, tech stack, and structure for context-aware analysis.
 - **Session notes** — Persist key decisions and constraints across long AI sessions.
 - **Impact analysis** — Understand file dependencies before refactoring or changing APIs.
@@ -344,7 +344,7 @@ Quick index:
 | **tapps_validate_config** | Validate Dockerfile, docker-compose, or infra configs. |
 | **tapps_consult_expert** | Ask a domain expert and get RAG-backed answer with confidence. |
 | **tapps_research** | Combined expert + docs lookup in one call (auto-supplements with Context7). |
-| **tapps_list_experts** | List the 16 built-in expert domains and their status. |
+| **tapps_list_experts** | List the 17 built-in expert domains and their status. |
 | **tapps_checklist** | See which tools were called this session and what is still missing. |
 | **tapps_project_profile** | Detect project type, tech stack, and structure for context-aware analysis. |
 | **tapps_session_notes** | Save and retrieve key decisions and constraints across the session. |
@@ -437,7 +437,7 @@ Quick index:
 
 ### tapps_consult_expert
 
-**What it does:** Sends a natural-language question to a domain expert. The server has 16 built-in domains (e.g. security, testing, API design, database, observability). You can leave **domain** empty for auto-routing from the question, or pass a domain id (e.g. `"security"`, `"testing-strategies"`). The expert uses RAG over curated knowledge files, returns an answer, a confidence score, contributing factors, and source chunks. Answers are filtered for PII/secrets before return.
+**What it does:** Sends a natural-language question to a domain expert. The server has 17 built-in domains (e.g. security, testing, API design, database, observability, GitHub). You can leave **domain** empty for auto-routing from the question, or pass a domain id (e.g. `"security"`, `"testing-strategies"`). The expert uses RAG over curated knowledge files, returns an answer, a confidence score, contributing factors, and source chunks. Answers are filtered for PII/secrets before return.
 
 **Why use it:** When the AI (or user) is unsure about patterns, trade-offs, or best practices in a specific area, a single call returns focused, sourced guidance instead of generic advice. Use for security decisions, test strategy, API design, DB schema, or observability so the response is grounded in the expert knowledge base and the confidence score signals how much to rely on it.
 
@@ -453,7 +453,7 @@ Quick index:
 
 ### tapps_list_experts
 
-**What it does:** Returns the list of all 16 built-in expert domains. For each expert it provides an id, display name, short description, and knowledge-base status (e.g. how many knowledge files are loaded). No parameters required.
+**What it does:** Returns the list of all 17 built-in expert domains. For each expert it provides an id, display name, short description, and knowledge-base status (e.g. how many knowledge files are loaded). No parameters required.
 
 **Why use it:** Lets the AI (or host) discover which domains exist before calling `tapps_consult_expert`. Use at session start or when the user asks "what can the experts help with?" so the right domain can be chosen and the right expert consulted.
 
@@ -701,7 +701,7 @@ src/tapps_mcp/
 │                                       #   multi-provider support (providers/)
 ├── validators/                         # Dockerfile, docker-compose, WebSocket, MQTT, InfluxDB
 ├── experts/                            # Domain detector, engine, RAG, registry, confidence,
-│                                       #   vector RAG, knowledge management, 119 knowledge files
+│                                       #   vector RAG, knowledge management, 135+ knowledge files
 ├── project/                            # Project profiling, session notes, impact analysis, reports,
 │                                       #   import graph, cycle detection, coupling metrics
 ├── adaptive/                           # Adaptive scoring, expert voting, weight distribution

--- a/docs/TAPPS_MCP_SETUP_AND_USE.md
+++ b/docs/TAPPS_MCP_SETUP_AND_USE.md
@@ -198,7 +198,7 @@ Restart Claude Desktop after changing the config.
 | **tapps_validate_changed** | Score + gate + security scan all changed files (auto-detects via git diff). |
 | **tapps_lookup_docs** | Fetch current library docs via Context7. Use before writing code that calls library APIs. |
 | **tapps_validate_config** | Validate Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB configs against best practices. |
-| **tapps_consult_expert** | Ask a domain expert (16 domains) and get RAG-backed guidance with confidence scores. |
+| **tapps_consult_expert** | Ask a domain expert (17 domains) and get RAG-backed guidance with confidence scores. |
 | **tapps_research** | Combined expert + docs lookup in one call (auto-supplements with Context7). |
 | **tapps_list_experts** | List available expert domains and their knowledge base status. |
 | **tapps_project_profile** | Detect project type, tech stack, and structure. Call at session start for context-aware analysis. |

--- a/plugin/cursor/CHANGELOG.md
+++ b/plugin/cursor/CHANGELOG.md
@@ -10,6 +10,6 @@
 - Security scanning via Bandit + secret detection
 - Configurable quality gates (development, staging, production presets)
 - Context7 documentation lookup with SWR cache
-- 16 domain expert consultants via RAG engine
+- 17 domain expert consultants via RAG engine
 - 3 skills, 3 agents, 3 cursor rules, and Cursor hooks bundle
 - BugBot quality standards for automated PR review

--- a/plugin/cursor/rules/tapps-expert-consultation.mdc
+++ b/plugin/cursor/rules/tapps-expert-consultation.mdc
@@ -9,12 +9,13 @@ description: >-
 
 Call `tapps_consult_expert(question)` for domain guidance.
 
-## Available Expert Domains
+## Available Expert Domains (17)
 
-- security, performance, architecture, testing
-- documentation, accessibility, devops, database
-- api, frontend, backend, data-science
-- ml, cloud, mobile, embedded
+- security, performance-optimization, testing-strategies, code-quality-analysis
+- software-architecture, development-workflow, data-privacy-compliance
+- accessibility, user-experience, documentation-knowledge-management
+- ai-frameworks, agent-learning, observability-monitoring
+- api-design-integration, cloud-infrastructure, database-data-management, github
 
 ## Usage
 

--- a/plugin/cursor/rules/tapps-python-quality.mdc
+++ b/plugin/cursor/rules/tapps-python-quality.mdc
@@ -11,13 +11,13 @@ When Python files are referenced, enforce these quality standards:
 
 TappsMCP scores Python code across 7 categories (0-100 each):
 
-1. **Correctness** - Logic errors, type safety, edge cases
-2. **Security** - Vulnerabilities, injection risks, secrets
-3. **Maintainability** - Complexity, naming, structure
-4. **Performance** - Efficiency, resource usage, scaling
-5. **Documentation** - Docstrings, comments, clarity
-6. **Testing** - Coverage, edge cases, assertions
-7. **Style** - PEP 8, formatting, consistency
+1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
+2. **Security** - Bandit + pattern heuristics
+3. **Maintainability** - Maintainability index (radon mi / AST fallback)
+4. **Test Coverage** - Heuristic from matching test file existence
+5. **Performance** - Nested loops, large functions, deep nesting
+6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
+7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
 
 ## Actions
 

--- a/src/tapps_mcp/experts/knowledge/README.md
+++ b/src/tapps_mcp/experts/knowledge/README.md
@@ -1,6 +1,6 @@
 # Built-in Expert Knowledge Bases
 
-This directory contains knowledge bases for built-in framework experts. These knowledge bases provide technical domain expertise that ships with the TappsCodingAgents framework.
+This directory contains knowledge bases for built-in framework experts. These knowledge bases provide technical domain expertise that ships with TappsMCP.
 
 **Last reviewed**: 2026-02. Keep content current with latest practices; remove or replace deprecated material.
 
@@ -10,12 +10,13 @@ Each expert has its own subdirectory containing markdown knowledge files:
 
 ```
 knowledge/
-├── security/                      # Security Expert knowledge base
+├── security/                      # Security Expert (5 files)
+│   ├── modern-security-patterns.md
 │   ├── owasp-top10.md
 │   ├── secure-coding-practices.md
 │   ├── threat-modeling.md
 │   └── vulnerability-patterns.md
-├── performance/                   # Performance Expert (Phase 2)
+├── performance/                   # Performance Expert (8 files)
 │   ├── optimization-patterns.md
 │   ├── caching.md
 │   ├── scalability.md
@@ -24,7 +25,7 @@ knowledge/
 │   ├── resource-management.md
 │   ├── profiling.md
 │   └── anti-patterns.md
-├── testing/                       # Testing Expert (Phase 2)
+├── testing/                       # Testing Expert (11 files)
 │   ├── best-practices.md
 │   ├── test-strategies.md
 │   ├── test-design-patterns.md
@@ -32,8 +33,11 @@ knowledge/
 │   ├── mocking.md
 │   ├── test-data.md
 │   ├── coverage-analysis.md
-│   └── test-maintenance.md
-├── data-privacy-compliance/       # Data Privacy Expert (Phase 3)
+│   ├── test-maintenance.md
+│   ├── mcp-testing-patterns.md
+│   ├── modern-testing-patterns.md
+│   └── test-configuration-and-urls.md
+├── data-privacy-compliance/       # Data Privacy Expert (10 files)
 │   ├── gdpr.md
 │   ├── ccpa.md
 │   ├── hipaa.md
@@ -44,7 +48,7 @@ knowledge/
 │   ├── data-subject-rights.md
 │   ├── anonymization.md
 │   └── encryption-privacy.md
-├── accessibility/                 # Accessibility Expert (Phase 4)
+├── accessibility/                 # Accessibility Expert (9 files)
 │   ├── wcag-2.1.md
 │   ├── wcag-2.2.md
 │   ├── semantic-html.md
@@ -54,7 +58,7 @@ knowledge/
 │   ├── color-contrast.md
 │   ├── accessible-forms.md
 │   └── testing-accessibility.md
-├── user-experience/               # UX Expert (Phase 4)
+├── user-experience/               # UX Expert (8 files)
 │   ├── ux-principles.md
 │   ├── user-research.md
 │   ├── user-journeys.md
@@ -63,7 +67,7 @@ knowledge/
 │   ├── prototyping.md
 │   ├── usability-heuristics.md
 │   └── usability-testing.md
-├── observability-monitoring/      # Observability Expert (Phase 5)
+├── observability-monitoring/      # Observability Expert (8 files)
 │   ├── distributed-tracing.md
 │   ├── metrics-and-monitoring.md
 │   ├── logging-strategies.md
@@ -72,7 +76,7 @@ knowledge/
 │   ├── alerting-patterns.md
 │   ├── observability-best-practices.md
 │   └── open-telemetry.md
-├── api-design-integration/        # API Design Expert (Phase 5)
+├── api-design-integration/        # API Design Expert (14 files)
 │   ├── restful-api-design.md
 │   ├── graphql-patterns.md
 │   ├── grpc-best-practices.md
@@ -87,18 +91,19 @@ knowledge/
 │   ├── mqtt-patterns.md
 │   ├── async-protocol-patterns.md
 │   └── external-api-integration.md
-├── cloud-infrastructure/          # Cloud Infrastructure Expert (Phase 5)
+├── cloud-infrastructure/          # Cloud Infrastructure Expert (11 files)
 │   ├── cloud-native-patterns.md
 │   ├── containerization.md
 │   ├── container-health-checks.md
 │   ├── kubernetes-patterns.md
+│   ├── kubernetes-security-patterns.md
 │   ├── infrastructure-as-code.md
 │   ├── serverless-architecture.md
 │   ├── multi-cloud-strategies.md
 │   ├── cost-optimization.md
 │   ├── disaster-recovery.md
 │   └── dockerfile-patterns.md
-├── database-data-management/      # Database Expert (Phase 5)
+├── database-data-management/      # Database Expert (12 files)
 │   ├── database-design.md
 │   ├── sql-optimization.md
 │   ├── nosql-patterns.md
@@ -111,34 +116,52 @@ knowledge/
 │   ├── influxdb-connection-patterns.md
 │   ├── flux-query-optimization.md
 │   └── time-series-modeling.md
-├── software-architecture/         # Software Architecture Expert
+├── software-architecture/         # Software Architecture Expert (4 files)
+│   ├── mcp-server-architecture.md
 │   ├── microservices-patterns.md
 │   ├── service-communication.md
 │   └── docker-compose-patterns.md
-├── code-quality-analysis/         # Code Quality & Analysis Expert
+├── code-quality-analysis/         # Code Quality & Analysis Expert (5 files)
 │   ├── static-analysis-patterns.md
 │   ├── code-metrics.md
 │   ├── complexity-analysis.md
 │   ├── technical-debt-patterns.md
 │   └── quality-gates.md
-├── development-workflow/          # Development Workflow Expert (DevOps)
+├── development-workflow/          # Development Workflow Expert (6 files)
 │   ├── ci-cd-patterns.md
 │   ├── git-workflows.md
 │   ├── build-strategies.md
 │   ├── deployment-patterns.md
-│   └── automation-best-practices.md
-├── documentation-knowledge-management/ # Documentation & Knowledge Management Expert
+│   ├── automation-best-practices.md
+│   └── github-actions-advanced.md
+├── documentation-knowledge-management/ # Documentation & Knowledge Management Expert (4 files)
 │   ├── documentation-standards.md
 │   ├── api-documentation-patterns.md
 │   ├── knowledge-management.md
 │   └── technical-writing-guide.md
-├── agent-learning/                # Agent Learning Best Practices
+├── github/                        # GitHub Platform Expert (10 files)
+│   ├── github-actions-ci-patterns.md
+│   ├── github-actions-best-practices.md
+│   ├── github-agentic-workflows.md
+│   ├── github-copilot-agent-setup.md
+│   ├── github-issues-and-forms.md
+│   ├── github-mcp-integration.md
+│   ├── github-projects-api.md
+│   ├── github-pull-requests.md
+│   ├── github-rulesets-and-governance.md
+│   └── github-security-features.md
+├── agent-learning/                # Agent Learning Best Practices (4 files)
+│   ├── adaptive-learning-patterns.md
 │   ├── best-practices.md
 │   ├── pattern-extraction.md
 │   └── prompt-optimization.md
-└── ai-frameworks/                 # AI Frameworks Expert
+└── ai-frameworks/                 # AI Frameworks Expert (6 files)
+    ├── agent-orchestration-patterns.md
+    ├── llm-integration-patterns.md
+    ├── mcp-patterns.md
     ├── model-optimization.md
-    └── openvino-patterns.md
+    ├── openvino-patterns.md
+    └── rag-patterns.md
 ```
 
 ## Knowledge Base Format

--- a/src/tapps_mcp/experts/knowledge/ai-frameworks/mcp-patterns.md
+++ b/src/tapps_mcp/experts/knowledge/ai-frameworks/mcp-patterns.md
@@ -139,6 +139,39 @@ if __name__ == "__main__":
 }
 ```
 
+## MCP Specification History
+
+| Version | Date | Key Changes |
+|---------|------|-------------|
+| 2024-11-05 | Nov 2024 | Initial release by Anthropic |
+| 2025-06-18 | Jun 2025 | Structured tool outputs, OAuth, elicitation, `MCP-Protocol-Version` header |
+| 2025-11-25 | Nov 2025 | Tasks primitive (experimental), OpenID Connect, icons metadata, extension framework |
+
+As of December 2025, MCP governance was donated to the **Agentic AI Foundation (AAIF)** under the Linux Foundation.
+
+## MCP Clients (2026)
+
+Major clients supporting MCP: Claude Code, Claude Desktop, Cursor, Windsurf (Codeium), VS Code (GitHub Copilot agent mode), Cline, Zed, Replit, Continue.dev, Gemini CLI, and 500+ others.
+
+## Tool Annotations (2025-06-18+)
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("MyTools")
+
+@mcp.tool(annotations={
+    "title": "Score File",
+    "readOnlyHint": True,
+    "openWorldHint": False,
+})
+async def score_file(file_path: str) -> str:
+    """Score a Python file for quality."""
+    ...
+```
+
+Annotations help clients understand tool behaviour (read-only vs side-effect, open-world vs sandboxed).
+
 ## Best Practices
 
 ### Tool Design
@@ -148,6 +181,7 @@ if __name__ == "__main__":
 3. **Return strings**: Tools should return human-readable string output
 4. **Idempotent reads**: Read operations should be safe to repeat
 5. **Explicit errors**: Return error messages as strings, don't raise exceptions
+6. **Annotations**: Use `readOnlyHint`, `idempotentHint`, `openWorldHint` to guide client behaviour
 
 ### Security
 
@@ -156,6 +190,7 @@ if __name__ == "__main__":
 3. **No secrets in output**: Never return API keys or credentials
 4. **Least privilege**: Only expose necessary filesystem access
 5. **Rate limiting**: Protect expensive operations from excessive calls
+6. **OAuth for remote**: Use MCP's built-in OAuth for HTTP-transported servers
 
 ### Performance
 
@@ -183,3 +218,4 @@ if __name__ == "__main__":
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
 - [FastMCP Documentation](https://gofastmcp.com/)
+- [MCP Spec 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25)

--- a/src/tapps_mcp/experts/knowledge/code-quality-analysis/static-analysis-patterns.md
+++ b/src/tapps_mcp/experts/knowledge/code-quality-analysis/static-analysis-patterns.md
@@ -37,10 +37,11 @@ Static analysis tools examine code without executing it, identifying potential b
 ## Popular Static Analysis Tools
 
 ### Python
-- **Ruff**: Linting and formatting (recommended—single tool, 10–100x faster than alternatives)
-- **mypy**: Static type checking
-- **bandit**: Security vulnerability scanner
-- **radon**: Complexity and maintainability metrics
+- **Ruff** (v0.15+): Linting and formatting (recommended—single tool, 10–100x faster than alternatives)
+- **mypy** (v1.19+): Static type checking
+- **ty** (beta, by Astral): Extremely fast Rust-based type checker and language server
+- **bandit** (v1.9+): Security vulnerability scanner (includes AI/ML checks B614, B615)
+- **radon** (v6.0+): Complexity and maintainability metrics (supports .ipynb)
 
 ### JavaScript/TypeScript
 - **ESLint**: JavaScript/TypeScript linter
@@ -60,7 +61,7 @@ Static analysis tools examine code without executing it, identifying potential b
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
+    rev: v0.15.0
     hooks:
       - id: ruff
         args: [--fix]

--- a/src/tapps_mcp/experts/knowledge/github/github-copilot-agent-setup.md
+++ b/src/tapps_mcp/experts/knowledge/github/github-copilot-agent-setup.md
@@ -81,6 +81,24 @@ Register MCP servers in repository Copilot settings:
 The coding agent accesses MCP tools during autonomous sessions.
 Secrets for MCP servers come from the "copilot" environment.
 
+## GitHub Copilot CLI (GA — February 2026)
+
+GitHub Copilot CLI reached general availability in February 2026:
+
+- Ships with GitHub's MCP server built in, supports custom MCP servers
+- **Agent Skills**: Markdown-based skill files that load automatically when relevant
+- **Custom agents**: `.agent.md` files specifying tools, MCP servers, and instructions
+- **Models available**: Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.3-Codex, Gemini 3 Pro
+- **Background delegation**: Prefix prompt with `&` to delegate to cloud coding agent
+
+## MCP in Copilot Agent Mode (2026)
+
+GitHub Copilot agent mode in VS Code is now GA with full MCP support:
+
+- MCP servers extend agent mode with external tools, APIs, and data sources
+- **GitHub MCP Server**: Open source local server for GitHub issues, PRs, search
+- Agent mode plans, executes, self-corrects, and runs terminal commands autonomously
+
 ## AGENTS.md Best Practices
 
 From GitHub's analysis of 2,500+ repositories:

--- a/src/tapps_mcp/experts/registry.py
+++ b/src/tapps_mcp/experts/registry.py
@@ -17,7 +17,7 @@ from tapps_mcp.experts.models import ExpertConfig
 class ExpertRegistry:
     """Registry of built-in domain experts.
 
-    All 16 technical-domain experts are defined here.  The registry is
+    All 17 technical-domain experts are defined here.  The registry is
     read-only at runtime — experts cannot be added or removed.
     """
 

--- a/src/tapps_mcp/pipeline/platform_generators.py
+++ b/src/tapps_mcp/pipeline/platform_generators.py
@@ -1158,13 +1158,13 @@ When Python files are referenced, enforce these quality standards:
 
 TappsMCP scores Python code across 7 categories (0-100 each):
 
-1. **Correctness** - Logic errors, type safety, edge cases
-2. **Security** - Vulnerabilities, injection risks, secrets
-3. **Maintainability** - Complexity, naming, structure
-4. **Performance** - Efficiency, resource usage, scaling
-5. **Documentation** - Docstrings, comments, clarity
-6. **Testing** - Coverage, edge cases, assertions
-7. **Style** - PEP 8, formatting, consistency
+1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
+2. **Security** - Bandit + pattern heuristics
+3. **Maintainability** - Maintainability index (radon mi / AST fallback)
+4. **Test Coverage** - Heuristic from matching test file existence
+5. **Performance** - Nested loops, large functions, deep nesting
+6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
+7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
 
 ## Actions
 
@@ -1185,12 +1185,13 @@ description: >-
 
 Call `tapps_consult_expert(question)` for domain guidance.
 
-## Available Expert Domains
+## Available Expert Domains (17)
 
-- security, performance, architecture, testing
-- documentation, accessibility, devops, database
-- api, frontend, backend, data-science
-- ml, cloud, mobile, embedded
+- security, performance-optimization, testing-strategies, code-quality-analysis
+- software-architecture, development-workflow, data-privacy-compliance
+- accessibility, user-experience, documentation-knowledge-management
+- ai-frameworks, agent-learning, observability-monitoring
+- api-design-integration, cloud-infrastructure, database-data-management, github
 
 ## Usage
 

--- a/src/tapps_mcp/prompts/agents_template.md
+++ b/src/tapps_mcp/prompts/agents_template.md
@@ -16,7 +16,7 @@ TappsMCP is an MCP server that provides a comprehensive quality toolset for your
 - **Circular dependency detection** (import graph analysis, cycle detection, coupling metrics)
 - **Documentation lookup** (up-to-date library docs via Context7 with multi-provider fallback and cache)
 - **Config validation** (Dockerfile, docker-compose, WebSocket/MQTT/InfluxDB best practices)
-- **Domain experts** (16 built-in experts with RAG-backed answers, optional vector search)
+- **Domain experts** (17 built-in experts with RAG-backed answers, optional vector search)
 - **Project context** (project type detection, tech stack, impact analysis)
 - **Session management** (persist decisions, constraints, and notes across long sessions)
 - **Quality reports** (JSON, Markdown, or HTML summaries)

--- a/src/tapps_mcp/prompts/research.md
+++ b/src/tapps_mcp/prompts/research.md
@@ -7,7 +7,7 @@ Gather domain knowledge and library documentation before writing code. This prev
 ## Allowed Tools
 
 - `tapps_lookup_docs` - Look up current library documentation via Context7. Use before writing code that depends on external libraries.
-- `tapps_consult_expert` - Ask domain-specific questions (security, testing, APIs, databases, etc.). Routes to one of 16 built-in experts.
+- `tapps_consult_expert` - Ask domain-specific questions (security, testing, APIs, databases, etc.). Routes to one of 17 built-in experts.
 - `tapps_list_experts` - See which expert domains are available before consulting.
 
 ## Constraints


### PR DESCRIPTION
- Fix expert count from 16 to 17 across README.md, AGENTS.md, CLAUDE.md,
  registry.py, prompts, setup docs, and plugin CHANGELOG
- Fix knowledge file count from 119 to 135+ in CLAUDE.md and README.md
- Fix incorrect scoring categories in Cursor rules and platform_generators.py
  (was: Correctness/Documentation/Testing/Style; now: Complexity/Test Coverage/
  Structure/DevEx matching actual scorer.py categories)
- Fix incorrect expert domain list in Cursor rules and platform_generators.py
  (was fabricated domains like frontend/mobile/embedded; now actual 17 domains)
- Update knowledge README.md file tree to include all 135+ files across 17
  domains (was missing github/, mcp-testing-patterns, modern-security-patterns,
  mcp-server-architecture, adaptive-learning-patterns, and many more)
- Fix TappsCodingAgents → TappsMCP naming in knowledge README
- Update MCP patterns knowledge with 2026 spec history and tool annotations
- Update GitHub Copilot knowledge with Copilot CLI GA (Feb 2026) and MCP in
  agent mode
- Update static analysis knowledge with 2026 tool versions (ruff 0.15+,
  mypy 1.19+, bandit 1.9+, radon 6.0+, ty beta)
- Update plugin/cursor/ rules bundle to match corrected templates

https://claude.ai/code/session_01DKjppM1pmff8an2QGLQum7