### PR TITLE
[TAP-523] validate DSN + pool config at bridge startup

### DIFF
--- a/packages/tapps-core/src/tapps_core/brain_bridge.py
+++ b/packages/tapps-core/src/tapps_core/brain_bridge.py
@@ -65,9 +65,7 @@ class BrainBridge:
         self._brain = brain
         self._failures: int = 0
         self._open_at: float | None = None
-        self._write_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
-            maxsize=_WRITE_QUEUE_CAP
-        )
+        self._write_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_WRITE_QUEUE_CAP)
         self._drain_task: asyncio.Task[None] | None = None
 
     # -------------------------------------------------------------------------
@@ -381,9 +379,7 @@ class BrainBridge:
                     skipped_private += 1
                 else:
                     propagated += 1
-                    details.append(
-                        {"key": entry.key, "namespace": saved.get("namespace", "")}
-                    )
+                    details.append({"key": entry.key, "namespace": saved.get("namespace", "")})
 
             return {
                 "enabled": True,
@@ -469,9 +465,7 @@ class BrainBridge:
             }
 
         def _fn() -> dict[str, Any]:
-            entry = self._brain.store.save(
-                key, value, tier=tier, scope=scope, tags=tags, **kwargs
-            )
+            entry = self._brain.store.save(key, value, tier=tier, scope=scope, tags=tags, **kwargs)
             return self._to_dict(entry)
 
         result: dict[str, Any] = await self._call(_fn)
@@ -681,6 +675,94 @@ class BrainBridge:
         return self._brain.store
 
     # -------------------------------------------------------------------------
+    # Startup health check (TAP-523)
+    # -------------------------------------------------------------------------
+
+    def health_check(self) -> dict[str, Any]:
+        """Synchronously probe DSN reachability and pool config validity.
+
+        Intended to run once at MCP server startup so misconfiguration is
+        surfaced at session-start time rather than inside the first memory
+        tool call. Returns a structured report; callers decide whether to
+        fail fast based on ``ok``.
+
+        Checks performed:
+
+        1. DSN reachability — calls ``store.count()`` to force a connection.
+        2. Pool config validity — inspects the
+           ``TAPPS_BRAIN_PG_POOL_MAX_WAITING`` and
+           ``TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS`` env vars (if set)
+           and rejects non-integer / negative values.
+        3. Optional native health — calls ``store.health()`` when available
+           for extra diagnostics (current count, schema version, etc.).
+        """
+        errors: list[str] = []
+        warnings: list[str] = []
+        details: dict[str, Any] = {}
+
+        # --- DSN reachability ------------------------------------------------
+        dsn_reachable = False
+        try:
+            entry_count = self._brain.store.count()
+            dsn_reachable = True
+            details["entry_count"] = int(entry_count)
+        except Exception as exc:
+            errors.append(f"dsn_unreachable: {exc}")
+
+        # --- Pool config validity -------------------------------------------
+        pool_config_valid = True
+        for env_name in (
+            "TAPPS_BRAIN_PG_POOL_MAX_WAITING",
+            "TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS",
+        ):
+            raw = os.environ.get(env_name, "")
+            if not raw:
+                continue
+            try:
+                value = int(raw)
+            except ValueError:
+                errors.append(f"invalid_pool_config: {env_name}={raw!r} is not an integer")
+                pool_config_valid = False
+                continue
+            if value < 0:
+                errors.append(f"invalid_pool_config: {env_name}={value} must be >= 0")
+                pool_config_valid = False
+                continue
+            details[env_name.lower()] = value
+            if env_name == "TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS" and 0 < value < 30:
+                warnings.append(
+                    f"{env_name}={value}s is unusually short "
+                    "(connections will churn heavily; minimum 30s recommended)"
+                )
+
+        # --- Optional native health ------------------------------------------
+        native_health_ok = False
+        health_fn = getattr(self._brain.store, "health", None)
+        if callable(health_fn):
+            try:
+                raw_health = health_fn()
+                native_health_ok = True
+                if hasattr(raw_health, "model_dump"):
+                    details["native_health"] = raw_health.model_dump()
+                elif isinstance(raw_health, dict):
+                    details["native_health"] = raw_health
+                else:
+                    details["native_health"] = {"value": str(raw_health)}
+            except Exception as exc:
+                warnings.append(f"native_health_probe_failed: {exc}")
+
+        ok = not errors and dsn_reachable and pool_config_valid
+        return {
+            "ok": ok,
+            "dsn_reachable": dsn_reachable,
+            "pool_config_valid": pool_config_valid,
+            "native_health_ok": native_health_ok,
+            "errors": errors,
+            "warnings": warnings,
+            "details": details,
+        }
+
+    # -------------------------------------------------------------------------
     # Lifecycle
     # -------------------------------------------------------------------------
 
@@ -758,9 +840,7 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
     if pg_pool_max_waiting:
         os.environ["TAPPS_BRAIN_PG_POOL_MAX_WAITING"] = str(pg_pool_max_waiting)
     if pg_pool_max_lifetime_seconds:
-        os.environ["TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS"] = str(
-            pg_pool_max_lifetime_seconds
-        )
+        os.environ["TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS"] = str(pg_pool_max_lifetime_seconds)
 
     # --- Construct & probe ---------------------------------------------------
     try:
@@ -770,9 +850,27 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
             profile=profile,
             hive_dsn=hive_dsn,
         )
-        # Probe the store to fail fast on bad DSN before returning
-        brain.store.count()
-        return BrainBridge(brain)
     except Exception as exc:
         logger.warning("brain_bridge.init_failed", error=str(exc))
         return None
+
+    bridge = BrainBridge(brain)
+    # TAP-523: validate DSN reachability + pool config before returning so
+    # misconfiguration surfaces at startup rather than inside the first
+    # user-facing tool call.
+    report = bridge.health_check()
+    if not report["ok"]:
+        logger.warning(
+            "brain_bridge.health_check_failed",
+            errors=report["errors"],
+            warnings=report["warnings"],
+        )
+        with contextlib.suppress(Exception):
+            brain.close()
+        return None
+    if report["warnings"]:
+        logger.info(
+            "brain_bridge.health_check_warnings",
+            warnings=report["warnings"],
+        )
+    return bridge

--- a/packages/tapps-core/tests/unit/test_brain_bridge_health_check.py
+++ b/packages/tapps-core/tests/unit/test_brain_bridge_health_check.py
@@ -1,0 +1,172 @@
+"""TAP-523: BrainBridge.health_check and startup fail-fast coverage.
+
+Probes:
+
+* DSN reachability check via ``store.count()``.
+* Pool config validation of
+  ``TAPPS_BRAIN_PG_POOL_MAX_WAITING`` and
+  ``TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS`` env vars.
+* Optional ``store.health()`` native probe.
+* ``create_brain_bridge`` fails fast (returns None + logs) when health is bad.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_brain(*, count_raises: Exception | None = None, health: Any = None) -> MagicMock:
+    brain = MagicMock()
+    store = MagicMock()
+    if count_raises is not None:
+        store.count.side_effect = count_raises
+    else:
+        store.count.return_value = 7
+    if health is None:
+        store.health.return_value = MagicMock(
+            model_dump=lambda: {"store_available": True, "current_count": 7}
+        )
+    else:
+        store.health.return_value = health
+    brain.store = store
+    brain.hive = None
+    return brain
+
+
+@pytest.fixture
+def bridge() -> Any:
+    from tapps_core.brain_bridge import BrainBridge
+
+    return BrainBridge(_make_brain())
+
+
+class TestHealthCheckDSN:
+    def test_ok_when_store_count_succeeds(self, bridge: Any) -> None:
+        report = bridge.health_check()
+        assert report["ok"] is True
+        assert report["dsn_reachable"] is True
+        assert report["details"]["entry_count"] == 7
+        assert report["errors"] == []
+
+    def test_fails_when_store_count_raises(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        b = BrainBridge(_make_brain(count_raises=RuntimeError("connection refused")))
+        report = b.health_check()
+        assert report["ok"] is False
+        assert report["dsn_reachable"] is False
+        assert any("dsn_unreachable" in e for e in report["errors"])
+
+
+class TestHealthCheckPoolConfig:
+    def test_accepts_valid_pool_vars(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", "15")
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "600")
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is True
+        assert report["ok"] is True
+        assert report["details"]["tapps_brain_pg_pool_max_waiting"] == 15
+        assert report["details"]["tapps_brain_pg_pool_max_lifetime_seconds"] == 600
+
+    def test_rejects_non_integer(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", "abc")
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is False
+        assert report["ok"] is False
+        assert any("is not an integer" in e for e in report["errors"])
+
+    def test_rejects_negative(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "-5")
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is False
+        assert report["ok"] is False
+        assert any("must be >= 0" in e for e in report["errors"])
+
+    def test_warns_on_short_lifetime(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "10")
+        report = bridge.health_check()
+        assert report["ok"] is True  # still valid, just suspicious
+        assert any("unusually short" in w for w in report["warnings"])
+
+    def test_ignores_unset_env_vars(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", raising=False)
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", raising=False)
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is True
+
+
+class TestHealthCheckNativeProbe:
+    def test_native_health_ok_when_health_method_exists(self, bridge: Any) -> None:
+        report = bridge.health_check()
+        assert report["native_health_ok"] is True
+        assert "native_health" in report["details"]
+        assert report["details"]["native_health"]["store_available"] is True
+
+    def test_native_health_probe_failure_is_non_fatal(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        brain = _make_brain()
+        brain.store.health.side_effect = RuntimeError("rpc timeout")
+        b = BrainBridge(brain)
+
+        report = b.health_check()
+        assert report["ok"] is True  # native probe is advisory
+        assert report["native_health_ok"] is False
+        assert any("native_health_probe_failed" in w for w in report["warnings"])
+
+    def test_native_health_absent_is_non_fatal(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        brain = _make_brain()
+        del brain.store.health
+        b = BrainBridge(brain)
+
+        report = b.health_check()
+        assert report["ok"] is True
+        assert report["native_health_ok"] is False
+
+
+class TestCreateBrainBridgeStartupFailFast:
+    def test_returns_bridge_when_health_check_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://u:p@h/db")
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", raising=False)
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", raising=False)
+        from tapps_core.brain_bridge import BrainBridge, create_brain_bridge
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            result = create_brain_bridge(settings=None)
+        assert isinstance(result, BrainBridge)
+
+    def test_returns_none_when_health_check_dsn_unreachable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://bad/dsn")
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        bad_brain = _make_brain(count_raises=RuntimeError("cannot connect"))
+        with patch("tapps_brain.AgentBrain", return_value=bad_brain):
+            result = create_brain_bridge(settings=None)
+        assert result is None
+        # Ensure brain.close was called to release the just-constructed pool
+        bad_brain.close.assert_called_once()
+
+    def test_returns_none_when_pool_config_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://u:p@h/db")
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", "not-an-int")
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            result = create_brain_bridge(settings=None)
+        assert result is None
+
+    def test_proceeds_with_warnings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://u:p@h/db")
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "5")
+        from tapps_core.brain_bridge import BrainBridge, create_brain_bridge
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            result = create_brain_bridge(settings=None)
+        assert isinstance(result, BrainBridge)

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -50,8 +50,7 @@ def _current_docs_provider() -> dict[str, Any]:
     import os as _os
 
     has_key = bool(
-        _os.environ.get("TAPPS_MCP_CONTEXT7_API_KEY")
-        or _os.environ.get("CONTEXT7_API_KEY")
+        _os.environ.get("TAPPS_MCP_CONTEXT7_API_KEY") or _os.environ.get("CONTEXT7_API_KEY")
     )
     info: dict[str, Any] = {
         "primary": "context7" if has_key else "llmstxt",
@@ -59,10 +58,10 @@ def _current_docs_provider() -> dict[str, Any]:
     }
     if not has_key:
         info["hint"] = (
-            "Set TAPPS_MCP_CONTEXT7_API_KEY for richer docs via Context7. "
-            "https://context7.com"
+            "Set TAPPS_MCP_CONTEXT7_API_KEY for richer docs via Context7. https://context7.com"
         )
     return info
+
 
 # Maximum files to validate concurrently (balances speed vs subprocess pressure).
 _VALIDATE_CONCURRENCY = 10
@@ -136,9 +135,7 @@ class _ProgressTracker:
     completed: int = 0
     last_file: str = ""
     _sidecar_path: Path | None = dataclasses.field(default=None, repr=False)
-    _results: list[dict[str, Any]] = dataclasses.field(
-        default_factory=list, repr=False
-    )
+    _results: list[dict[str, Any]] = dataclasses.field(default_factory=list, repr=False)
     _started_at: str = dataclasses.field(default="", repr=False)
 
     def init_sidecar(self, project_root: Path) -> None:
@@ -149,11 +146,13 @@ class _ProgressTracker:
 
     def record_file_result(self, file_path: str, result: dict[str, Any]) -> None:
         """Record a completed file result and update the sidecar."""
-        self._results.append({
-            "file": file_path,
-            "score": result.get("overall_score", 0.0),
-            "gate_passed": result.get("gate_passed", False),
-        })
+        self._results.append(
+            {
+                "file": file_path,
+                "score": result.get("overall_score", 0.0),
+                "gate_passed": result.get("gate_passed", False),
+            }
+        )
         self._write_sidecar({"status": "running"})
 
     def finalize(
@@ -163,12 +162,14 @@ class _ProgressTracker:
         elapsed_ms: int,
     ) -> None:
         """Write final sidecar state with completed status."""
-        self._write_sidecar({
-            "status": "completed",
-            "all_gates_passed": all_passed,
-            "summary": summary,
-            "elapsed_ms": elapsed_ms,
-        })
+        self._write_sidecar(
+            {
+                "status": "completed",
+                "all_gates_passed": all_passed,
+                "summary": summary,
+                "elapsed_ms": elapsed_ms,
+            }
+        )
 
     def finalize_error(self, error: str) -> None:
         """Write error status to sidecar."""
@@ -188,9 +189,7 @@ class _ProgressTracker:
                 **extra,
             }
             self._sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-            self._sidecar_path.write_text(
-                _json.dumps(data, indent=2), encoding="utf-8"
-            )
+            self._sidecar_path.write_text(_json.dumps(data, indent=2), encoding="utf-8")
         except Exception:
             _logger.debug("sidecar_write_failed", exc_info=True)
 
@@ -506,9 +505,7 @@ def _build_structured_validation_output(
         _logger.debug("structured_output_failed: tapps_validate_changed", exc_info=True)
 
 
-def _resolve_security_depth(
-    security_depth: str, include_security: bool, quick: bool
-) -> bool:
+def _resolve_security_depth(security_depth: str, include_security: bool, quick: bool) -> bool:
     """Determine whether to run full security scanning."""
     return (security_depth == "full") or (include_security and not quick)
 
@@ -640,7 +637,10 @@ async def tapps_validate_changed(
 
     if not paths:
         return _handle_no_changed_files(
-            start, settings, _record_execution, _with_nudges,
+            start,
+            settings,
+            _record_execution,
+            _with_nudges,
             explicit_paths=bool(file_paths.strip()),
             base_ref=base_ref,
             correlation_id=correlation_id,
@@ -654,9 +654,7 @@ async def tapps_validate_changed(
     tracker = _ProgressTracker(total=total_files)
     tracker.init_sidecar(settings.project_root)
     stop_progress = asyncio.Event()
-    progress_task = _start_progress_reporting(
-        ctx, total_files, start, stop_progress, tracker
-    )
+    progress_task = _start_progress_reporting(ctx, total_files, start, stop_progress, tracker)
 
     auto_detect = not file_paths.strip()
     cached_results, uncached_paths = _partition_by_cache(paths)
@@ -673,9 +671,7 @@ async def tapps_validate_changed(
 
         tasks = [
             asyncio.create_task(
-                _validate_single_file(
-                    p, preset, quick, do_security_full, sem, tracker, ctx
-                )
+                _validate_single_file(p, preset, quick, do_security_full, sem, tracker, ctx)
             )
             for p in uncached_paths
         ]
@@ -702,9 +698,7 @@ async def tapps_validate_changed(
                     await asyncio.gather(*pending, return_exceptions=True)
             task_results = _collect_results(raw_results, completed_paths)
         elif tasks:
-            raw_results = list(
-                await asyncio.gather(*tasks, return_exceptions=True)
-            )
+            raw_results = list(await asyncio.gather(*tasks, return_exceptions=True))
             task_results = _collect_results(raw_results, uncached_paths)
         else:
             task_results = []
@@ -872,9 +866,7 @@ def _start_progress_reporting(
     if callable(report):
         with contextlib.suppress(Exception):
             # Fire initial progress via background task (store ref to prevent GC)
-            init_task = asyncio.create_task(
-                _report_initial_progress(report, total_files)
-            )
+            init_task = asyncio.create_task(_report_initial_progress(report, total_files))
             _background_tasks.add(init_task)
             init_task.add_done_callback(_background_tasks.discard)
     return asyncio.create_task(
@@ -1083,9 +1075,7 @@ def _enrich_memory_status_hints(
         project_root_str = str(settings.project_root)
         if any(p.project_root == project_root_str for p in config.projects):
             synced = sum(1 for e in entries if "federated" in (e.tags or []))
-            memory_status["federation_hint"] = (
-                f"hub_registered, {synced} synced entries"
-            )
+            memory_status["federation_hint"] = f"hub_registered, {synced} synced entries"
     except Exception:
         _logger.debug("memory_status_hints_failed", exc_info=True)
 
@@ -1134,9 +1124,7 @@ def _maybe_consolidation_scan(
         return None
 
     mem_settings = getattr(settings, "memory", None)
-    consolidation_settings = (
-        getattr(mem_settings, "consolidation", None) if mem_settings else None
-    )
+    consolidation_settings = getattr(mem_settings, "consolidation", None) if mem_settings else None
     scan_enabled = getattr(consolidation_settings, "scan_on_session_start", True)
     if not consolidation_settings or not scan_enabled:
         return None
@@ -1283,7 +1271,9 @@ async def _maybe_validate_memories(
             return {"ran": True, "validated": 0, "skipped": "no stale entries"}
 
         apply_result = await validator.apply_results(
-            report, store, dry_run=dry_run,
+            report,
+            store,
+            dry_run=dry_run,
         )
 
         _logger.info(
@@ -1348,6 +1338,29 @@ def _schedule_background_maintenance(
     task.add_done_callback(_background_tasks.discard)
 
 
+def _collect_brain_bridge_health() -> dict[str, Any]:
+    """TAP-523: run BrainBridge.health_check() at session start.
+
+    Reports DSN reachability and pool config validity. Non-blocking: probes
+    the cached BrainBridge singleton if available, otherwise reports
+    ``{enabled: False}``. Failures inside ``health_check`` surface as
+    ``ok: false`` with an ``errors`` list.
+    """
+    try:
+        from tapps_mcp.server_helpers import _get_brain_bridge
+
+        bridge = _get_brain_bridge()
+    except Exception as exc:
+        return {"enabled": False, "error": f"bridge_resolve_failed: {exc}"}
+    if bridge is None:
+        return {"enabled": False}
+    try:
+        report = bridge.health_check()
+    except Exception as exc:
+        return {"enabled": True, "ok": False, "errors": [f"health_check_raised: {exc}"]}
+    return {"enabled": True, **report}
+
+
 def _collect_memory_status(settings: Any) -> dict[str, Any]:
     """Collect memory subsystem status for session start."""
     status: dict[str, Any] = {"enabled": False}
@@ -1364,7 +1377,10 @@ def _collect_memory_status(settings: Any) -> dict[str, Any]:
         contradicted_count = sum(1 for entry in snapshot.entries if entry.contradicted)
 
         by_tier: dict[str, int] = {
-            "architectural": 0, "pattern": 0, "procedural": 0, "context": 0,
+            "architectural": 0,
+            "pattern": 0,
+            "procedural": 0,
+            "context": 0,
         }
         confidences: list[float] = []
         for entry in snapshot.entries:
@@ -1570,6 +1586,13 @@ async def tapps_session_start(
         _logger.debug("hive_status_check_failed", exc_info=True)
     timings["hive_status_ms"] = (time.perf_counter_ns() - phase_start) // 1_000_000
 
+    # TAP-523: surface BrainBridge health at startup so misconfiguration
+    # (bad DSN, invalid pool env vars) lands in session_start output instead
+    # of deep in the first memory tool call.
+    phase_start = time.perf_counter_ns()
+    brain_bridge_health = _collect_brain_bridge_health()
+    timings["brain_bridge_health_ms"] = (time.perf_counter_ns() - phase_start) // 1_000_000
+
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_session_start", start)
     timings["total_ms"] = elapsed_ms
@@ -1626,6 +1649,7 @@ async def tapps_session_start(
         "checklist_session_id": checklist_sid,
         "memory_status": memory_status,
         "hive_status": hive_status,
+        "brain_bridge_health": brain_bridge_health,
         "memory_gc": "background",
         "memory_consolidation": "background",
         "memory_doc_validation": "background",
@@ -2128,11 +2152,17 @@ async def tapps_upgrade(
         for plat_result in components.get("platforms", []):
             host = plat_result.get("host", "unknown")
             for comp_name, comp_val in plat_result.get("components", {}).items():
-                if (isinstance(comp_val, str) and comp_val in ("created", "updated", "regenerated")) or (isinstance(comp_val, dict) and comp_val.get("action") in (
-                    "created",
-                    "updated",
-                    "regenerated",
-                )):
+                if (
+                    isinstance(comp_val, str) and comp_val in ("created", "updated", "regenerated")
+                ) or (
+                    isinstance(comp_val, dict)
+                    and comp_val.get("action")
+                    in (
+                        "created",
+                        "updated",
+                        "regenerated",
+                    )
+                ):
                     await emit_ctx_info(ctx, f"Updated {host}/{comp_name}")
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
@@ -2252,8 +2282,7 @@ def tapps_set_engagement_level(level: str) -> dict[str, Any]:
             ],
             agent_instructions=AgentInstructions(
                 persona=(
-                    "You are a configuration assistant. Write the config "
-                    "file exactly as provided."
+                    "You are a configuration assistant. Write the config file exactly as provided."
                 ),
                 tool_preference="Use the Write tool to overwrite .tapps-mcp.yaml.",
                 verification_steps=[
@@ -2367,34 +2396,43 @@ async def tapps_pipeline(
         stage_start = time.perf_counter_ns()
         try:
             await ensure_session_initialized()
-            stages.append({
-                "name": "session_start",
-                "success": True,
-                "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
-                "summary": "session initialized",
-            })
+            stages.append(
+                {
+                    "name": "session_start",
+                    "success": True,
+                    "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
+                    "summary": "session initialized",
+                }
+            )
         except Exception as exc:
             pipeline_passed = False
-            stages.append({
-                "name": "session_start",
-                "success": False,
-                "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
-                "summary": f"session_start failed: {exc}",
-            })
+            stages.append(
+                {
+                    "name": "session_start",
+                    "success": False,
+                    "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
+                    "summary": f"session_start failed: {exc}",
+                }
+            )
 
     # Stage 2 — quick_check (batch).
     stage_start = time.perf_counter_ns()
     qc_resp = await tapps_quick_check(
-        file_path="", preset=preset, fix=False, file_paths=file_paths,
+        file_path="",
+        preset=preset,
+        fix=False,
+        file_paths=file_paths,
     )
     qc_data = qc_resp.get("data", {}) if isinstance(qc_resp, dict) else {}
     qc_passed = bool(qc_resp.get("success")) and not qc_data.get("security_floor_failed")
-    stages.append({
-        "name": "quick_check",
-        "success": qc_passed,
-        "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
-        "summary": _summarize_quick_check(qc_data),
-    })
+    stages.append(
+        {
+            "name": "quick_check",
+            "success": qc_passed,
+            "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
+            "summary": _summarize_quick_check(qc_data),
+        }
+    )
     if not qc_passed:
         pipeline_passed = False
     if qc_data.get("security_floor_failed"):
@@ -2406,24 +2444,28 @@ async def tapps_pipeline(
         vc_resp = await tapps_validate_changed(file_paths=file_paths, preset=preset)
         vc_data = vc_resp.get("data", {}) if isinstance(vc_resp, dict) else {}
         vc_passed = bool(vc_resp.get("success")) and bool(vc_data.get("all_passed", False))
-        stages.append({
-            "name": "validate_changed",
-            "success": vc_passed,
-            "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
-            "summary": (
-                f"{vc_data.get('passed_count', 0)} passed / "
-                f"{vc_data.get('failed_count', 0)} failed"
-            ),
-        })
+        stages.append(
+            {
+                "name": "validate_changed",
+                "success": vc_passed,
+                "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
+                "summary": (
+                    f"{vc_data.get('passed_count', 0)} passed / "
+                    f"{vc_data.get('failed_count', 0)} failed"
+                ),
+            }
+        )
         if not vc_passed:
             pipeline_passed = False
     else:
-        stages.append({
-            "name": "validate_changed",
-            "success": False,
-            "elapsed_ms": 0,
-            "summary": f"skipped ({short_circuit})",
-        })
+        stages.append(
+            {
+                "name": "validate_changed",
+                "success": False,
+                "elapsed_ms": 0,
+                "summary": f"skipped ({short_circuit})",
+            }
+        )
         pipeline_passed = False
 
     # Stage 4 — checklist (always runs, even on failure, for the report).
@@ -2434,22 +2476,26 @@ async def tapps_pipeline(
         cl_resp = await tapps_checklist(task_type=task_type, output_format="compact")
         cl_data = cl_resp.get("data", {}) if isinstance(cl_resp, dict) else {}
         cl_passed = bool(cl_resp.get("success")) and not cl_data.get("missing")
-        stages.append({
-            "name": "checklist",
-            "success": cl_passed,
-            "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
-            "summary": cl_data.get("compact_summary") or str(cl_data.get("status", "")),
-        })
+        stages.append(
+            {
+                "name": "checklist",
+                "success": cl_passed,
+                "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
+                "summary": cl_data.get("compact_summary") or str(cl_data.get("status", "")),
+            }
+        )
         if not cl_passed:
             pipeline_passed = False
     except Exception as exc:
         pipeline_passed = False
-        stages.append({
-            "name": "checklist",
-            "success": False,
-            "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
-            "summary": f"checklist failed: {exc}",
-        })
+        stages.append(
+            {
+                "name": "checklist",
+                "success": False,
+                "elapsed_ms": (time.perf_counter_ns() - stage_start) // 1_000_000,
+                "summary": f"checklist failed: {exc}",
+            }
+        )
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     data: dict[str, Any] = {
@@ -2466,10 +2512,7 @@ def _summarize_quick_check(qc_data: dict[str, Any]) -> str:
     """Compact one-line summary of a quick_check response."""
     if "batch" in qc_data:
         batch = qc_data["batch"]
-        return (
-            f"{batch.get('passed_count', 0)} passed / "
-            f"{batch.get('failed_count', 0)} failed"
-        )
+        return f"{batch.get('passed_count', 0)} passed / {batch.get('failed_count', 0)} failed"
     score = qc_data.get("score") or qc_data.get("overall_score")
     return f"score={score}" if score is not None else "ok"
 
@@ -2478,7 +2521,7 @@ def _summarize_quick_check(qc_data: dict[str, Any]) -> str:
 # tapps_decompose — task decomposition into 15-minute units (TAP-479)
 # ---------------------------------------------------------------------------
 
-from pydantic import BaseModel as _BaseModel  # noqa: E402 (local alias)
+from pydantic import BaseModel as _BaseModel
 
 # Model tier keyword sets (order matters — checked from highest to lowest tier)
 _OPUS_KEYWORDS = frozenset(
@@ -2493,8 +2536,19 @@ _HAIKU_KEYWORDS = frozenset(
 
 # Risk classification keywords
 _HIGH_RISK_KEYWORDS = frozenset(
-    {"security", "auth", "payment", "database", "migration", "deploy", "delete", "remove",
-     "architect", "design", "threat"}
+    {
+        "security",
+        "auth",
+        "payment",
+        "database",
+        "migration",
+        "deploy",
+        "delete",
+        "remove",
+        "architect",
+        "design",
+        "threat",
+    }
 )
 _LOW_RISK_KEYWORDS = frozenset(
     {"read", "search", "list", "format", "display", "show", "grep", "find"}
@@ -2670,7 +2724,9 @@ def register(mcp_instance: FastMCP, allowed_tools: frozenset[str]) -> None:
     if "tapps_init" in allowed_tools:
         mcp_instance.tool(annotations=_ANNOTATIONS_SIDE_EFFECT_IDEMPOTENT)(tapps_init)
     if "tapps_set_engagement_level" in allowed_tools:
-        mcp_instance.tool(annotations=_ANNOTATIONS_SIDE_EFFECT_IDEMPOTENT)(tapps_set_engagement_level)
+        mcp_instance.tool(annotations=_ANNOTATIONS_SIDE_EFFECT_IDEMPOTENT)(
+            tapps_set_engagement_level
+        )
     if "tapps_upgrade" in allowed_tools:
         mcp_instance.tool(annotations=_ANNOTATIONS_SIDE_EFFECT_IDEMPOTENT)(tapps_upgrade)
     if "tapps_doctor" in allowed_tools:


### PR DESCRIPTION
## Summary

Closes [TAP-523](https://linear.app/tappscodingagents/issue/TAP-523).

Previously, bad pool env vars or an unreachable DSN would only surface on the first user-visible memory tool call. This PR adds `BrainBridge.health_check()` which synchronously probes:

1. **DSN reachability** — `store.count()` probe. Fails if the DSN can't open a connection.
2. **Pool config validity** — inspects `TAPPS_BRAIN_PG_POOL_MAX_WAITING` and `TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS` env vars. Rejects non-integer or negative values. Warns on suspiciously short lifetimes (< 30s).
3. **Optional native health** — calls `store.health()` when available for richer diagnostics (count, schema version, tier distribution).

Return shape:
```python
{
  "ok": bool,
  "dsn_reachable": bool,
  "pool_config_valid": bool,
  "native_health_ok": bool,
  "errors": [str, ...],
  "warnings": [str, ...],
  "details": {...},
}
```

### Wiring

- `create_brain_bridge` replaces the bare `store.count()` probe with `health_check()`. On `ok=False` it logs `brain_bridge.health_check_failed`, closes the half-initialized brain, and returns `None` — preserving backward-compat None-on-failure semantics while surfacing structured errors.
- `tapps_session_start` adds a top-level `brain_bridge_health` field populated from a fresh `health_check()` run. Operators see pool misconfig at session-start time.

## Test plan

- [x] `packages/tapps-core/tests/unit/test_brain_bridge_health_check.py` — 14 new tests:
  - DSN reachability OK / raises
  - Pool config: valid / non-int / negative / short-lifetime warn / unset
  - Native probe: ok / raises (non-fatal) / absent (non-fatal)
  - Factory fail-fast: returns bridge on OK; returns None + calls brain.close on bad DSN; returns None on bad pool config; proceeds on warnings
- [x] Full regression: 62/62 tapps-core brain_bridge tests pass, 118/118 session_start/pipeline tests pass.
- [x] `uv run ruff check --fix` + `ruff format` + `mypy --strict` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)