### PR TITLE
[TAP-515] catch BrainBridgeUnavailable in memory handlers

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import structlog
 
+from tapps_core.brain_bridge import BrainBridgeUnavailable
 from tapps_mcp.server_helpers import (
     _agent_teams_env_enabled,
     _get_brain_bridge,
@@ -117,6 +118,42 @@ def _bridge_unavailable_response(action: str) -> dict[str, Any]:
             "Set TAPPS_BRAIN_DATABASE_URL in your environment or .tapps-mcp.yaml",
         ],
     }
+
+
+def _bridge_call_failed_response(
+    action: str,
+    exc: BaseException,
+    *,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Structured response when a BrainBridge call raises BrainBridgeUnavailable (TAP-515).
+
+    Distinct from :func:`_bridge_unavailable_response` which covers the "bridge is
+    unconfigured" case. This covers the "bridge is configured but unreachable"
+    case: circuit breaker open, or all retries exhausted against tapps-brain.
+    """
+    payload: dict[str, Any] = {
+        "action": action,
+        "success": False,
+        "ok": False,
+        "degraded": True,
+        "retryable": True,
+        "reason": "brain_bridge_call_failed",
+        "error": str(exc) or type(exc).__name__,
+        "remediation": (
+            "tapps-brain is unreachable (circuit open or retries exhausted). "
+            "Verify TAPPS_BRAIN_DATABASE_URL is reachable, then retry after ~30s "
+            "for the circuit breaker to reset."
+        ),
+        "next_steps": [
+            "Check TAPPS_BRAIN_DATABASE_URL is reachable from this host",
+            "Retry after 30s to allow the circuit breaker to reset",
+        ],
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
 
 _BULK_SAVE_MAX_ENTRIES = 50
 
@@ -887,7 +924,14 @@ async def _handle_gc(store: MemoryStore, p: _Params) -> dict[str, Any]:
     if bridge is None:
         return _bridge_unavailable_response("gc")
 
-    result = await bridge.gc(dry_run=p.dry_run)
+    try:
+        result = await bridge.gc(dry_run=p.dry_run)
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "gc",
+            exc,
+            extra={"store_metadata": _store_metadata(store)},
+        )
     return {
         "action": "gc",
         "success": True,
@@ -913,10 +957,17 @@ async def _handle_contradictions(store: MemoryStore, _p: _Params) -> dict[str, A
     profile = detect_project_profile(settings.project_root)
     profile.project_type = profile.project_type or ""
 
-    result = await bridge.detect_conflicts(
-        profile=profile,
-        project_root=settings.project_root,
-    )
+    try:
+        result = await bridge.detect_conflicts(
+            profile=profile,
+            project_root=settings.project_root,
+        )
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "contradictions",
+            exc,
+            extra={"store_metadata": _store_metadata(store)},
+        )
 
     return {
         "action": "contradictions",
@@ -1142,7 +1193,14 @@ async def _handle_consolidate(store: MemoryStore, p: _Params) -> dict[str, Any]:
                 "store_metadata": _store_metadata(store),
             }
 
-        scan = await bridge.consolidate(dry_run=False)
+        try:
+            scan = await bridge.consolidate(dry_run=False)
+        except BrainBridgeUnavailable as exc:
+            return _bridge_call_failed_response(
+                "consolidate",
+                exc,
+                extra={"store_metadata": _store_metadata(store)},
+            )
         groups_found = int(scan.get("groups_found", 0))
         consolidated_flag = groups_found > 0
         skipped_reason = str(scan.get("skipped_reason", "") or "")
@@ -1669,7 +1727,14 @@ async def _handle_maintain(store: MemoryStore, _p: _Params) -> dict[str, Any]:
     if bridge is None:
         return _bridge_unavailable_response("maintain")
 
-    result = await bridge.maintain()
+    try:
+        result = await bridge.maintain()
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "maintain",
+            exc,
+            extra={"store_metadata": _store_metadata(store)},
+        )
     return {
         "action": "maintain",
         "success": True,
@@ -1694,7 +1759,14 @@ async def _handle_health(store: MemoryStore, _p: _Params) -> dict[str, Any]:
             "configured": False,
         }
 
-    health = await bridge.health()
+    try:
+        health = await bridge.health()
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "health",
+            exc,
+            extra={"status": "degraded", "configured": True},
+        )
 
     integrity_tampered = int(health.get("integrity_tampered", 0))
     return {
@@ -1771,7 +1843,14 @@ async def _handle_verify_integrity(store: MemoryStore, _p: _Params) -> dict[str,
     if bridge is None:
         return _bridge_unavailable_response("verify_integrity")
 
-    result = await bridge.verify_integrity()
+    try:
+        result = await bridge.verify_integrity()
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "verify_integrity",
+            exc,
+            extra={"store_metadata": _store_metadata(store)},
+        )
     return {
         "action": "verify_integrity",
         "success": True,
@@ -1986,12 +2065,19 @@ async def _handle_hive_status(store: MemoryStore, _p: _Params) -> dict[str, Any]
     agent_id = os.environ.get("CLAUDE_AGENT_ID", f"agent-{os.getpid()}")
     agent_name = os.environ.get("CLAUDE_AGENT_NAME", "unnamed")
 
-    status = await bridge.hive_status(
-        agent_id=agent_id,
-        agent_name=agent_name,
-        agent_profile=settings.memory.profile or "repo-brain",
-        project_root=str(settings.project_root),
-    )
+    try:
+        status = await bridge.hive_status(
+            agent_id=agent_id,
+            agent_name=agent_name,
+            agent_profile=settings.memory.profile or "repo-brain",
+            project_root=str(settings.project_root),
+        )
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "hive_status",
+            exc,
+            extra={"enabled": True, "store_metadata": _store_metadata(store)},
+        )
     return {
         "action": "hive_status",
         **status,
@@ -2035,12 +2121,24 @@ async def _handle_hive_search(store: MemoryStore, p: _Params) -> dict[str, Any]:
     limit = p.limit if p.limit > 0 else _HIVE_SEARCH_DEFAULT_LIMIT
     namespaces = p.tag_list if p.tag_list else None
 
-    raw = await bridge.hive_search(
-        text,
-        limit=limit,
-        namespaces=namespaces,
-        min_confidence=p.min_confidence,
-    )
+    try:
+        raw = await bridge.hive_search(
+            text,
+            limit=limit,
+            namespaces=namespaces,
+            min_confidence=p.min_confidence,
+        )
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "hive_search",
+            exc,
+            extra={
+                "enabled": True,
+                "results": [],
+                "result_count": 0,
+                "store_metadata": _store_metadata(store),
+            },
+        )
     if raw == [] and bridge._brain.hive is None:
         return {
             "action": "hive_search",
@@ -2097,11 +2195,23 @@ async def _handle_hive_propagate(store: MemoryStore, p: _Params) -> dict[str, An
     cap = p.limit if p.limit > 0 else _HIVE_PROPAGATE_DEFAULT_LIMIT
     entries = store.snapshot().entries[:cap]
 
-    result = await bridge.hive_propagate(
-        entries,
-        agent_id=agent_id,
-        agent_profile=active_profile,
-    )
+    try:
+        result = await bridge.hive_propagate(
+            entries,
+            agent_id=agent_id,
+            agent_profile=active_profile,
+        )
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "hive_propagate",
+            exc,
+            extra={
+                "enabled": True,
+                "propagated": 0,
+                "skipped_private": 0,
+                "store_metadata": _store_metadata(store),
+            },
+        )
     return {
         "action": "hive_propagate",
         **result,
@@ -2145,13 +2255,20 @@ async def _handle_agent_register(store: MemoryStore, p: _Params) -> dict[str, An
     display = (p.value or "").strip() or aid
     profile_name = settings.memory.profile or "repo-brain"
 
-    result = await bridge.agent_register(
-        agent_id=aid,
-        name=display,
-        profile=profile_name,
-        skills=p.tag_list,
-        project_root=str(settings.project_root),
-    )
+    try:
+        result = await bridge.agent_register(
+            agent_id=aid,
+            name=display,
+            profile=profile_name,
+            skills=p.tag_list,
+            project_root=str(settings.project_root),
+        )
+    except BrainBridgeUnavailable as exc:
+        return _bridge_call_failed_response(
+            "agent_register",
+            exc,
+            extra={"enabled": True, "store_metadata": _store_metadata(store)},
+        )
     return {
         "action": "agent_register",
         "enabled": True,

--- a/packages/tapps-mcp/tests/unit/test_memory_bridge_unavailable.py
+++ b/packages/tapps-mcp/tests/unit/test_memory_bridge_unavailable.py
@@ -1,0 +1,262 @@
+"""Failure-path coverage for memory handlers when BrainBridge raises.
+
+TAP-515: every ``await bridge.X()`` inside a memory handler must catch
+``BrainBridgeUnavailable`` and return a structured ``degraded=true``
+payload instead of propagating the raw exception to the MCP client.
+
+TAP-522: this file is also the unified failure-path sweep — one test per
+handler that hits a ``BrainBridge`` method.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tapps_core.brain_bridge import BrainBridgeUnavailable
+from tapps_mcp.server_memory_tools import (
+    _handle_agent_register,
+    _handle_consolidate,
+    _handle_contradictions,
+    _handle_gc,
+    _handle_health,
+    _handle_hive_propagate,
+    _handle_hive_search,
+    _handle_hive_status,
+    _handle_maintain,
+    _handle_verify_integrity,
+    _Params,
+)
+
+
+def _params(**kwargs: Any) -> _Params:
+    """Build _Params with zero-value defaults."""
+    base: dict[str, Any] = {
+        "key": "",
+        "value": "",
+        "tier": "pattern",
+        "source": "agent",
+        "source_agent": "unknown",
+        "scope": "project",
+        "tag_list": [],
+        "branch": "",
+        "query": "",
+        "confidence": -1.0,
+        "ranked": True,
+        "limit": 0,
+        "include_summary": True,
+        "file_path": "",
+        "overwrite": False,
+        "entries": "",
+        "entry_ids": [],
+        "dry_run": False,
+        "include_sources": False,
+        "project_id": "",
+        "sources": [],
+        "min_confidence": 0.5,
+        "include_hub": True,
+        "stale_only": False,
+        "max_entries": 10,
+        "export_format": "json",
+        "include_frontmatter": True,
+        "export_group_by": "tier",
+        "include_session_index": False,
+        "session_id": "",
+        "chunks": "",
+        "safety_bypass": False,
+    }
+    base.update(kwargs)
+    return _Params(**base)
+
+
+@pytest.fixture
+def store() -> MagicMock:
+    """Minimal MemoryStore double that satisfies _store_metadata()."""
+    mock_store = MagicMock()
+    snap = MagicMock()
+    snap.total_count = 0
+    snap.tier_counts = {}
+    snap.entries = []
+    mock_store.snapshot.return_value = snap
+    mock_store.count.return_value = 0
+    return mock_store
+
+
+def _unavailable_bridge(method: str) -> MagicMock:
+    """Bridge double whose *method* raises BrainBridgeUnavailable."""
+    bridge = MagicMock()
+    setattr(
+        bridge,
+        method,
+        AsyncMock(side_effect=BrainBridgeUnavailable("circuit open")),
+    )
+    return bridge
+
+
+def _assert_degraded(out: dict[str, Any], action: str) -> None:
+    """Shared assertion: structured TAP-515 error shape."""
+    assert out["action"] == action
+    assert out["success"] is False
+    assert out["ok"] is False
+    assert out["degraded"] is True
+    assert out["retryable"] is True
+    assert out["reason"] == "brain_bridge_call_failed"
+    assert "circuit open" in out["error"]
+    assert "remediation" in out
+    assert out["next_steps"]
+
+
+# ---------------------------------------------------------------------------
+# Non-hive handlers (no AGENT_TEAMS gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gc_returns_degraded_when_bridge_unavailable(store: MagicMock) -> None:
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("gc"),
+    ):
+        out = await _handle_gc(store, _params(dry_run=True))
+    _assert_degraded(out, "gc")
+    assert "store_metadata" in out
+
+
+@pytest.mark.asyncio
+async def test_contradictions_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+) -> None:
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("detect_conflicts"),
+    ):
+        out = await _handle_contradictions(store, _params())
+    _assert_degraded(out, "contradictions")
+    assert "store_metadata" in out
+
+
+@pytest.mark.asyncio
+async def test_consolidate_auto_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+) -> None:
+    store.list_all.return_value = [MagicMock(contradicted=False) for _ in range(3)]
+    for entry in store.list_all.return_value:
+        entry.is_consolidated = False
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("consolidate"),
+    ):
+        out = await _handle_consolidate(store, _params(dry_run=False))
+    _assert_degraded(out, "consolidate")
+    assert "store_metadata" in out
+
+
+@pytest.mark.asyncio
+async def test_maintain_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+) -> None:
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("maintain"),
+    ):
+        out = await _handle_maintain(store, _params())
+    _assert_degraded(out, "maintain")
+    assert "store_metadata" in out
+
+
+@pytest.mark.asyncio
+async def test_health_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+) -> None:
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("health"),
+    ):
+        out = await _handle_health(store, _params())
+    _assert_degraded(out, "health")
+    assert out["status"] == "degraded"
+    assert out["configured"] is True
+
+
+@pytest.mark.asyncio
+async def test_verify_integrity_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+) -> None:
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("verify_integrity"),
+    ):
+        out = await _handle_verify_integrity(store, _params())
+    _assert_degraded(out, "verify_integrity")
+    assert "store_metadata" in out
+
+
+# ---------------------------------------------------------------------------
+# Hive handlers (require AGENT_TEAMS env)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hive_status_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("hive_status"),
+    ):
+        out = await _handle_hive_status(store, _params())
+    _assert_degraded(out, "hive_status")
+    assert out["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_hive_search_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("hive_search"),
+    ):
+        out = await _handle_hive_search(store, _params(query="jwt"))
+    _assert_degraded(out, "hive_search")
+    assert out["enabled"] is True
+    assert out["results"] == []
+    assert out["result_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hive_propagate_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("hive_propagate"),
+    ):
+        out = await _handle_hive_propagate(store, _params())
+    _assert_degraded(out, "hive_propagate")
+    assert out["enabled"] is True
+    assert out["propagated"] == 0
+    assert out["skipped_private"] == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_register_returns_degraded_when_bridge_unavailable(
+    store: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    with patch(
+        "tapps_mcp.server_memory_tools._get_brain_bridge",
+        return_value=_unavailable_bridge("agent_register"),
+    ):
+        out = await _handle_agent_register(store, _params(key="agent-42"))
+    _assert_degraded(out, "agent_register")
+    assert out["enabled"] is True


### PR DESCRIPTION
## Summary

Closes [TAP-515](https://linear.app/tappscodingagents/issue/TAP-515). Also covers [TAP-522](https://linear.app/tappscodingagents/issue/TAP-522) (failure-path test sweep).

Memory handlers that `await bridge.X()` now catch `BrainBridgeUnavailable` and return a structured `{ok: false, degraded: true, retryable: true, remediation: ..., next_steps: [...]}` payload instead of propagating the raw exception to the MCP client. This means the circuit-breaker-open and retries-exhausted states produce a useful, actionable response rather than an opaque 500.

**10 call sites wrapped:** `gc`, `contradictions`, `consolidate`, `maintain`, `health`, `verify_integrity`, `hive_status`, `hive_search`, `hive_propagate`, `agent_register`.

A new helper `_bridge_call_failed_response(action, exc, extra=...)` sits alongside the existing `_bridge_unavailable_response(action)` — the two cases are deliberately distinct:
- `_bridge_unavailable_response` — bridge is unconfigured (no DSN).
- `_bridge_call_failed_response` — bridge is configured but unreachable (circuit open / retries exhausted).

## Test plan

- [x] `uv run pytest packages/tapps-mcp/tests/unit/test_memory_bridge_unavailable.py -q` — 10/10 pass
- [x] `uv run pytest` across memory handler test suites (hive, gc, consolidate, contradictions, foundation, tool) — 94/94 pass, no regressions
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy --strict` — clean
- [x] `tapps_validate_changed` quick mode — both files score 100, gate pass, security pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)