### PR TITLE
[TAP-517] drain offline write queue on shutdown; surface bridge state

### DIFF
--- a/packages/tapps-core/src/tapps_core/brain_bridge.py
+++ b/packages/tapps-core/src/tapps_core/brain_bridge.py
@@ -15,9 +15,12 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import atexit
 import contextlib
 import os
 import random
+import signal
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -44,6 +47,11 @@ _RETRY_MAX: float = 8.0
 # --- Write queue -------------------------------------------------------------
 _WRITE_QUEUE_CAP: int = 100
 
+# --- Shutdown drain ---------------------------------------------------------
+# Bounded deadline (seconds) that ``close`` / ``drain_blocking`` waits for the
+# offline write queue to drain on shutdown before giving up (TAP-517).
+_DRAIN_DEADLINE_SECONDS: float = 5.0
+
 
 class BrainBridgeUnavailable(Exception):
     """Raised when the circuit is open or the bridge is not configured."""
@@ -65,9 +73,7 @@ class BrainBridge:
         self._brain = brain
         self._failures: int = 0
         self._open_at: float | None = None
-        self._write_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
-            maxsize=_WRITE_QUEUE_CAP
-        )
+        self._write_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_WRITE_QUEUE_CAP)
         self._drain_task: asyncio.Task[None] | None = None
 
     # -------------------------------------------------------------------------
@@ -89,6 +95,27 @@ class BrainBridge:
     def queue_depth(self) -> int:
         """Number of writes currently queued."""
         return self._write_queue.qsize()
+
+    @property
+    def circuit_state(self) -> str:
+        """Circuit state as a stable string — ``"open"`` or ``"closed"``.
+
+        Exposed via :meth:`status` for server_info consumers so they do not
+        need to consume the mutating :attr:`circuit_open` check.
+        """
+        return "open" if self.circuit_open else "closed"
+
+    def status(self) -> dict[str, Any]:
+        """Non-blocking diagnostic snapshot of bridge health (TAP-517).
+
+        Safe to call from read-only paths like ``tapps_server_info``.
+        """
+        return {
+            "queue_depth": self.queue_depth,
+            "queue_cap": _WRITE_QUEUE_CAP,
+            "circuit_state": self.circuit_state,
+            "failures": self._failures,
+        }
 
     def _record_success(self) -> None:
         self._failures = 0
@@ -134,11 +161,21 @@ class BrainBridge:
     # -------------------------------------------------------------------------
 
     def _enqueue_write(self, entry: dict[str, Any]) -> bool:
-        """Queue a write for later drain. Returns False when queue is full."""
+        """Queue a write for later drain. Returns False when queue is full.
+
+        Logs a ``brain_write_queue_full`` warning on overflow (TAP-517) so
+        operators can see when the offline buffer is dropping writes.
+        """
         try:
             self._write_queue.put_nowait(entry)
             return True
         except asyncio.QueueFull:
+            logger.warning(
+                "brain_write_queue_full",
+                queue_depth=self._write_queue.qsize(),
+                queue_cap=_WRITE_QUEUE_CAP,
+                dropped_key=entry.get("key"),
+            )
             return False
 
     async def _drain_write_queue(self) -> None:
@@ -381,9 +418,7 @@ class BrainBridge:
                     skipped_private += 1
                 else:
                     propagated += 1
-                    details.append(
-                        {"key": entry.key, "namespace": saved.get("namespace", "")}
-                    )
+                    details.append({"key": entry.key, "namespace": saved.get("namespace", "")})
 
             return {
                 "enabled": True,
@@ -469,9 +504,7 @@ class BrainBridge:
             }
 
         def _fn() -> dict[str, Any]:
-            entry = self._brain.store.save(
-                key, value, tier=tier, scope=scope, tags=tags, **kwargs
-            )
+            entry = self._brain.store.save(key, value, tier=tier, scope=scope, tags=tags, **kwargs)
             return self._to_dict(entry)
 
         result: dict[str, Any] = await self._call(_fn)
@@ -684,8 +717,51 @@ class BrainBridge:
     # Lifecycle
     # -------------------------------------------------------------------------
 
-    def close(self) -> None:
-        """Close the underlying AgentBrain connection pool."""
+    def drain_blocking(self, timeout: float = _DRAIN_DEADLINE_SECONDS) -> dict[str, int]:
+        """Synchronously drain the offline write queue (TAP-517).
+
+        Bypasses ``_call`` / ``asyncio.to_thread`` because this path runs from
+        shutdown hooks (atexit / SIGTERM) where the event loop may already be
+        gone. Bounded by *timeout* seconds; remaining entries are left on the
+        queue and reported in the return dict.
+        """
+        deadline = time.monotonic() + max(0.0, timeout)
+        drained = 0
+        dropped = 0
+        while not self._write_queue.empty():
+            if time.monotonic() >= deadline:
+                break
+            try:
+                entry = self._write_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            try:
+                self._brain.store.save(**entry)
+                drained += 1
+            except Exception as exc:
+                logger.warning(
+                    "brain_bridge.drain_blocking_entry_failed",
+                    error=str(exc),
+                    key=entry.get("key"),
+                )
+                dropped += 1
+        remaining = self._write_queue.qsize()
+        if drained or dropped or remaining:
+            logger.info(
+                "brain_bridge.drain_blocking_complete",
+                drained=drained,
+                dropped=dropped,
+                remaining=remaining,
+                deadline_exceeded=time.monotonic() >= deadline,
+            )
+        return {"drained": drained, "dropped": dropped, "remaining": remaining}
+
+    def close(self, drain_timeout: float = _DRAIN_DEADLINE_SECONDS) -> None:
+        """Drain queued writes (bounded) then close the AgentBrain pool."""
+        try:
+            self.drain_blocking(drain_timeout)
+        except Exception as exc:
+            logger.warning("brain_bridge.drain_on_close_failed", error=str(exc))
         try:
             self._brain.close()
         except Exception as exc:
@@ -758,9 +834,7 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
     if pg_pool_max_waiting:
         os.environ["TAPPS_BRAIN_PG_POOL_MAX_WAITING"] = str(pg_pool_max_waiting)
     if pg_pool_max_lifetime_seconds:
-        os.environ["TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS"] = str(
-            pg_pool_max_lifetime_seconds
-        )
+        os.environ["TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS"] = str(pg_pool_max_lifetime_seconds)
 
     # --- Construct & probe ---------------------------------------------------
     try:
@@ -772,7 +846,40 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
         )
         # Probe the store to fail fast on bad DSN before returning
         brain.store.count()
-        return BrainBridge(brain)
+        bridge = BrainBridge(brain)
+        _register_shutdown_hooks(bridge)
+        return bridge
     except Exception as exc:
         logger.warning("brain_bridge.init_failed", error=str(exc))
         return None
+
+
+_shutdown_hooks_registered: bool = False
+
+
+def _register_shutdown_hooks(bridge: BrainBridge) -> None:
+    """Wire atexit + SIGTERM drain hooks for *bridge* (TAP-517).
+
+    atexit covers normal interpreter shutdown and ``sys.exit``. SIGTERM by
+    default kills the process without running atexit, so we route it through
+    ``sys.exit(0)`` to get the bounded drain. Signal registration only works
+    on the main thread of the main interpreter, so we swallow failures from
+    worker threads / embedded contexts.
+    """
+    global _shutdown_hooks_registered
+    if _shutdown_hooks_registered:
+        return
+
+    atexit.register(bridge.close)
+
+    def _sigterm_drain_exit(_signum: int, _frame: Any) -> None:
+        sys.exit(0)
+
+    try:
+        signal.signal(signal.SIGTERM, _sigterm_drain_exit)
+    except (OSError, ValueError):
+        # Non-main-thread, embedded interpreter, or platform without
+        # SIGTERM — atexit still covers normal shutdown paths.
+        logger.debug("brain_bridge.sigterm_register_skipped")
+
+    _shutdown_hooks_registered = True

--- a/packages/tapps-core/tests/unit/test_brain_bridge_shutdown.py
+++ b/packages/tapps-core/tests/unit/test_brain_bridge_shutdown.py
@@ -1,0 +1,282 @@
+"""Shutdown-drain, queue overflow, and status snapshot coverage (TAP-517).
+
+These tests target the behaviours added for TAP-517:
+
+* Enqueue overflow emits a structured warning.
+* ``status()`` exposes ``queue_depth`` and ``circuit_state``.
+* ``drain_blocking()`` drains the offline queue under a bounded deadline.
+* ``close()`` runs the drain before closing the underlying brain.
+* ``_register_shutdown_hooks`` wires atexit idempotently.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_brain() -> MagicMock:
+    brain = MagicMock()
+    store = MagicMock()
+    store.count.return_value = 0
+    save_entry = MagicMock()
+    save_entry.model_dump.return_value = {"key": "k", "value": "v"}
+    store.save.return_value = save_entry
+    brain.store = store
+    brain.hive = None
+    return brain
+
+
+@pytest.fixture
+def bridge() -> Any:
+    from tapps_core.brain_bridge import BrainBridge
+
+    return BrainBridge(_make_brain())
+
+
+# ---------------------------------------------------------------------------
+# Enqueue overflow warning
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueOverflowWarning:
+    def test_warning_logged_when_queue_full(self, bridge: Any) -> None:
+        from tapps_core.brain_bridge import _WRITE_QUEUE_CAP
+
+        for i in range(_WRITE_QUEUE_CAP):
+            assert bridge._enqueue_write({"key": f"k{i}", "value": "v"}) is True
+
+        with patch("tapps_core.brain_bridge.logger") as mock_logger:
+            overflow = bridge._enqueue_write({"key": "overflow", "value": "v"})
+
+        assert overflow is False
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args.args[0] == "brain_write_queue_full"
+        assert call_args.kwargs["queue_depth"] == _WRITE_QUEUE_CAP
+        assert call_args.kwargs["queue_cap"] == _WRITE_QUEUE_CAP
+        assert call_args.kwargs["dropped_key"] == "overflow"
+
+
+# ---------------------------------------------------------------------------
+# Status snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestStatusSnapshot:
+    def test_status_returns_expected_keys(self, bridge: Any) -> None:
+        snapshot = bridge.status()
+        assert snapshot == {
+            "queue_depth": 0,
+            "queue_cap": 100,
+            "circuit_state": "closed",
+            "failures": 0,
+        }
+
+    def test_circuit_state_closed_initially(self, bridge: Any) -> None:
+        assert bridge.circuit_state == "closed"
+
+    def test_circuit_state_open_after_threshold_failures(self, bridge: Any) -> None:
+        from tapps_core.brain_bridge import _CB_FAILURE_THRESHOLD
+
+        for _ in range(_CB_FAILURE_THRESHOLD):
+            bridge._record_failure()
+        assert bridge.circuit_state == "open"
+
+    def test_status_reflects_queued_writes(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v"})
+        bridge._enqueue_write({"key": "k2", "value": "v"})
+        assert bridge.status()["queue_depth"] == 2
+
+
+# ---------------------------------------------------------------------------
+# drain_blocking
+# ---------------------------------------------------------------------------
+
+
+class TestDrainBlocking:
+    def test_drain_empties_queue_and_persists_entries(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v1"})
+        bridge._enqueue_write({"key": "k2", "value": "v2"})
+
+        result = bridge.drain_blocking(timeout=1.0)
+
+        assert result["drained"] == 2
+        assert result["dropped"] == 0
+        assert result["remaining"] == 0
+        assert bridge.queue_depth == 0
+        assert bridge._brain.store.save.call_count == 2
+
+    def test_drain_counts_dropped_on_store_exception(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v1"})
+        bridge._brain.store.save.side_effect = RuntimeError("postgres is down")
+
+        result = bridge.drain_blocking(timeout=1.0)
+
+        assert result["drained"] == 0
+        assert result["dropped"] == 1
+        assert result["remaining"] == 0
+
+    def test_drain_respects_timeout_deadline(self, bridge: Any) -> None:
+        """Timeout=0 means we should not drain anything — deadline check fires first."""
+        for i in range(5):
+            bridge._enqueue_write({"key": f"k{i}", "value": "v"})
+
+        # Timeout=0: deadline is exceeded immediately, nothing drains.
+        result = bridge.drain_blocking(timeout=0.0)
+
+        assert result["drained"] == 0
+        assert result["remaining"] == 5
+        assert bridge._brain.store.save.call_count == 0
+
+    def test_drain_on_empty_queue_is_noop(self, bridge: Any) -> None:
+        result = bridge.drain_blocking(timeout=1.0)
+        assert result == {"drained": 0, "dropped": 0, "remaining": 0}
+        assert bridge._brain.store.save.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# close() drains before closing
+# ---------------------------------------------------------------------------
+
+
+class TestCloseDrains:
+    def test_close_invokes_drain_blocking_before_brain_close(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v1"})
+
+        call_order: list[str] = []
+
+        original_save = bridge._brain.store.save
+        original_brain_close = bridge._brain.close
+
+        def _save(*a: Any, **kw: Any) -> Any:
+            call_order.append("store.save")
+            return original_save(*a, **kw)
+
+        def _brain_close() -> None:
+            call_order.append("brain.close")
+            original_brain_close()
+
+        bridge._brain.store.save = _save
+        bridge._brain.close = _brain_close
+
+        bridge.close()
+
+        assert call_order == ["store.save", "brain.close"]
+        assert bridge.queue_depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Shutdown-hook registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterShutdownHooks:
+    def test_registers_atexit_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tapps_core.brain_bridge as bb
+
+        monkeypatch.setattr(bb, "_shutdown_hooks_registered", False)
+
+        registered: list[Any] = []
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.atexit.register",
+            lambda fn: registered.append(fn),
+        )
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.signal.signal",
+            lambda *_a, **_kw: None,
+        )
+
+        b = bb.BrainBridge(_make_brain())
+        bb._register_shutdown_hooks(b)
+
+        assert b.close in registered
+
+    def test_registration_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tapps_core.brain_bridge as bb
+
+        monkeypatch.setattr(bb, "_shutdown_hooks_registered", False)
+        call_count = {"n": 0}
+
+        def _count(_fn: Any) -> None:
+            call_count["n"] += 1
+
+        monkeypatch.setattr("tapps_core.brain_bridge.atexit.register", _count)
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.signal.signal",
+            lambda *_a, **_kw: None,
+        )
+
+        b = bb.BrainBridge(_make_brain())
+        bb._register_shutdown_hooks(b)
+        bb._register_shutdown_hooks(b)  # second call should be a no-op
+
+        assert call_count["n"] == 1
+
+    def test_sigterm_register_failure_is_tolerated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Signal registration from non-main threads raises ValueError; must be swallowed."""
+        import tapps_core.brain_bridge as bb
+
+        monkeypatch.setattr(bb, "_shutdown_hooks_registered", False)
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.atexit.register", lambda _fn: None
+        )
+
+        def _raise(*_a: Any, **_kw: Any) -> None:
+            raise ValueError("signal only works in main thread")
+
+        monkeypatch.setattr("tapps_core.brain_bridge.signal.signal", _raise)
+
+        b = bb.BrainBridge(_make_brain())
+        bb._register_shutdown_hooks(b)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Integration: BrainBridge.status() is stable across circuit transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_updates_after_circuit_opens_and_writes_queue(bridge: Any) -> None:
+    from tapps_core.brain_bridge import _CB_FAILURE_THRESHOLD
+
+    for _ in range(_CB_FAILURE_THRESHOLD):
+        bridge._record_failure()
+    assert bridge.status()["circuit_state"] == "open"
+
+    await bridge.save(key="k1", value="v1")
+
+    snap = bridge.status()
+    assert snap["circuit_state"] == "open"
+    assert snap["queue_depth"] == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_blocking_clears_entries_queued_via_save(bridge: Any) -> None:
+    from tapps_core.brain_bridge import _CB_FAILURE_THRESHOLD
+
+    for _ in range(_CB_FAILURE_THRESHOLD):
+        bridge._record_failure()
+    await bridge.save(key="k1", value="v1")
+    await bridge.save(key="k2", value="v2")
+
+    result = bridge.drain_blocking(timeout=1.0)
+    assert result["drained"] == 2
+    assert bridge.queue_depth == 0
+
+
+def test_drain_blocking_finishes_well_within_timeout(bridge: Any) -> None:
+    """Sanity check: drain_blocking returns quickly on a small queue."""
+    for i in range(3):
+        bridge._enqueue_write({"key": f"k{i}", "value": "v"})
+
+    start = time.monotonic()
+    bridge.drain_blocking(timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0

--- a/packages/tapps-mcp/src/tapps_mcp/server.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server.py
@@ -93,8 +93,10 @@ def _bootstrap_cache_dir(project_root: Path) -> tuple[Path, bool]:
     2. ``<project_root>/.tapps-mcp-cache``
     3. ``<tempdir>/.tapps-mcp-cache`` (fallback when project root not writable)
     """
-    cache_dir = Path(os.environ["TAPPS_CACHE_DIR"]) if os.environ.get("TAPPS_CACHE_DIR") else (
-        project_root / ".tapps-mcp-cache"
+    cache_dir = (
+        Path(os.environ["TAPPS_CACHE_DIR"])
+        if os.environ.get("TAPPS_CACHE_DIR")
+        else (project_root / ".tapps-mcp-cache")
     )
     fallback_used = False
 
@@ -152,130 +154,168 @@ def _validate_file_path(file_path: str) -> Path:
     return validator.validate_read_path(path_str)
 
 
-
 # ---------------------------------------------------------------------------
 # Constants extracted to avoid duplication
 # ---------------------------------------------------------------------------
 
 # Canonical list of all TappsMCP tools (26).
 # Used for filtering and fallback.
-ALL_TOOL_NAMES: frozenset[str] = frozenset({
-    "tapps_server_info",
-    "tapps_session_start",
-    "tapps_score_file",
-    "tapps_security_scan",
-    "tapps_quality_gate",
-    "tapps_lookup_docs",
-    "tapps_validate_config",
-    "tapps_validate_changed",
-    "tapps_quick_check",
-    "tapps_checklist",
-    "tapps_session_notes",
-    "tapps_impact_analysis",
-    "tapps_report",
-    "tapps_init",
-    "tapps_upgrade",
-    "tapps_doctor",
-    "tapps_set_engagement_level",
-    "tapps_dashboard",
-    "tapps_stats",
-    "tapps_feedback",
-    "tapps_dead_code",
-    "tapps_dependency_scan",
-    "tapps_dependency_graph",
-    "tapps_memory",
-    "tapps_pipeline",
-    "tapps_decompose",
-})
+ALL_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "tapps_server_info",
+        "tapps_session_start",
+        "tapps_score_file",
+        "tapps_security_scan",
+        "tapps_quality_gate",
+        "tapps_lookup_docs",
+        "tapps_validate_config",
+        "tapps_validate_changed",
+        "tapps_quick_check",
+        "tapps_checklist",
+        "tapps_session_notes",
+        "tapps_impact_analysis",
+        "tapps_report",
+        "tapps_init",
+        "tapps_upgrade",
+        "tapps_doctor",
+        "tapps_set_engagement_level",
+        "tapps_dashboard",
+        "tapps_stats",
+        "tapps_feedback",
+        "tapps_dead_code",
+        "tapps_dependency_scan",
+        "tapps_dependency_graph",
+        "tapps_memory",
+        "tapps_pipeline",
+        "tapps_decompose",
+    }
+)
 
 # Tier 1 from TOOL-TIER-RANKING (Epic 79.1)
-TOOL_PRESET_CORE: frozenset[str] = frozenset({
-    "tapps_session_start",
-    "tapps_quick_check",
-    "tapps_validate_changed",
-    "tapps_quality_gate",
-    "tapps_checklist",
-    "tapps_lookup_docs",
-    "tapps_security_scan",
-    "tapps_pipeline",
-})
+TOOL_PRESET_CORE: frozenset[str] = frozenset(
+    {
+        "tapps_session_start",
+        "tapps_quick_check",
+        "tapps_validate_changed",
+        "tapps_quality_gate",
+        "tapps_checklist",
+        "tapps_lookup_docs",
+        "tapps_security_scan",
+        "tapps_pipeline",
+    }
+)
 
 # Tier 1 + Tier 2
-TOOL_PRESET_PIPELINE: frozenset[str] = TOOL_PRESET_CORE | frozenset({
-    "tapps_score_file",
-    "tapps_memory",
-    "tapps_impact_analysis",
-    "tapps_validate_config",
-})
+TOOL_PRESET_PIPELINE: frozenset[str] = TOOL_PRESET_CORE | frozenset(
+    {
+        "tapps_score_file",
+        "tapps_memory",
+        "tapps_impact_analysis",
+        "tapps_validate_config",
+    }
+)
 
 # Role presets Phase 1 (Epic 79.5) — from ROLE-PRESETS-IMPLEMENT-FIRST.md
-TOOL_PRESET_REVIEWER: frozenset[str] = frozenset({
-    "tapps_session_start", "tapps_quick_check", "tapps_validate_changed",
-    "tapps_quality_gate", "tapps_checklist", "tapps_security_scan",
-    "tapps_score_file", "tapps_dead_code", "tapps_dependency_scan",
-})
-TOOL_PRESET_PLANNER: frozenset[str] = frozenset({
-    "tapps_session_start", "tapps_checklist", "tapps_validate_changed",
-    "tapps_quality_gate", "tapps_score_file", "tapps_memory",
-})
-TOOL_PRESET_FRONTEND: frozenset[str] = frozenset({
-    "tapps_session_start", "tapps_quick_check", "tapps_score_file",
-    "tapps_lookup_docs", "tapps_quality_gate",
-})
-TOOL_PRESET_DEVELOPER: frozenset[str] = frozenset({
-    "tapps_session_start", "tapps_quick_check", "tapps_validate_changed",
-    "tapps_quality_gate", "tapps_checklist", "tapps_score_file",
-    "tapps_security_scan", "tapps_lookup_docs", "tapps_memory",
-    "tapps_impact_analysis",
-})
+TOOL_PRESET_REVIEWER: frozenset[str] = frozenset(
+    {
+        "tapps_session_start",
+        "tapps_quick_check",
+        "tapps_validate_changed",
+        "tapps_quality_gate",
+        "tapps_checklist",
+        "tapps_security_scan",
+        "tapps_score_file",
+        "tapps_dead_code",
+        "tapps_dependency_scan",
+    }
+)
+TOOL_PRESET_PLANNER: frozenset[str] = frozenset(
+    {
+        "tapps_session_start",
+        "tapps_checklist",
+        "tapps_validate_changed",
+        "tapps_quality_gate",
+        "tapps_score_file",
+        "tapps_memory",
+    }
+)
+TOOL_PRESET_FRONTEND: frozenset[str] = frozenset(
+    {
+        "tapps_session_start",
+        "tapps_quick_check",
+        "tapps_score_file",
+        "tapps_lookup_docs",
+        "tapps_quality_gate",
+    }
+)
+TOOL_PRESET_DEVELOPER: frozenset[str] = frozenset(
+    {
+        "tapps_session_start",
+        "tapps_quick_check",
+        "tapps_validate_changed",
+        "tapps_quality_gate",
+        "tapps_checklist",
+        "tapps_score_file",
+        "tapps_security_scan",
+        "tapps_lookup_docs",
+        "tapps_memory",
+        "tapps_impact_analysis",
+    }
+)
 
 # TAP-485: Mode presets for --mode quality|admin|all
 # quality mode: coding session tools (reduces context overhead for daily use)
-TAPPS_TOOL_PRESET_QUALITY: frozenset[str] = frozenset({
-    "tapps_session_start",
-    "tapps_quick_check",
-    "tapps_score_file",
-    "tapps_quality_gate",
-    "tapps_checklist",
-    "tapps_validate_changed",
-    "tapps_security_scan",
-    "tapps_lookup_docs",
-    "tapps_memory",
-    "tapps_dead_code",
-    "tapps_impact_analysis",
-    "tapps_validate_config",
-    "tapps_dependency_scan",
-    "tapps_dependency_graph",
-})
+TAPPS_TOOL_PRESET_QUALITY: frozenset[str] = frozenset(
+    {
+        "tapps_session_start",
+        "tapps_quick_check",
+        "tapps_score_file",
+        "tapps_quality_gate",
+        "tapps_checklist",
+        "tapps_validate_changed",
+        "tapps_security_scan",
+        "tapps_lookup_docs",
+        "tapps_memory",
+        "tapps_dead_code",
+        "tapps_impact_analysis",
+        "tapps_validate_config",
+        "tapps_dependency_scan",
+        "tapps_dependency_graph",
+    }
+)
 
 # admin mode: setup/troubleshooting tools
-TAPPS_TOOL_PRESET_ADMIN: frozenset[str] = frozenset({
-    "tapps_init",
-    "tapps_upgrade",
-    "tapps_doctor",
-    "tapps_server_info",
-    "tapps_set_engagement_level",
-    "tapps_dashboard",
-    "tapps_stats",
-    "tapps_feedback",
-    "tapps_report",
-    "tapps_pipeline",
-    "tapps_decompose",
-    "tapps_session_notes",
-})
+TAPPS_TOOL_PRESET_ADMIN: frozenset[str] = frozenset(
+    {
+        "tapps_init",
+        "tapps_upgrade",
+        "tapps_doctor",
+        "tapps_server_info",
+        "tapps_set_engagement_level",
+        "tapps_dashboard",
+        "tapps_stats",
+        "tapps_feedback",
+        "tapps_report",
+        "tapps_pipeline",
+        "tapps_decompose",
+        "tapps_session_notes",
+    }
+)
 
 _FALLBACK_TOOL_LIST: list[str] = sorted(ALL_TOOL_NAMES)
 
 _SECURITY_SCAN_FINDING_LIMIT: int = 50
 
-_VALID_CONFIG_TYPES: frozenset[str] = frozenset({
-    "dockerfile",
-    "docker_compose",
-    "websocket",
-    "mqtt",
-    "influxdb",
-    "mcp",
-})
+_VALID_CONFIG_TYPES: frozenset[str] = frozenset(
+    {
+        "dockerfile",
+        "docker_compose",
+        "websocket",
+        "mqtt",
+        "influxdb",
+        "mcp",
+    }
+)
 
 _MAX_CONFIG_FILE_SIZE: int = 1_048_576  # 1 MB
 
@@ -335,8 +375,7 @@ def _get_available_tools() -> list[str]:
 def _current_docs_provider_summary() -> dict[str, Any]:
     """Return the active docs-lookup provider summary (Issue #79)."""
     has_key = bool(
-        os.environ.get("TAPPS_MCP_CONTEXT7_API_KEY")
-        or os.environ.get("CONTEXT7_API_KEY")
+        os.environ.get("TAPPS_MCP_CONTEXT7_API_KEY") or os.environ.get("CONTEXT7_API_KEY")
     )
     summary: dict[str, Any] = {
         "primary": "context7" if has_key else "llmstxt",
@@ -344,8 +383,7 @@ def _current_docs_provider_summary() -> dict[str, Any]:
     }
     if not has_key:
         summary["hint"] = (
-            "Set TAPPS_MCP_CONTEXT7_API_KEY for richer docs via Context7. "
-            "https://context7.com"
+            "Set TAPPS_MCP_CONTEXT7_API_KEY for richer docs via Context7. https://context7.com"
         )
     return summary
 
@@ -379,6 +417,7 @@ def _build_server_info_data(
         ),
         "docs_provider": _current_docs_provider_summary(),
         "diagnostics": diagnostics.model_dump(),
+        "brain_bridge": _brain_bridge_status_for_server_info(),
         "recommended_workflow": RECOMMENDED_WORKFLOW_TEXT,
         "quick_start": list(DAILY_STEPS),
         "critical_rules": [
@@ -399,6 +438,24 @@ def _build_server_info_data(
             "prompts_available": True,
         },
     }
+
+
+def _brain_bridge_status_for_server_info() -> dict[str, Any]:
+    """Non-blocking BrainBridge snapshot for ``tapps_server_info`` (TAP-517).
+
+    Peeks the cached singleton so the info tool does not force a Postgres
+    connection just to answer a status query. When the bridge has not been
+    initialized yet, reports ``{"initialized": False}``.
+    """
+    try:
+        from tapps_mcp.server_helpers import _peek_brain_bridge
+
+        bridge = _peek_brain_bridge()
+    except Exception as exc:
+        return {"initialized": False, "error": str(exc)}
+    if bridge is None:
+        return {"initialized": False}
+    return {"initialized": True, **bridge.status()}
 
 
 _checklist_state: dict[str, bool] = {"persist_configured": False}
@@ -681,9 +738,7 @@ def tapps_security_scan(
         "medium_count": result.medium_count,
         "low_count": result.low_count,
         "bandit_available": result.bandit_available,
-        "bandit_issues": serialize_issues(
-            result.bandit_issues, limit=_SECURITY_SCAN_FINDING_LIMIT
-        ),
+        "bandit_issues": serialize_issues(result.bandit_issues, limit=_SECURITY_SCAN_FINDING_LIMIT),
         "secret_findings": serialize_issues(
             result.secret_findings, limit=_SECURITY_SCAN_FINDING_LIMIT
         ),
@@ -782,8 +837,7 @@ def _build_lookup_data(result: LookupResult) -> dict[str, Any]:
     # running in degraded mode.
     source_str = str(result.source or "").lower()
     has_key = bool(
-        os.environ.get("TAPPS_MCP_CONTEXT7_API_KEY")
-        or os.environ.get("CONTEXT7_API_KEY")
+        os.environ.get("TAPPS_MCP_CONTEXT7_API_KEY") or os.environ.get("CONTEXT7_API_KEY")
     )
     if not has_key and ("llmstxt" in source_str or source_str == "fallback"):
         data["context7_hint"] = (
@@ -1072,9 +1126,7 @@ def _checklist_compact_format(
         parts.append(f"{len(result.missing_required)} required missing ({missing_names})")
     if result.missing_recommended:
         missing_names = ", ".join(result.missing_recommended)
-        parts.append(
-            f"{len(result.missing_recommended)} recommended missing ({missing_names})"
-        )
+        parts.append(f"{len(result.missing_recommended)} recommended missing ({missing_names})")
 
     summary = f"Checklist {result.task_type}: {', '.join(parts)}"
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import Context
-    from tapps_brain.backends import AgentRegistry as _HiveAgentRegistryType
     from tapps_brain import HiveBackend as _HiveStoreType
+    from tapps_brain.backends import AgentRegistry as _HiveAgentRegistryType
 
     from tapps_core.brain_bridge import BrainBridge as _BrainBridgeType
     from tapps_core.config.settings import TappsMCPSettings
@@ -40,6 +40,7 @@ async def emit_ctx_info(ctx: Context[Any, Any, Any] | None, message: str) -> Non
         return
     with contextlib.suppress(Exception):
         await info_fn(message)
+
 
 # ---------------------------------------------------------------------------
 # CodeScorer singleton — avoids re-instantiating on every tool call.
@@ -158,6 +159,16 @@ def _reset_brain_bridge_cache() -> None:
         _brain_bridge = None
 
 
+def _peek_brain_bridge() -> _BrainBridgeType | None:
+    """Return the cached :class:`BrainBridge` without forcing init (TAP-517).
+
+    Used by read-only consumers like ``tapps_server_info`` that need to
+    report bridge state but must not incur a Postgres connection just to
+    answer a diagnostics query.
+    """
+    return _brain_bridge
+
+
 def _get_memory_store() -> _MemoryStoreType:
     """Return the Postgres-backed :class:`MemoryStore` from the BrainBridge.
 
@@ -257,13 +268,15 @@ def build_impact_memory_context(
     for entry in filtered:
         val = str(getattr(entry, "value", "") or "")
         cap = _IMPACT_MEMORY_SUMMARY_MAX
-        items.append({
-            "key": str(getattr(entry, "key", "")),
-            "summary": val[:cap] + ("..." if len(val) > cap else ""),
-            "tier": _tier_str(getattr(entry, "tier", "")),
-            "confidence": float(getattr(entry, "confidence", 0.0)),
-            "source": "memory",
-        })
+        items.append(
+            {
+                "key": str(getattr(entry, "key", "")),
+                "summary": val[:cap] + ("..." if len(val) > cap else ""),
+                "tier": _tier_str(getattr(entry, "tier", "")),
+                "confidence": float(getattr(entry, "confidence", 0.0)),
+                "source": "memory",
+            }
+        )
 
     return {
         "memory_context": items,
@@ -334,22 +347,31 @@ def _ensure_hive_singletons() -> tuple[
         if _hive_store is None:
             dsn = os.environ.get("TAPPS_BRAIN_DATABASE_URL", "")
             if not dsn:
-                return None, None, (
-                    "TAPPS_BRAIN_DATABASE_URL not configured "
-                    "(Postgres DSN required for Hive; ADR-007)"
+                return (
+                    None,
+                    None,
+                    (
+                        "TAPPS_BRAIN_DATABASE_URL not configured "
+                        "(Postgres DSN required for Hive; ADR-007)"
+                    ),
                 )
             if not dsn.startswith(("postgres://", "postgresql://")):
                 scheme = dsn.split("://", 1)[0] if "://" in dsn else "<none>"
-                return None, None, (
-                    f"TAPPS_BRAIN_DATABASE_URL scheme '{scheme}' not supported "
-                    "(Hive requires postgres:// or postgresql://)"
+                return (
+                    None,
+                    None,
+                    (
+                        f"TAPPS_BRAIN_DATABASE_URL scheme '{scheme}' not supported "
+                        "(Hive requires postgres:// or postgresql://)"
+                    ),
                 )
             if _hive_init_error is not None:
                 return None, None, _hive_init_error
             try:
                 from tapps_brain.backends import create_hive_backend
+
                 _hive_store = create_hive_backend(dsn)
-            except Exception as exc:  # noqa: BLE001 — surface real init failure
+            except Exception as exc:
                 _hive_init_error = f"create_hive_backend failed: {exc}"
                 return None, None, _hive_init_error
         if _hive_registry is None:
@@ -654,12 +676,14 @@ async def ensure_session_initialized() -> None:
     except Exception:
         pass  # Best-effort; profiling failure should not block session init
 
-    mark_session_initialized({
-        "project_root": str(settings.project_root),
-        "quality_preset": settings.quality_preset,
-        "auto_initialized": True,
-        "project_profile": profile_data,
-    })
+    mark_session_initialized(
+        {
+            "project_root": str(settings.project_root),
+            "quality_preset": settings.quality_preset,
+            "auto_initialized": True,
+            "project_profile": profile_data,
+        }
+    )
 
 
 def ensure_session_initialized_sync() -> None:
@@ -674,9 +698,11 @@ def ensure_session_initialized_sync() -> None:
     from tapps_core.config.settings import load_settings
 
     settings = load_settings()
-    mark_session_initialized({
-        "project_root": str(settings.project_root),
-        "quality_preset": settings.quality_preset,
-        "auto_initialized": True,
-        "sync_only": True,
-    })
+    mark_session_initialized(
+        {
+            "project_root": str(settings.project_root),
+            "quality_preset": settings.quality_preset,
+            "auto_initialized": True,
+            "sync_only": True,
+        }
+    )

--- a/packages/tapps-mcp/tests/integration/test_mcp_handshake.py
+++ b/packages/tapps-mcp/tests/integration/test_mcp_handshake.py
@@ -25,6 +25,7 @@ class TestMCPHandshake:
         data = result["data"]
         assert data["server"]["name"] == "TappsMCP"
         from tapps_mcp import __version__
+
         assert data["server"]["version"] == __version__
         assert data["server"]["protocol_version"] == "2025-11-25"
 
@@ -74,3 +75,15 @@ class TestMCPHandshake:
         except AttributeError:
             # If internal API changes, at least verify the tool function exists
             assert callable(tapps_server_info)
+
+    @pytest.mark.asyncio
+    async def test_server_info_includes_brain_bridge_snapshot(self):
+        """TAP-517: server_info must expose BrainBridge queue_depth + circuit_state."""
+        result = await tapps_server_info()
+        bb = result["data"].get("brain_bridge")
+        assert bb is not None
+        assert "initialized" in bb
+        if bb["initialized"]:
+            assert bb["circuit_state"] in {"open", "closed"}
+            assert isinstance(bb["queue_depth"], int)
+            assert isinstance(bb["queue_cap"], int)


### PR DESCRIPTION
## Summary

Closes [TAP-517](https://linear.app/tappscodingagents/issue/TAP-517).

Three changes, tied to one failure mode (writes silently dropped at the brain boundary):

1. **Queue overflow is no longer silent.** `_enqueue_write` emits a `brain_write_queue_full` structlog warning (with `queue_depth`, `queue_cap`, dropped `key`) when the offline queue is full. Before this, overflow just returned False and we lost the write without a trace.

2. **Shutdown drains the queue.** New `BrainBridge.drain_blocking(timeout)` synchronously drains queued writes under a bounded deadline (default 5s), bypassing `asyncio.to_thread` so it is safe from atexit / SIGTERM handlers where the event loop may be gone. `BrainBridge.close()` now runs the drain before closing the AgentBrain pool. `create_brain_bridge` registers both `atexit` and `SIGTERM` hooks (idempotent, tolerant of non-main-thread failures) so normal exit and `SIGTERM` both drain.

3. **Bridge state is visible in `tapps_server_info`.** New `bridge.status()` snapshot plus a non-blocking `_peek_brain_bridge` helper feed a `brain_bridge` field into the server_info response reporting `initialized`, `queue_depth`, `queue_cap`, `circuit_state`, and `failures`. The peek does not force Postgres init — if the bridge hasn't been initialized yet, the field just reports `{initialized: false}`.

## Test plan

- [x] New `packages/tapps-core/tests/unit/test_brain_bridge_shutdown.py` (16 tests): overflow warning, status keys, circuit_state transitions, drain_blocking happy path / timeout / store-exception counting, close() call-order ordering, atexit/SIGTERM registration idempotency + failure tolerance, integration of status with queued writes.
- [x] Added assertion to `tests/integration/test_mcp_handshake.py` that `tapps_server_info` exposes the `brain_bridge` field.
- [x] Full regression: 64 tapps-core brain_bridge tests pass, 77 tapps-mcp server_info/diagnostics/nudges tests pass.
- [x] `uv run ruff check --fix`, `ruff format`, `mypy --strict` all clean on changed files.
- [x] `tapps_validate_changed` quick mode — all 5 files pass gate + security.

## Notes for reviewer

The `server.py` and `server_helpers.py` diffs are large because ruff format normalized pre-existing formatting drift (frozenset literal line-wrapping) at the same time as my additions. The functional changes are the new `_brain_bridge_status_for_server_info` helper, its insertion into `_build_server_info_data`, and `_peek_brain_bridge` in server_helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)