### PR TITLE
docs: comprehensive review and update of all .md files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,25 +10,35 @@ following tools to maintain code quality throughout development.
   each work session. Call this first.
 - `tapps_quick_check` — Run a quick quality check on a single file after
   editing. Returns score and top issues.
+- `tapps_score_file` — Get a detailed 7-category quality score for any file.
 - `tapps_quality_gate` — Run a pass/fail quality gate against a configurable
-  preset (development, staging, or production).
+  preset (standard, strict, or framework).
+- `tapps_security_scan` — Run Bandit + secret detection on a Python file.
 - `tapps_validate_changed` — Validate all changed files against the quality
   gate. Call this before declaring work complete.
+- `tapps_lookup_docs` — Fetch current library documentation to avoid
+  hallucinated APIs.
 - `tapps_consult_expert` — Consult a domain expert (security, performance,
   architecture, testing, and more) for guidance.
-- `tapps_score_file` — Get a detailed 7-category quality score for any file.
+- `tapps_research` — Combined expert + docs lookup in one call.
+- `tapps_impact_analysis` — Analyze file dependencies before refactoring.
+- `tapps_dead_code` — Find unused functions, classes, imports, and variables.
+- `tapps_dependency_scan` — Check dependencies for known vulnerabilities.
+- `tapps_dependency_graph` — Build import graph and detect circular imports.
+- `tapps_checklist` — Verify all required quality steps were completed.
 
 ## Workflow
 
 1. Start a session: call `tapps_session_start`
-2. After editing Python files: call `tapps_quick_check` on changed files
-3. Before creating a PR or declaring work complete: call
-   `tapps_validate_changed`
-4. For domain-specific guidance: call `tapps_consult_expert` with the
+2. Before using a library API: call `tapps_lookup_docs`
+3. After editing Python files: call `tapps_quick_check` on changed files
+4. Before creating a PR or declaring work complete: call
+   `tapps_validate_changed`, then `tapps_checklist`
+5. For domain-specific guidance: call `tapps_consult_expert` with the
    relevant domain
 
 ## Quality Scoring Categories
 
 TappsMCP scores code across 7 categories (0-100 each):
-correctness, security, maintainability, performance, documentation,
-testing, and style.
+complexity, security, maintainability, test_coverage, performance,
+structure, and devex (developer experience).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ TappsMCP is an **MCP server** providing deterministic code quality tools to LLMs
 # Install dependencies
 uv sync
 
-# Run all tests (2282+ tests)
+# Run all tests (2850+ tests)
 uv run pytest tests/ -v
 
 # Run a single test file
@@ -87,7 +87,7 @@ All file I/O goes through `security/path_validator.py`, which sandboxes operatio
 
 ### Expert system
 
-17 domain experts in `experts/` with 135+ curated knowledge markdown files under `experts/knowledge/`. The `experts/engine.py` uses keyword-based RAG (or optional vector RAG with faiss). All retrieved content passes through `knowledge/rag_safety.py` for prompt injection filtering.
+17 domain experts in `experts/` with 139 curated knowledge markdown files under `experts/knowledge/`. The `experts/engine.py` uses keyword-based RAG (or optional vector RAG with faiss). All retrieved content passes through `knowledge/rag_safety.py` for prompt injection filtering.
 
 ### Platform generation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ uv sync
 ### Running Tests
 
 ```bash
-# All tests (1995+ tests)
+# All tests (2850+ tests)
 uv run pytest tests/ -v
 
 # With coverage (80% minimum required)

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ src/tapps_mcp/
 │                                       #   multi-provider support (providers/)
 ├── validators/                         # Dockerfile, docker-compose, WebSocket, MQTT, InfluxDB
 ├── experts/                            # Domain detector, engine, RAG, registry, confidence,
-│                                       #   vector RAG, knowledge management, 135+ knowledge files
+│                                       #   vector RAG, knowledge management, 139 knowledge files
 ├── project/                            # Project profiling, session notes, impact analysis, reports,
 │                                       #   import graph, cycle detection, coupling metrics
 ├── adaptive/                           # Adaptive scoring, expert voting, weight distribution

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,10 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| 0.1.x   | :white_check_mark: |
+| 0.4.x   | :white_check_mark: |
+| 0.3.x   | :white_check_mark: |
+| 0.2.x   | :x:                |
+| 0.1.x   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/addenda.md
+++ b/addenda.md
@@ -29,7 +29,7 @@ TappsMCP is designed as a **shared quality infrastructure** that any MCP-capable
 ### Session workflow
 
 ```
-1. tapps_session_start         → Initialize context (server info + project profile)
+1. tapps_session_start         → Initialize session (server info only; call tapps_project_profile for project context)
 2. tapps_lookup_docs           → Before using any external library API
 3. tapps_quick_check           → After each file edit (fast feedback)
 4. tapps_validate_changed      → Before declaring work complete (all changed files)
@@ -149,8 +149,10 @@ TappsMCP works without these, but produces best results with them installed:
 | **mypy** | Type checking | `pip install mypy` | No type error detection |
 | **bandit** | Security scanning | `pip install bandit` | Heuristic-only security scoring |
 | **radon** | Complexity metrics | `pip install radon` | AST-based complexity fallback |
+| **vulture** | Dead code detection | `pip install vulture` | No dead code analysis |
+| **pip-audit** | Dependency vulnerability scanning | `pip install pip-audit` | No CVE scanning |
 
-Install all at once: `pip install ruff mypy bandit radon`
+Install all at once: `pip install ruff mypy bandit radon vulture pip-audit`
 
 For semantic expert search (optional): `pip install tapps-mcp[rag]`
 

--- a/docs/UPGRADE_FOR_CONSUMERS.md
+++ b/docs/UPGRADE_FOR_CONSUMERS.md
@@ -68,7 +68,7 @@ tapps-mcp init --check            # verify MCP config is correct
 
 ---
 
-## 5. Re-run init for caches and TECH_STACK
+## 6. Re-run init for caches and TECH_STACK
 
 A normal `tapps_init` run (without overwrite flags) will:
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -39,13 +39,14 @@ jobs:
         env:
           TAPPS_MCP_PROJECT_ROOT: ${{ github.workspace }}
         run: |
-          tapps-mcp validate-changed --preset staging
+          tapps-mcp validate-changed --quick
 ```
 
 ### Customizing the Workflow
 
-- Change `--preset staging` to `development` (lenient) or `production` (strict)
-- Add `--changed-files` to explicitly list files instead of auto-detection
+- Change `--quick` to `--full` for comprehensive validation (ruff + mypy + bandit + radon + vulture)
+- Set `TAPPS_MCP_QUALITY_PRESET` env var to `strict` or `framework` for higher thresholds
+- Use `--project-root /path` to specify a different project root
 - Set `TAPPS_MCP_CONTEXT7_API_KEY` for documentation lookup in CI
 
 ## Claude Code Headless Mode
@@ -56,7 +57,7 @@ Claude Code can run non-interactively in CI using `--headless`:
 # Run quality validation headlessly
 claude --headless \
   --allowedTools "mcp__tapps-mcp__tapps_validate_changed" \
-  "Run tapps_validate_changed with preset=staging"
+  "Run tapps_validate_changed on all changed files"
 ```
 
 ### Team Onboarding with --init-only
@@ -81,9 +82,13 @@ For CI systems that don't use Claude Code, invoke TappsMCP directly:
 # Install
 pip install tapps-mcp
 
-# Validate changed files
+# Validate changed files (quick mode, ruff-only)
 TAPPS_MCP_PROJECT_ROOT=/workspace \
-  tapps-mcp validate-changed --preset staging
+  tapps-mcp validate-changed --quick
+
+# Or full validation (ruff + mypy + bandit + radon + vulture)
+TAPPS_MCP_PROJECT_ROOT=/workspace \
+  tapps-mcp validate-changed --full
 ```
 
 ## VS Code / Headless Settings

--- a/npm/README.md
+++ b/npm/README.md
@@ -41,7 +41,7 @@ This is a thin wrapper that:
 
 ## Optional dependencies
 
-For best results, install these Python tools: `pip install ruff mypy bandit radon`
+For best results, install these Python tools: `pip install ruff mypy bandit radon vulture pip-audit`
 
 For semantic expert search: `pip install tapps-mcp[rag]`
 


### PR DESCRIPTION
- SECURITY.md: update supported versions table (0.4.x/0.3.x supported, 0.2.x/0.1.x EOL)
- CLAUDE.md: update test count to 2850+, knowledge files count to 139
- CONTRIBUTING.md: update test count to 2850+
- README.md: update knowledge files count from 135+ to 139
- copilot-instructions.md: fix scoring category names (complexity, security, maintainability,
  test_coverage, performance, structure, devex), expand tool list from 6 to 14, fix preset
  names, add tapps_lookup_docs and tapps_checklist to workflow
- ci-integration.md: fix invalid --preset CLI parameter to correct --quick/--full flags,
  update all code examples to match actual CLI interface
- addenda.md: fix tapps_session_start description (server info only since v0.4.3),
  add vulture and pip-audit to external tools table
- UPGRADE_FOR_CONSUMERS.md: fix duplicate step number (two "5." sections)
- npm/README.md: add vulture and pip-audit to optional dependencies

https://claude.ai/code/session_01F9GdRg2n5gktxKkFKyPpFt