### PR TITLE
release: v2.9.0 — Karpathy guidelines vendored into init/upgrade/doctor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,3 +359,80 @@ The bare `mcp__tapps-mcp` entry is needed as a reliable fallback - the wildcard 
 
 ---
 
+<!-- BEGIN: karpathy-guidelines c9a44ae (MIT, forrestchang/andrej-karpathy-skills) -->
+<!--
+  Vendored from https://github.com/forrestchang/andrej-karpathy-skills
+  Pinned commit: c9a44ae835fa2f5765a697216692705761a53f40 (2026-04-15)
+  License: MIT (c) forrestchang
+  Do not edit by hand — update KARPATHY_GUIDELINES_SOURCE_SHA in prompt_loader.py
+  and re-run the vendor script, then bump tapps-mcp version.
+-->
+## Karpathy Behavioral Guidelines
+
+> Source: https://github.com/forrestchang/andrej-karpathy-skills @ c9a44ae835fa2f5765a697216692705761a53f40 (MIT)
+> Derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+<!-- END: karpathy-guidelines -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-04-17
+
+### Added
+
+- **Karpathy behavioral guidelines** vendored into the package and installed into consuming projects by `tapps_init` / refreshed by `tapps_upgrade` / verified by `tapps_doctor`. Content pinned to [`forrestchang/andrej-karpathy-skills@c9a44ae`](https://github.com/forrestchang/andrej-karpathy-skills/commit/c9a44ae835fa2f5765a697216692705761a53f40) (MIT). Four principles — Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution — appended to both `AGENTS.md` and `CLAUDE.md` between idempotent BEGIN/END HTML-comment markers. Files that don't exist are skipped (never created by the block installer). Content outside the markers is preserved byte-for-byte; re-runs are no-ops once the SHA matches.
+- **`tapps_init(include_karpathy=True)`** (default-on). Set to `False` to opt out. After writing AGENTS.md and running platform bootstrap, `_install_karpathy_blocks` calls `karpathy_block.install_or_refresh` on both `AGENTS.md` and `CLAUDE.md`; reports per-file actions (`added` / `refreshed` / `unchanged` / `skipped_file_missing`) under `result["karpathy_guidelines"]["files"]`.
+- **`tapps_upgrade`** gains `_refresh_karpathy_blocks`, which runs after per-host platform upgrades so a platform-generated CLAUDE.md gets the refresh. Reuses the existing pre-upgrade backup. When the vendored SHA bumps, old blocks are replaced between their markers; surrounding user content is preserved.
+- **`tapps_doctor`** gains `check_karpathy_guidelines`, which inspects both `AGENTS.md` and `CLAUDE.md`. Passes when every existing file carries the block pinned to the current SHA; fails when any existing file is missing the block or pinned to a stale SHA (reporting which file and which SHA, e.g. `CLAUDE.md@deadbee`).
+- New module [`tapps_mcp.pipeline.karpathy_block`](packages/tapps-mcp/src/tapps_mcp/pipeline/karpathy_block.py) — `install_or_refresh(path)` (the sole write path) and `check(path)` (read-only doctor inspection). Marker-based identity; never creates files; never touches content outside markers.
+- Vendored source: [`packages/tapps-mcp/src/tapps_mcp/prompts/karpathy_guidelines.md`](packages/tapps-mcp/src/tapps_mcp/prompts/karpathy_guidelines.md). Pinned via `KARPATHY_GUIDELINES_SOURCE_SHA` in `prompt_loader.py`.
+
+### Changed
+
+- Version bump: tapps-core 2.8.0 → 2.9.0, tapps-mcp 2.8.0 → 2.9.0, docs-mcp 2.8.0 → 2.9.0.
+
 ## [2.8.0] - 2026-04-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,3 +207,74 @@ consider designating one teammate as a **quality watchdog**. To enable Agent Tea
 ## CI Integration
 
 TappsMCP can run in CI. Use `TAPPS_MCP_PROJECT_ROOT` and `tapps-mcp validate-changed --preset staging`, or Claude Code headless mode with `tapps_validate_changed`.
+
+<!-- BEGIN: karpathy-guidelines c9a44ae (MIT, forrestchang/andrej-karpathy-skills) -->
+## Karpathy Behavioral Guidelines
+
+> Source: https://github.com/forrestchang/andrej-karpathy-skills @ c9a44ae835fa2f5765a697216692705761a53f40 (MIT)
+> Derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+<!-- END: karpathy-guidelines -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,13 @@ consider designating one teammate as a **quality watchdog**. To enable Agent Tea
 TappsMCP can run in CI. Use `TAPPS_MCP_PROJECT_ROOT` and `tapps-mcp validate-changed --preset staging`, or Claude Code headless mode with `tapps_validate_changed`.
 
 <!-- BEGIN: karpathy-guidelines c9a44ae (MIT, forrestchang/andrej-karpathy-skills) -->
+<!--
+  Vendored from https://github.com/forrestchang/andrej-karpathy-skills
+  Pinned commit: c9a44ae835fa2f5765a697216692705761a53f40 (2026-04-15)
+  License: MIT (c) forrestchang
+  Do not edit by hand — update KARPATHY_GUIDELINES_SOURCE_SHA in prompt_loader.py
+  and re-run the vendor script, then bump tapps-mcp version.
+-->
 ## Karpathy Behavioral Guidelines
 
 > Source: https://github.com/forrestchang/andrej-karpathy-skills @ c9a44ae835fa2f5765a697216692705761a53f40 (MIT)

--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ The MCP tool version has all CLI options plus additional parameters for fine-gra
 | `warm_expert_rag_from_tech_stack` | bool | `true` | Pre-build expert RAG indices for relevant domains. |
 | `install_missing_checkers` | bool | `false` | Auto-install missing ruff/mypy/bandit/radon. |
 | `scaffold_experts` | bool | `false` | Generate business expert scaffolding. |
+| `include_karpathy` | bool | `true` | Append the vendored [Karpathy behavioral guidelines](https://github.com/forrestchang/andrej-karpathy-skills) (MIT) to AGENTS.md between idempotent markers. Set to `false` to opt out. `tapps_upgrade` refreshes the block when the vendored SHA changes; `tapps_doctor` reports `ok`/`stale`/`missing`. |
 | `mcp_config` | bool | `false` | Write MCP config file only (no other files). |
 | `output_mode` | str | `"auto"` | `"auto"` (write or return), `"content_return"` (always return file content), `"direct_write"` (always write). |
 | `verify_only` | bool | `false` | Check which external checkers are installed. |
@@ -591,7 +592,7 @@ tapps-mcp doctor
 tapps-mcp doctor --project-root /path/to/project
 ```
 
-Checks: MCP config, AGENTS.md, `.claude/settings.json` permissions, hooks, installed checkers, tapps-brain, memory pipeline flags (informational), dual-memory-server warning.
+Checks: MCP config, AGENTS.md, Karpathy guidelines block freshness, `.claude/settings.json` permissions, hooks, installed checkers, tapps-brain, memory pipeline flags (informational), dual-memory-server warning.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ The MCP tool version has all CLI options plus additional parameters for fine-gra
 | `warm_expert_rag_from_tech_stack` | bool | `true` | Pre-build expert RAG indices for relevant domains. |
 | `install_missing_checkers` | bool | `false` | Auto-install missing ruff/mypy/bandit/radon. |
 | `scaffold_experts` | bool | `false` | Generate business expert scaffolding. |
-| `include_karpathy` | bool | `true` | Append the vendored [Karpathy behavioral guidelines](https://github.com/forrestchang/andrej-karpathy-skills) (MIT) to AGENTS.md between idempotent markers. Set to `false` to opt out. `tapps_upgrade` refreshes the block when the vendored SHA changes; `tapps_doctor` reports `ok`/`stale`/`missing`. |
+| `include_karpathy` | bool | `true` | Append the vendored [Karpathy behavioral guidelines](https://github.com/forrestchang/andrej-karpathy-skills) (MIT) to AGENTS.md and CLAUDE.md between idempotent BEGIN/END markers — content outside the markers is preserved. Both files are append/update only, never replaced. Set to `false` to opt out. `tapps_upgrade` refreshes the block when the vendored SHA changes; `tapps_doctor` reports `ok`/`stale`/`missing` per file. |
 | `mcp_config` | bool | `false` | Write MCP config file only (no other files). |
 | `output_mode` | str | `"auto"` | `"auto"` (write or return), `"content_return"` (always return file content), `"direct_write"` (always write). |
 | `verify_only` | bool | `false` | Check which external checkers are installed. |

--- a/packages/docs-mcp/pyproject.toml
+++ b/packages/docs-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docs-mcp"
-version = "2.8.0"
+version = "2.9.0"
 description = "MCP server for automated documentation generation, validation, and maintenance"
 readme = "docs/README.md"
 license = "MIT"

--- a/packages/docs-mcp/tests/conftest.py
+++ b/packages/docs-mcp/tests/conftest.py
@@ -10,6 +10,15 @@ from pathlib import Path
 
 import pytest
 
+# Preload ``docs_mcp.server`` so that tests which import submodules first
+# (e.g. ``from docs_mcp.server_gen_tools import ...``) don't trigger a
+# circular-import failure. ``server.py`` calls ``_register_tool_modules()``
+# during its own import, which re-imports each submodule; if a submodule
+# is mid-init it returns a partial module and ``.register`` is undefined.
+# Importing ``docs_mcp.server`` at conftest load time guarantees the full
+# registration completes before any test-order variation can wedge it.
+import docs_mcp.server  # noqa: F401
+
 
 @pytest.fixture(autouse=True)
 def _reset_caches() -> Generator[None, None, None]:

--- a/packages/tapps-core/pyproject.toml
+++ b/packages/tapps-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-core"
-version = "2.8.0"
+version = "2.9.0"
 description = "Shared infrastructure library for Tapps platform (config, security, logging, knowledge, memory, metrics)"
 license = "MIT"
 requires-python = ">=3.12"

--- a/packages/tapps-mcp/pyproject.toml
+++ b/packages/tapps-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-mcp"
-version = "2.8.0"
+version = "2.9.0"
 description = "MCP server providing deterministic code quality tools for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -444,6 +444,46 @@ def check_agents_md(project_root: Path) -> CheckResult:
     )
 
 
+def check_karpathy_guidelines(project_root: Path) -> CheckResult:
+    """Check that the Karpathy guidelines block in AGENTS.md matches the vendored SHA."""
+    from tapps_mcp.pipeline import karpathy_block
+
+    agents_md = project_root / "AGENTS.md"
+    report = karpathy_block.check(agents_md)
+    state = report["state"]
+    expected_sha = report["expected_sha"] or ""
+    expected_short = expected_sha[:7]
+
+    if state == "ok":
+        return CheckResult(
+            "Karpathy guidelines",
+            True,
+            f"Karpathy guidelines block present and pinned to {expected_short}",
+        )
+    if state == "file_absent":
+        return CheckResult(
+            "Karpathy guidelines",
+            False,
+            "AGENTS.md not found — block cannot be installed",
+            "Run: tapps_init",
+        )
+    if state == "missing":
+        return CheckResult(
+            "Karpathy guidelines",
+            False,
+            "Karpathy guidelines block not present in AGENTS.md",
+            "Run: tapps_upgrade (or tapps_init with include_karpathy=True)",
+        )
+    # stale
+    current = report["current_sha"] or "unknown"
+    return CheckResult(
+        "Karpathy guidelines",
+        False,
+        f"Karpathy guidelines block is pinned to {current} but vendored SHA is {expected_short}",
+        "Run: tapps_upgrade",
+    )
+
+
 def check_claude_settings(project_root: Path) -> CheckResult:
     """Check ``.claude/settings.json`` for permissions and hook schema validity.
 
@@ -1118,6 +1158,7 @@ def _collect_checks(root: Path, *, quick: bool = False) -> list[CheckResult]:
     checks.append(check_claude_md(root))
     checks.append(check_cursor_rules(root))
     checks.append(check_agents_md(root))
+    checks.append(check_karpathy_guidelines(root))
     checks.append(check_claude_settings(root))
     checks.append(check_claude_hook_scripts(root))
     checks.append(check_hooks(root))

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -445,42 +445,61 @@ def check_agents_md(project_root: Path) -> CheckResult:
 
 
 def check_karpathy_guidelines(project_root: Path) -> CheckResult:
-    """Check that the Karpathy guidelines block in AGENTS.md matches the vendored SHA."""
+    """Check the Karpathy guidelines block across AGENTS.md and CLAUDE.md.
+
+    - Passes when every file that exists carries the block pinned to the
+      vendored SHA.
+    - Passes (informational) when neither file exists.
+    - Fails when any existing file is missing the block or is pinned to a
+      stale SHA.
+    """
     from tapps_mcp.pipeline import karpathy_block
 
-    agents_md = project_root / "AGENTS.md"
-    report = karpathy_block.check(agents_md)
-    state = report["state"]
-    expected_sha = report["expected_sha"] or ""
+    reports: dict[str, dict[str, str | None]] = {
+        rel: karpathy_block.check(project_root / rel) for rel in ("AGENTS.md", "CLAUDE.md")
+    }
+    expected_sha = karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA
     expected_short = expected_sha[:7]
 
-    if state == "ok":
+    existing = {rel: r for rel, r in reports.items() if r["state"] != "file_absent"}
+    if not existing:
+        return CheckResult(
+            "Karpathy guidelines",
+            False,
+            "Neither AGENTS.md nor CLAUDE.md found — block cannot be installed",
+            "Run: tapps_init",
+        )
+
+    stale: list[str] = []
+    missing: list[str] = []
+    ok: list[str] = []
+    for rel, rep in existing.items():
+        state = rep["state"]
+        if state == "ok":
+            ok.append(rel)
+        elif state == "missing":
+            missing.append(rel)
+        elif state == "stale":
+            current = rep["current_sha"] or "unknown"
+            stale.append(f"{rel}@{current}")
+
+    if not missing and not stale:
         return CheckResult(
             "Karpathy guidelines",
             True,
-            f"Karpathy guidelines block present and pinned to {expected_short}",
+            f"Karpathy guidelines block present in {', '.join(ok)}; pinned to {expected_short}",
         )
-    if state == "file_absent":
-        return CheckResult(
-            "Karpathy guidelines",
-            False,
-            "AGENTS.md not found — block cannot be installed",
-            "Run: tapps_init",
-        )
-    if state == "missing":
-        return CheckResult(
-            "Karpathy guidelines",
-            False,
-            "Karpathy guidelines block not present in AGENTS.md",
-            "Run: tapps_upgrade (or tapps_init with include_karpathy=True)",
-        )
-    # stale
-    current = report["current_sha"] or "unknown"
+
+    parts: list[str] = []
+    if missing:
+        parts.append(f"missing in: {', '.join(missing)}")
+    if stale:
+        parts.append(f"stale ({', '.join(stale)}; expected {expected_short})")
     return CheckResult(
         "Karpathy guidelines",
         False,
-        f"Karpathy guidelines block is pinned to {current} but vendored SHA is {expected_short}",
-        "Run: tapps_upgrade",
+        "; ".join(parts),
+        "Run: tapps_upgrade (or tapps_init with include_karpathy=True)",
     )
 
 

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
@@ -1388,6 +1388,19 @@ def _format_upgrade_result(result: dict[str, Any], *, dry_run: bool = False) -> 
     color = "green" if agents_action == "up-to-date" else "yellow"
     click.echo(click.style(f"  AGENTS.md: {agents_text}", fg=color))
 
+    # Karpathy guidelines block (AGENTS.md + CLAUDE.md)
+    kp = result.get("components", {}).get("karpathy_guidelines", {})
+    if kp:
+        click.echo("")
+        click.echo(click.style("--- Karpathy guidelines ---", bold=True))
+        sha = (kp.get("source_sha") or "")[:7]
+        ok_actions = {"unchanged", "added", "refreshed", "skipped_file_missing"}
+        for rel, action in (kp.get("files") or {}).items():
+            fg = "green" if action in ok_actions else "yellow"
+            click.echo(click.style(f"  {rel}: {action}", fg=fg))
+        if sha:
+            click.echo(f"  pinned to: {sha}")
+
     # Per-platform results
     platforms: list[dict[str, Any]] = result.get("components", {}).get("platforms", [])
     for platform in platforms:

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/init.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/init.py
@@ -74,6 +74,7 @@ class BootstrapConfig:
     llm_engagement_level: str = "medium"
     scaffold_experts: bool = False
     docs_automation: bool = True
+    include_karpathy: bool = True
 
     @classmethod
     def from_params(
@@ -243,6 +244,7 @@ def bootstrap_pipeline(
     verify_only: bool = False,
     llm_engagement_level: str | None = None,
     scaffold_experts: bool = False,
+    include_karpathy: bool = True,
 ) -> dict[str, Any]:
     """Create pipeline template files in the project.
 
@@ -285,6 +287,7 @@ def bootstrap_pipeline(
             verify_only=verify_only,
             llm_engagement_level=llm_engagement_level,
             scaffold_experts=scaffold_experts,
+            include_karpathy=include_karpathy,
         )
     # Determine write mode: direct (local) or content-return (Docker/read-only)
     resolved_root = project_root.resolve()
@@ -619,6 +622,21 @@ def _create_agents_md(cfg: BootstrapConfig, state: _BootstrapState) -> None:
     else:
         state.safe_write("AGENTS.md", template_content)
         state.result["agents_md"] = {"action": "created", "version": __version__}
+
+    if cfg.include_karpathy and not state.content_return and agents_path.exists():
+        from tapps_mcp.pipeline import karpathy_block
+
+        try:
+            action = karpathy_block.install_or_refresh(agents_path, dry_run=cfg.dry_run)
+            state.result["karpathy_guidelines"] = {
+                "action": action,
+                "source_sha": karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA,
+            }
+        except Exception as exc:
+            state.errors.append(f"Karpathy guidelines install failed: {exc}")
+            state.result["karpathy_guidelines"] = {"action": "error", "reason": str(exc)}
+    elif not cfg.include_karpathy:
+        state.result["karpathy_guidelines"] = {"action": "skipped", "reason": "disabled"}
 
 
 def _generate_platform_file_ops(cfg: BootstrapConfig, state: _BootstrapState) -> None:

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/init.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/init.py
@@ -335,6 +335,7 @@ def bootstrap_pipeline(
         }
     elif not cfg.dry_run:
         _setup_platform(cfg, state)
+        _install_karpathy_blocks(cfg, state)
         # Ensure Claude Code permissions even when platform != "claude",
         # if the .claude/ directory already exists (user is in Claude Code).
         if cfg.platform != "claude" and (state.project_root / ".claude").is_dir():
@@ -623,20 +624,41 @@ def _create_agents_md(cfg: BootstrapConfig, state: _BootstrapState) -> None:
         state.safe_write("AGENTS.md", template_content)
         state.result["agents_md"] = {"action": "created", "version": __version__}
 
-    if cfg.include_karpathy and not state.content_return and agents_path.exists():
-        from tapps_mcp.pipeline import karpathy_block
 
-        try:
-            action = karpathy_block.install_or_refresh(agents_path, dry_run=cfg.dry_run)
-            state.result["karpathy_guidelines"] = {
-                "action": action,
-                "source_sha": karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA,
-            }
-        except Exception as exc:
-            state.errors.append(f"Karpathy guidelines install failed: {exc}")
-            state.result["karpathy_guidelines"] = {"action": "error", "reason": str(exc)}
-    elif not cfg.include_karpathy:
+def _install_karpathy_blocks(cfg: BootstrapConfig, state: _BootstrapState) -> None:
+    """Install or refresh the Karpathy guidelines block in AGENTS.md and CLAUDE.md.
+
+    Both files are only ever appended-to (between BEGIN/END markers); content
+    outside the markers is preserved. Skips files that don't exist — this
+    function runs after ``_create_templates`` (which may create AGENTS.md)
+    and ``_setup_platform`` (which may create CLAUDE.md), so whichever
+    file(s) the consumer's project has will be covered.
+    """
+    if not cfg.include_karpathy:
         state.result["karpathy_guidelines"] = {"action": "skipped", "reason": "disabled"}
+        return
+    if state.content_return:
+        state.result["karpathy_guidelines"] = {"action": "skipped", "reason": "content_return"}
+        return
+
+    from tapps_mcp.pipeline import karpathy_block
+
+    per_file: dict[str, str] = {}
+    for rel in ("AGENTS.md", "CLAUDE.md"):
+        target = state.project_root / rel
+        if not target.exists():
+            per_file[rel] = "skipped_file_missing"
+            continue
+        try:
+            per_file[rel] = karpathy_block.install_or_refresh(target, dry_run=cfg.dry_run)
+        except Exception as exc:
+            per_file[rel] = "error"
+            state.errors.append(f"Karpathy guidelines install failed for {rel}: {exc}")
+
+    state.result["karpathy_guidelines"] = {
+        "source_sha": karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA,
+        "files": per_file,
+    }
 
 
 def _generate_platform_file_ops(cfg: BootstrapConfig, state: _BootstrapState) -> None:

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/karpathy_block.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/karpathy_block.py
@@ -1,0 +1,145 @@
+"""Install, refresh, and inspect the vendored Karpathy guidelines block.
+
+The block is a fixed chunk of markdown (vendored under
+``prompts/karpathy_guidelines.md``) that `tapps_init` appends to AGENTS.md
+and `tapps_upgrade` refreshes in place. Both operations key off two HTML
+comment markers so we can rewrite between them without touching anything
+outside — and so `tapps_doctor` can report whether the block is present
+and pinned to the current source SHA.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Literal
+
+from tapps_mcp.prompts.prompt_loader import (
+    KARPATHY_GUIDELINES_MARKER_BEGIN,
+    KARPATHY_GUIDELINES_MARKER_END,
+    KARPATHY_GUIDELINES_SOURCE_SHA,
+    load_karpathy_guidelines,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+Action = Literal["added", "refreshed", "unchanged", "skipped_file_missing"]
+DoctorState = Literal["ok", "stale", "missing", "file_absent"]
+
+_SHA_RE = re.compile(r"<!--\s*BEGIN:\s*karpathy-guidelines\s+([0-9a-f]{7,40})\b")
+
+
+def _find_block_span(content: str) -> tuple[int, int] | None:
+    """Return ``(begin_idx, end_idx_exclusive)`` for the block, or ``None``.
+
+    ``begin_idx`` points at the start of the BEGIN marker; ``end_idx`` is
+    just past the END marker so ``content[begin:end]`` is the full block.
+    Matching uses the marker *prefix* up to the SHA placeholder, so blocks
+    vendored under older SHAs are still found (and thus refreshable).
+    """
+    begin_prefix = "<!-- BEGIN: karpathy-guidelines"
+    begin = content.find(begin_prefix)
+    if begin == -1:
+        return None
+    end_marker_idx = content.find(KARPATHY_GUIDELINES_MARKER_END, begin)
+    if end_marker_idx == -1:
+        return None
+    return begin, end_marker_idx + len(KARPATHY_GUIDELINES_MARKER_END)
+
+
+def _extract_sha(content: str) -> str | None:
+    """Return the SHA recorded in the BEGIN marker, or ``None`` if absent."""
+    match = _SHA_RE.search(content)
+    return match.group(1) if match else None
+
+
+def install_or_refresh(path: Path, *, dry_run: bool = False) -> Action:
+    """Install the Karpathy block into *path*, or refresh an outdated copy.
+
+    - If *path* does not exist: returns ``"skipped_file_missing"``.
+    - If the block is absent: appends it after a blank line; returns ``"added"``.
+    - If the block exists with the current SHA and identical content:
+      returns ``"unchanged"``.
+    - Otherwise: replaces the block between its markers; returns ``"refreshed"``.
+
+    When ``dry_run=True``, computes the outcome without touching the file.
+    """
+    if not path.exists():
+        return "skipped_file_missing"
+
+    original = path.read_text(encoding="utf-8")
+    new_block = load_karpathy_guidelines()
+    span = _find_block_span(original)
+
+    if span is None:
+        separator = (
+            "" if original.endswith("\n\n") else ("\n" if original.endswith("\n") else "\n\n")
+        )
+        updated = f"{original}{separator}{new_block}\n"
+        action: Action = "added"
+    else:
+        begin, end = span
+        existing_block = original[begin:end]
+        if existing_block == new_block:
+            return "unchanged"
+        updated = original[:begin] + new_block + original[end:]
+        action = "refreshed"
+
+    if not dry_run:
+        path.write_text(updated, encoding="utf-8")
+    return action
+
+
+def check(path: Path) -> dict[str, str | None]:
+    """Return a doctor-style report on the block in *path*.
+
+    Keys:
+        state: ``"ok"`` | ``"stale"`` | ``"missing"`` | ``"file_absent"``
+        current_sha: SHA recorded in the file's marker, or ``None``
+        expected_sha: The currently vendored SHA
+        hint: Human-readable next-step suggestion (always present)
+    """
+    expected = KARPATHY_GUIDELINES_SOURCE_SHA
+    if not path.exists():
+        return {
+            "state": "file_absent",
+            "current_sha": None,
+            "expected_sha": expected,
+            "hint": f"{path.name} not found — run tapps_init to create it.",
+        }
+
+    content = path.read_text(encoding="utf-8")
+    if _find_block_span(content) is None:
+        return {
+            "state": "missing",
+            "current_sha": None,
+            "expected_sha": expected,
+            "hint": "Karpathy guidelines block not found — run tapps_upgrade to install it.",
+        }
+
+    current = _extract_sha(content)
+    if current and expected.startswith(current):
+        return {
+            "state": "ok",
+            "current_sha": current,
+            "expected_sha": expected,
+            "hint": "Karpathy guidelines block is up to date.",
+        }
+    return {
+        "state": "stale",
+        "current_sha": current,
+        "expected_sha": expected,
+        "hint": "Karpathy guidelines block is pinned to an older SHA — run tapps_upgrade to refresh.",
+    }
+
+
+__all__ = [
+    "KARPATHY_GUIDELINES_MARKER_BEGIN",
+    "KARPATHY_GUIDELINES_MARKER_END",
+    "KARPATHY_GUIDELINES_SOURCE_SHA",
+    "Action",
+    "DoctorState",
+    "check",
+    "install_or_refresh",
+]

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
@@ -33,6 +33,7 @@ def _upgrade_agents_md(
 
     Returns a result dict with ``action`` and optional ``detail``.
     """
+    from tapps_mcp.pipeline import karpathy_block
     from tapps_mcp.pipeline.agents_md import AgentsValidation, update_agents_md
     from tapps_mcp.prompts.prompt_loader import load_agents_template
 
@@ -42,24 +43,35 @@ def _upgrade_agents_md(
     if not agents_path.exists():
         if not dry_run:
             agents_path.write_text(template_content, encoding="utf-8")
-        return {"action": "created"}
+        result: dict[str, Any] = {"action": "created"}
+    else:
+        validation = AgentsValidation(agents_path.read_text(encoding="utf-8"))
+        if validation.is_up_to_date:
+            result = {"action": "up-to-date"}
+        else:
+            issues: list[str] = []
+            if validation.sections_missing:
+                issues.append(f"missing sections: {', '.join(validation.sections_missing)}")
+            if validation.tools_missing:
+                issues.append(f"missing tools: {', '.join(validation.tools_missing)}")
+            detail = "; ".join(issues) or "version mismatch"
 
-    validation = AgentsValidation(agents_path.read_text(encoding="utf-8"))
-    if validation.is_up_to_date:
-        return {"action": "up-to-date"}
+            if dry_run:
+                result = {"action": "needs-update", "detail": detail}
+            else:
+                action, merge_detail = update_agents_md(agents_path, template_content)
+                result = {"action": action, "detail": merge_detail or detail}
 
-    issues: list[str] = []
-    if validation.sections_missing:
-        issues.append(f"missing sections: {', '.join(validation.sections_missing)}")
-    if validation.tools_missing:
-        issues.append(f"missing tools: {', '.join(validation.tools_missing)}")
-    detail = "; ".join(issues) or "version mismatch"
+    try:
+        kp_action = karpathy_block.install_or_refresh(agents_path, dry_run=dry_run)
+        result["karpathy_guidelines"] = {
+            "action": kp_action,
+            "source_sha": karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA,
+        }
+    except Exception as exc:
+        result["karpathy_guidelines"] = {"action": "error", "reason": str(exc)}
 
-    if dry_run:
-        return {"action": "needs-update", "detail": detail}
-
-    action, merge_detail = update_agents_md(agents_path, template_content)
-    return {"action": action, "detail": merge_detail or detail}
+    return result
 
 
 def _upgrade_platform(

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
@@ -33,7 +33,6 @@ def _upgrade_agents_md(
 
     Returns a result dict with ``action`` and optional ``detail``.
     """
-    from tapps_mcp.pipeline import karpathy_block
     from tapps_mcp.pipeline.agents_md import AgentsValidation, update_agents_md
     from tapps_mcp.prompts.prompt_loader import load_agents_template
 
@@ -43,35 +42,53 @@ def _upgrade_agents_md(
     if not agents_path.exists():
         if not dry_run:
             agents_path.write_text(template_content, encoding="utf-8")
-        result: dict[str, Any] = {"action": "created"}
-    else:
-        validation = AgentsValidation(agents_path.read_text(encoding="utf-8"))
-        if validation.is_up_to_date:
-            result = {"action": "up-to-date"}
-        else:
-            issues: list[str] = []
-            if validation.sections_missing:
-                issues.append(f"missing sections: {', '.join(validation.sections_missing)}")
-            if validation.tools_missing:
-                issues.append(f"missing tools: {', '.join(validation.tools_missing)}")
-            detail = "; ".join(issues) or "version mismatch"
+        return {"action": "created"}
 
-            if dry_run:
-                result = {"action": "needs-update", "detail": detail}
-            else:
-                action, merge_detail = update_agents_md(agents_path, template_content)
-                result = {"action": action, "detail": merge_detail or detail}
+    validation = AgentsValidation(agents_path.read_text(encoding="utf-8"))
+    if validation.is_up_to_date:
+        return {"action": "up-to-date"}
 
-    try:
-        kp_action = karpathy_block.install_or_refresh(agents_path, dry_run=dry_run)
-        result["karpathy_guidelines"] = {
-            "action": kp_action,
-            "source_sha": karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA,
-        }
-    except Exception as exc:
-        result["karpathy_guidelines"] = {"action": "error", "reason": str(exc)}
+    issues: list[str] = []
+    if validation.sections_missing:
+        issues.append(f"missing sections: {', '.join(validation.sections_missing)}")
+    if validation.tools_missing:
+        issues.append(f"missing tools: {', '.join(validation.tools_missing)}")
+    detail = "; ".join(issues) or "version mismatch"
 
-    return result
+    if dry_run:
+        return {"action": "needs-update", "detail": detail}
+    action, merge_detail = update_agents_md(agents_path, template_content)
+    return {"action": action, "detail": merge_detail or detail}
+
+
+def _refresh_karpathy_blocks(
+    project_root: Path,
+    *,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Install or refresh the Karpathy guidelines block in AGENTS.md and CLAUDE.md.
+
+    Appends between BEGIN/END markers, preserving content outside them.
+    Files that don't exist are skipped (they aren't owned by this upgrade
+    step; ``tapps_init`` creates them).
+    """
+    from tapps_mcp.pipeline import karpathy_block
+
+    per_file: dict[str, str] = {}
+    for rel in ("AGENTS.md", "CLAUDE.md"):
+        target = project_root / rel
+        if not target.exists():
+            per_file[rel] = "skipped_file_missing"
+            continue
+        try:
+            per_file[rel] = karpathy_block.install_or_refresh(target, dry_run=dry_run)
+        except Exception as exc:
+            per_file[rel] = f"error: {exc}"
+
+    return {
+        "source_sha": karpathy_block.KARPATHY_GUIDELINES_SOURCE_SHA,
+        "files": per_file,
+    }
 
 
 def _upgrade_platform(
@@ -619,6 +636,17 @@ def upgrade_pipeline(
             )
 
     result["components"]["platforms"] = platform_results
+
+    # Karpathy guidelines block — refresh in AGENTS.md and CLAUDE.md after
+    # per-host upgrades have potentially created/updated CLAUDE.md.
+    try:
+        result["components"]["karpathy_guidelines"] = _refresh_karpathy_blocks(
+            project_root,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        result["errors"].append(f"Karpathy guidelines: {exc}")
+        result["components"]["karpathy_guidelines"] = {"action": "error", "detail": str(exc)}
 
     # GitHub templates, CI, Copilot, governance, and issue/PR templates (platform-agnostic)
     if not dry_run:

--- a/packages/tapps-mcp/src/tapps_mcp/prompts/karpathy_guidelines.md
+++ b/packages/tapps-mcp/src/tapps_mcp/prompts/karpathy_guidelines.md
@@ -1,0 +1,75 @@
+<!--
+  Vendored from https://github.com/forrestchang/andrej-karpathy-skills
+  Pinned commit: c9a44ae835fa2f5765a697216692705761a53f40 (2026-04-15)
+  License: MIT (c) forrestchang
+  Do not edit by hand — update KARPATHY_GUIDELINES_SOURCE_SHA in prompt_loader.py
+  and re-run the vendor script, then bump tapps-mcp version.
+-->
+## Karpathy Behavioral Guidelines
+
+> Source: https://github.com/forrestchang/andrej-karpathy-skills @ c9a44ae835fa2f5765a697216692705761a53f40 (MIT)
+> Derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/packages/tapps-mcp/src/tapps_mcp/prompts/prompt_loader.py
+++ b/packages/tapps-mcp/src/tapps_mcp/prompts/prompt_loader.py
@@ -23,6 +23,21 @@ from tapps_core.prompts.prompt_loader import load_stage_prompt as load_stage_pro
 
 _PACKAGE = "tapps_mcp.prompts"
 
+KARPATHY_GUIDELINES_SOURCE_SHA = "c9a44ae835fa2f5765a697216692705761a53f40"
+"""Pinned commit SHA for the vendored Karpathy guidelines.
+
+Update together with ``karpathy_guidelines.md`` when re-vendoring from
+https://github.com/forrestchang/andrej-karpathy-skills — `tapps_doctor`
+compares this constant against the SHA recorded in the consuming project's
+AGENTS.md marker to decide whether the block is stale.
+"""
+
+KARPATHY_GUIDELINES_MARKER_BEGIN = (
+    f"<!-- BEGIN: karpathy-guidelines {KARPATHY_GUIDELINES_SOURCE_SHA[:7]} "
+    "(MIT, forrestchang/andrej-karpathy-skills) -->"
+)
+KARPATHY_GUIDELINES_MARKER_END = "<!-- END: karpathy-guidelines -->"
+
 
 def _read_resource(filename: str) -> str:
     """Read a text resource from the tapps_mcp prompts package.
@@ -61,6 +76,18 @@ def load_agents_template(engagement_level: str = "medium") -> str:
         raise ValueError(msg)
     content = _read_resource(f"agents_template_{engagement_level}.md")
     return f"<!-- tapps-agents-version: {__version__} -->\n{content}"
+
+
+def load_karpathy_guidelines() -> str:
+    """Load vendored Karpathy behavioral guidelines wrapped in idempotence markers.
+
+    Returns a block beginning with ``KARPATHY_GUIDELINES_MARKER_BEGIN`` and
+    ending with ``KARPATHY_GUIDELINES_MARKER_END``. Callers splice this block
+    into AGENTS.md / CLAUDE.md between those exact markers so subsequent
+    upgrades can rewrite the block without touching surrounding content.
+    """
+    body = _read_resource("karpathy_guidelines.md")
+    return f"{KARPATHY_GUIDELINES_MARKER_BEGIN}\n{body.rstrip()}\n{KARPATHY_GUIDELINES_MARKER_END}"
 
 
 def load_platform_rules(platform: str, engagement_level: str = "medium") -> str:

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -1874,10 +1874,12 @@ async def tapps_init(
             scaffold missing knowledge directories for business experts
             (creates README.md and overview.md starter files).
         include_karpathy: When ``True`` (default), append the vendored
-            Karpathy behavioral guidelines block to AGENTS.md between
-            idempotent HTML-comment markers. ``tapps_upgrade`` refreshes
-            this block when the vendored SHA changes; ``tapps_doctor``
-            reports ``ok``/``stale``/``missing``. Set to ``False`` to
+            Karpathy behavioral guidelines block to AGENTS.md and
+            CLAUDE.md (whichever exist in the project) between idempotent
+            BEGIN/END HTML-comment markers — content outside the markers
+            is preserved. ``tapps_upgrade`` refreshes the block when the
+            vendored SHA changes; ``tapps_doctor`` reports
+            ``ok``/``stale``/``missing`` per file. Set to ``False`` to
             opt out.
         mcp_config: When ``True``, write project-scoped MCP server config after
             bootstrap completes. Always uses ``scope="project"`` (never user).

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -1799,6 +1799,7 @@ async def tapps_init(
     verify_only: bool = False,
     llm_engagement_level: str | None = None,
     scaffold_experts: bool = False,
+    include_karpathy: bool = True,
     mcp_config: bool = False,
     output_mode: str = "auto",
     ctx: Context[Any, Any, Any] | None = None,
@@ -1872,6 +1873,12 @@ async def tapps_init(
         scaffold_experts: When ``True`` and ``.tapps-mcp/experts.yaml`` exists,
             scaffold missing knowledge directories for business experts
             (creates README.md and overview.md starter files).
+        include_karpathy: When ``True`` (default), append the vendored
+            Karpathy behavioral guidelines block to AGENTS.md between
+            idempotent HTML-comment markers. ``tapps_upgrade`` refreshes
+            this block when the vendored SHA changes; ``tapps_doctor``
+            reports ``ok``/``stale``/``missing``. Set to ``False`` to
+            opt out.
         mcp_config: When ``True``, write project-scoped MCP server config after
             bootstrap completes. Always uses ``scope="project"`` (never user).
         output_mode: Controls file writing behavior (Epic 87).
@@ -1954,6 +1961,7 @@ async def tapps_init(
         verify_only=verify_only,
         llm_engagement_level=llm_engagement_level or settings.llm_engagement_level,
         scaffold_experts=scaffold_experts,
+        include_karpathy=include_karpathy,
     )
 
     # Epic 87: Set TAPPS_WRITE_MODE for content-return override

--- a/packages/tapps-mcp/tests/unit/test_karpathy_guidelines.py
+++ b/packages/tapps-mcp/tests/unit/test_karpathy_guidelines.py
@@ -192,12 +192,6 @@ def test_doctor_check_passes_when_block_present(tmp_path: Path) -> None:
     assert KARPATHY_GUIDELINES_SOURCE_SHA[:7] in result.message
 
 
-def test_doctor_check_fails_when_agents_missing(tmp_path: Path) -> None:
-    result = check_karpathy_guidelines(tmp_path)
-    assert not result.ok
-    assert "tapps_init" in result.detail
-
-
 def test_doctor_check_fails_when_block_missing(tmp_path: Path) -> None:
     (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
     result = check_karpathy_guidelines(tmp_path)
@@ -247,13 +241,55 @@ def test_init_installs_block_into_new_agents_md(tmp_path: Path) -> None:
     assert agents.exists()
     content = agents.read_text(encoding="utf-8")
     assert KARPATHY_GUIDELINES_MARKER_BEGIN in content
-    assert result["karpathy_guidelines"]["action"] in {"added", "unchanged"}
-    assert result["karpathy_guidelines"]["source_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
+    kp = result["karpathy_guidelines"]
+    assert kp["source_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
+    assert kp["files"]["AGENTS.md"] in {"added", "unchanged"}
+    # No CLAUDE.md was created (platform=""), so it should be skipped
+    assert kp["files"]["CLAUDE.md"] == "skipped_file_missing"
+
+
+@pytest.mark.slow
+def test_init_installs_block_into_both_files_when_claude_md_present(tmp_path: Path) -> None:
+    from tapps_mcp.pipeline.init import BootstrapConfig, bootstrap_pipeline
+
+    # Pre-create a user-owned CLAUDE.md to simulate a project that uses Claude Code
+    (tmp_path / "CLAUDE.md").write_text(
+        "# CLAUDE.md\n\nuser-owned preamble that must survive.\n",
+        encoding="utf-8",
+    )
+
+    cfg = BootstrapConfig(
+        create_handoff=False,
+        create_runlog=False,
+        create_agents_md=True,
+        create_tech_stack_md=False,
+        platform="",  # don't run platform bootstrap; we just want the karpathy step
+        verify_server=False,
+        install_missing_checkers=False,
+        warm_cache_from_tech_stack=False,
+        warm_expert_rag_from_tech_stack=False,
+        include_karpathy=True,
+    )
+    result = bootstrap_pipeline(tmp_path, config=cfg)
+
+    claude = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "user-owned preamble that must survive." in claude  # user content preserved
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN in claude
+
+    agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN in agents
+
+    kp = result["karpathy_guidelines"]
+    assert kp["files"]["AGENTS.md"] in {"added", "unchanged"}
+    assert kp["files"]["CLAUDE.md"] == "added"
 
 
 @pytest.mark.slow
 def test_init_skips_block_when_include_karpathy_false(tmp_path: Path) -> None:
     from tapps_mcp.pipeline.init import BootstrapConfig, bootstrap_pipeline
+
+    # CLAUDE.md present too — must also be left alone
+    (tmp_path / "CLAUDE.md").write_text("# CLAUDE\n", encoding="utf-8")
 
     cfg = BootstrapConfig(
         create_handoff=False,
@@ -269,31 +305,96 @@ def test_init_skips_block_when_include_karpathy_false(tmp_path: Path) -> None:
     )
     result = bootstrap_pipeline(tmp_path, config=cfg)
 
-    agents = tmp_path / "AGENTS.md"
-    assert agents.exists()
-    content = agents.read_text(encoding="utf-8")
-    assert KARPATHY_GUIDELINES_MARKER_BEGIN not in content
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN not in (tmp_path / "AGENTS.md").read_text(
+        encoding="utf-8"
+    )
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN not in (tmp_path / "CLAUDE.md").read_text(
+        encoding="utf-8"
+    )
     assert result["karpathy_guidelines"]["action"] == "skipped"
 
 
-def test_upgrade_refreshes_stale_block(tmp_path: Path) -> None:
-    from tapps_mcp.pipeline.upgrade import _upgrade_agents_md
-    from tapps_mcp.prompts.prompt_loader import load_agents_template
+def test_upgrade_refreshes_stale_block_in_both_files(tmp_path: Path) -> None:
+    from tapps_mcp.pipeline.upgrade import _refresh_karpathy_blocks
 
-    agents = tmp_path / "AGENTS.md"
-    # Current template so smart-merge says "up-to-date", but stale karpathy block
-    agents.write_text(
-        load_agents_template() + "\n\n" + "<!-- BEGIN: karpathy-guidelines deadbee "
+    stale = (
+        "<!-- BEGIN: karpathy-guidelines deadbee "
         "(MIT, forrestchang/andrej-karpathy-skills) -->\n"
         "stale\n"
+        "<!-- END: karpathy-guidelines -->\n"
+    )
+    (tmp_path / "AGENTS.md").write_text(f"# AGENTS\n\n{stale}", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text(f"# CLAUDE\n\n{stale}", encoding="utf-8")
+
+    result = _refresh_karpathy_blocks(tmp_path, dry_run=False)
+    assert result["source_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
+    assert result["files"]["AGENTS.md"] == "refreshed"
+    assert result["files"]["CLAUDE.md"] == "refreshed"
+
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        content = (tmp_path / name).read_text(encoding="utf-8")
+        assert "deadbee" not in content
+        assert KARPATHY_GUIDELINES_SOURCE_SHA[:7] in content
+
+
+def test_upgrade_skips_missing_files(tmp_path: Path) -> None:
+    from tapps_mcp.pipeline.upgrade import _refresh_karpathy_blocks
+
+    result = _refresh_karpathy_blocks(tmp_path, dry_run=False)
+    assert result["files"]["AGENTS.md"] == "skipped_file_missing"
+    assert result["files"]["CLAUDE.md"] == "skipped_file_missing"
+
+
+# ---------------------------------------------------------------------------
+# doctor: dual-file states
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_check_fails_when_both_files_missing(tmp_path: Path) -> None:
+    result = check_karpathy_guidelines(tmp_path)
+    assert not result.ok
+    assert "Neither AGENTS.md nor CLAUDE.md" in result.message
+    assert "tapps_init" in result.detail
+
+
+def test_doctor_check_passes_when_both_files_have_block(tmp_path: Path) -> None:
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        p = tmp_path / name
+        p.write_text(f"# {name}\n", encoding="utf-8")
+        karpathy_block.install_or_refresh(p)
+
+    result = check_karpathy_guidelines(tmp_path)
+    assert result.ok
+    assert "AGENTS.md" in result.message
+    assert "CLAUDE.md" in result.message
+
+
+def test_doctor_check_fails_when_one_file_missing_block(tmp_path: Path) -> None:
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("# AGENTS\n", encoding="utf-8")
+    karpathy_block.install_or_refresh(agents)
+    (tmp_path / "CLAUDE.md").write_text("# CLAUDE\n", encoding="utf-8")
+
+    result = check_karpathy_guidelines(tmp_path)
+    assert not result.ok
+    assert "CLAUDE.md" in result.message
+    assert "missing" in result.message
+    assert "tapps_upgrade" in result.detail
+
+
+def test_doctor_check_fails_when_one_file_stale(tmp_path: Path) -> None:
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("# AGENTS\n", encoding="utf-8")
+    karpathy_block.install_or_refresh(agents)
+    (tmp_path / "CLAUDE.md").write_text(
+        "# CLAUDE\n\n"
+        "<!-- BEGIN: karpathy-guidelines deadbee "
+        "(MIT, forrestchang/andrej-karpathy-skills) -->\nold\n"
         "<!-- END: karpathy-guidelines -->\n",
         encoding="utf-8",
     )
 
-    result = _upgrade_agents_md(tmp_path, dry_run=False)
-    assert result["karpathy_guidelines"]["action"] == "refreshed"
-    assert result["karpathy_guidelines"]["source_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
-
-    content = agents.read_text(encoding="utf-8")
-    assert "deadbee" not in content
-    assert KARPATHY_GUIDELINES_SOURCE_SHA[:7] in content
+    result = check_karpathy_guidelines(tmp_path)
+    assert not result.ok
+    assert "stale" in result.message
+    assert "CLAUDE.md@deadbee" in result.message

--- a/packages/tapps-mcp/tests/unit/test_karpathy_guidelines.py
+++ b/packages/tapps-mcp/tests/unit/test_karpathy_guidelines.py
@@ -1,0 +1,299 @@
+"""Tests for the vendored Karpathy guidelines block: loader + install/refresh + doctor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tapps_mcp.distribution.doctor import check_karpathy_guidelines
+from tapps_mcp.pipeline import karpathy_block
+from tapps_mcp.prompts.prompt_loader import (
+    KARPATHY_GUIDELINES_MARKER_BEGIN,
+    KARPATHY_GUIDELINES_MARKER_END,
+    KARPATHY_GUIDELINES_SOURCE_SHA,
+    load_karpathy_guidelines,
+)
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_karpathy_guidelines_has_pinned_sha() -> None:
+    assert len(KARPATHY_GUIDELINES_SOURCE_SHA) == 40
+    assert all(c in "0123456789abcdef" for c in KARPATHY_GUIDELINES_SOURCE_SHA)
+
+
+def test_load_karpathy_guidelines_wraps_in_markers() -> None:
+    block = load_karpathy_guidelines()
+    assert block.startswith(KARPATHY_GUIDELINES_MARKER_BEGIN)
+    assert block.endswith(KARPATHY_GUIDELINES_MARKER_END)
+    # Both markers present exactly once each
+    assert block.count(KARPATHY_GUIDELINES_MARKER_BEGIN) == 1
+    assert block.count(KARPATHY_GUIDELINES_MARKER_END) == 1
+
+
+def test_load_karpathy_guidelines_contains_all_four_principles() -> None:
+    block = load_karpathy_guidelines()
+    assert "Think Before Coding" in block
+    assert "Simplicity First" in block
+    assert "Surgical Changes" in block
+    assert "Goal-Driven Execution" in block
+
+
+def test_load_karpathy_guidelines_preserves_attribution() -> None:
+    block = load_karpathy_guidelines()
+    assert "forrestchang/andrej-karpathy-skills" in block
+    assert KARPATHY_GUIDELINES_SOURCE_SHA in block
+
+
+# ---------------------------------------------------------------------------
+# install_or_refresh
+# ---------------------------------------------------------------------------
+
+
+def test_install_skips_when_file_missing(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    action = karpathy_block.install_or_refresh(target)
+    assert action == "skipped_file_missing"
+    assert not target.exists()
+
+
+def test_install_adds_block_when_absent(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# AGENTS\n\nproject-specific content.\n", encoding="utf-8")
+
+    action = karpathy_block.install_or_refresh(target)
+    assert action == "added"
+
+    content = target.read_text(encoding="utf-8")
+    assert "project-specific content." in content  # user content preserved
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN in content
+    assert KARPATHY_GUIDELINES_MARKER_END in content
+
+
+def test_install_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# AGENTS\n", encoding="utf-8")
+
+    first = karpathy_block.install_or_refresh(target)
+    after_first = target.read_text(encoding="utf-8")
+
+    second = karpathy_block.install_or_refresh(target)
+    after_second = target.read_text(encoding="utf-8")
+
+    assert first == "added"
+    assert second == "unchanged"
+    assert after_first == after_second
+    # Markers still present exactly once
+    assert after_second.count(KARPATHY_GUIDELINES_MARKER_BEGIN) == 1
+    assert after_second.count(KARPATHY_GUIDELINES_MARKER_END) == 1
+
+
+def test_install_refreshes_stale_block(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    stale_block = (
+        "<!-- BEGIN: karpathy-guidelines 0000000 "
+        "(MIT, forrestchang/andrej-karpathy-skills) -->\n"
+        "## Karpathy Behavioral Guidelines\n\n"
+        "Stale content from an older vendor.\n"
+        "<!-- END: karpathy-guidelines -->"
+    )
+    target.write_text(
+        f"# AGENTS\n\nkept preamble.\n\n{stale_block}\n\ntrailing user content.\n",
+        encoding="utf-8",
+    )
+
+    action = karpathy_block.install_or_refresh(target)
+    assert action == "refreshed"
+
+    content = target.read_text(encoding="utf-8")
+    # Refreshed: old SHA prefix gone, new SHA present
+    assert "0000000" not in content
+    assert KARPATHY_GUIDELINES_SOURCE_SHA[:7] in content
+    # Surrounding user content preserved
+    assert "kept preamble." in content
+    assert "trailing user content." in content
+    # Still exactly one block
+    assert content.count(KARPATHY_GUIDELINES_MARKER_END) == 1
+
+
+def test_install_dry_run_does_not_write(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    original = "# AGENTS\n\ncontent.\n"
+    target.write_text(original, encoding="utf-8")
+
+    action = karpathy_block.install_or_refresh(target, dry_run=True)
+    assert action == "added"
+    assert target.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# check (doctor)
+# ---------------------------------------------------------------------------
+
+
+def test_check_reports_file_absent(tmp_path: Path) -> None:
+    report = karpathy_block.check(tmp_path / "AGENTS.md")
+    assert report["state"] == "file_absent"
+    assert report["current_sha"] is None
+    assert report["expected_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
+
+
+def test_check_reports_missing(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# AGENTS\nno block here.\n", encoding="utf-8")
+
+    report = karpathy_block.check(target)
+    assert report["state"] == "missing"
+    assert report["current_sha"] is None
+
+
+def test_check_reports_ok_after_install(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# AGENTS\n", encoding="utf-8")
+    karpathy_block.install_or_refresh(target)
+
+    report = karpathy_block.check(target)
+    assert report["state"] == "ok"
+    assert report["current_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA[:7]
+
+
+def test_check_reports_stale_when_sha_mismatch(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    stale = (
+        "# AGENTS\n\n"
+        "<!-- BEGIN: karpathy-guidelines deadbee "
+        "(MIT, forrestchang/andrej-karpathy-skills) -->\n"
+        "stale body\n"
+        "<!-- END: karpathy-guidelines -->\n"
+    )
+    target.write_text(stale, encoding="utf-8")
+
+    report = karpathy_block.check(target)
+    assert report["state"] == "stale"
+    assert report["current_sha"] == "deadbee"
+
+
+# ---------------------------------------------------------------------------
+# doctor.check_karpathy_guidelines integration
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_check_passes_when_block_present(tmp_path: Path) -> None:
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("# AGENTS\n", encoding="utf-8")
+    karpathy_block.install_or_refresh(agents)
+
+    result = check_karpathy_guidelines(tmp_path)
+    assert result.ok
+    assert "Karpathy guidelines" in result.name
+    assert KARPATHY_GUIDELINES_SOURCE_SHA[:7] in result.message
+
+
+def test_doctor_check_fails_when_agents_missing(tmp_path: Path) -> None:
+    result = check_karpathy_guidelines(tmp_path)
+    assert not result.ok
+    assert "tapps_init" in result.detail
+
+
+def test_doctor_check_fails_when_block_missing(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+    result = check_karpathy_guidelines(tmp_path)
+    assert not result.ok
+    assert "tapps_upgrade" in result.detail
+
+
+def test_doctor_check_fails_when_block_stale(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text(
+        "# AGENTS\n\n"
+        "<!-- BEGIN: karpathy-guidelines deadbee "
+        "(MIT, forrestchang/andrej-karpathy-skills) -->\n"
+        "old body\n"
+        "<!-- END: karpathy-guidelines -->\n",
+        encoding="utf-8",
+    )
+    result = check_karpathy_guidelines(tmp_path)
+    assert not result.ok
+    assert "deadbee" in result.message
+    assert "tapps_upgrade" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# init/upgrade wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_init_installs_block_into_new_agents_md(tmp_path: Path) -> None:
+    from tapps_mcp.pipeline.init import BootstrapConfig, bootstrap_pipeline
+
+    cfg = BootstrapConfig(
+        create_handoff=False,
+        create_runlog=False,
+        create_agents_md=True,
+        create_tech_stack_md=False,
+        platform="",
+        verify_server=False,
+        install_missing_checkers=False,
+        warm_cache_from_tech_stack=False,
+        warm_expert_rag_from_tech_stack=False,
+        include_karpathy=True,
+    )
+    result = bootstrap_pipeline(tmp_path, config=cfg)
+
+    agents = tmp_path / "AGENTS.md"
+    assert agents.exists()
+    content = agents.read_text(encoding="utf-8")
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN in content
+    assert result["karpathy_guidelines"]["action"] in {"added", "unchanged"}
+    assert result["karpathy_guidelines"]["source_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
+
+
+@pytest.mark.slow
+def test_init_skips_block_when_include_karpathy_false(tmp_path: Path) -> None:
+    from tapps_mcp.pipeline.init import BootstrapConfig, bootstrap_pipeline
+
+    cfg = BootstrapConfig(
+        create_handoff=False,
+        create_runlog=False,
+        create_agents_md=True,
+        create_tech_stack_md=False,
+        platform="",
+        verify_server=False,
+        install_missing_checkers=False,
+        warm_cache_from_tech_stack=False,
+        warm_expert_rag_from_tech_stack=False,
+        include_karpathy=False,
+    )
+    result = bootstrap_pipeline(tmp_path, config=cfg)
+
+    agents = tmp_path / "AGENTS.md"
+    assert agents.exists()
+    content = agents.read_text(encoding="utf-8")
+    assert KARPATHY_GUIDELINES_MARKER_BEGIN not in content
+    assert result["karpathy_guidelines"]["action"] == "skipped"
+
+
+def test_upgrade_refreshes_stale_block(tmp_path: Path) -> None:
+    from tapps_mcp.pipeline.upgrade import _upgrade_agents_md
+    from tapps_mcp.prompts.prompt_loader import load_agents_template
+
+    agents = tmp_path / "AGENTS.md"
+    # Current template so smart-merge says "up-to-date", but stale karpathy block
+    agents.write_text(
+        load_agents_template() + "\n\n" + "<!-- BEGIN: karpathy-guidelines deadbee "
+        "(MIT, forrestchang/andrej-karpathy-skills) -->\n"
+        "stale\n"
+        "<!-- END: karpathy-guidelines -->\n",
+        encoding="utf-8",
+    )
+
+    result = _upgrade_agents_md(tmp_path, dry_run=False)
+    assert result["karpathy_guidelines"]["action"] == "refreshed"
+    assert result["karpathy_guidelines"]["source_sha"] == KARPATHY_GUIDELINES_SOURCE_SHA
+
+    content = agents.read_text(encoding="utf-8")
+    assert "deadbee" not in content
+    assert KARPATHY_GUIDELINES_SOURCE_SHA[:7] in content

--- a/tapps_mcp.spec
+++ b/tapps_mcp.spec
@@ -188,6 +188,7 @@ a = Analysis(
         "tapps_mcp.pipeline.init",
         "tapps_mcp.pipeline.upgrade",
         "tapps_mcp.pipeline.agents_md",
+        "tapps_mcp.pipeline.karpathy_block",
         "tapps_mcp.pipeline.github_templates",
         "tapps_mcp.pipeline.github_ci",
         "tapps_mcp.pipeline.github_copilot",

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "docs-mcp"
-version = "2.8.0"
+version = "2.9.0"
 source = { editable = "packages/docs-mcp" }
 dependencies = [
     { name = "click" },
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "tapps-core"
-version = "2.8.0"
+version = "2.9.0"
 source = { editable = "packages/tapps-core" }
 dependencies = [
     { name = "httpx" },
@@ -2500,7 +2500,7 @@ provides-extras = ["vector", "reranker"]
 
 [[package]]
 name = "tapps-mcp"
-version = "2.8.0"
+version = "2.9.0"
 source = { editable = "packages/tapps-mcp" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Vendors [forrestchang/andrej-karpathy-skills@c9a44ae](https://github.com/forrestchang/andrej-karpathy-skills/commit/c9a44ae835fa2f5765a697216692705761a53f40) (MIT) into tapps-mcp and wires it through the full pipeline:

- **init** — `tapps_init(include_karpathy=True)` (default-on) appends the block to `AGENTS.md` and `CLAUDE.md` between idempotent BEGIN/END markers; content outside markers preserved; files that don't exist are skipped.
- **upgrade** — `tapps_upgrade` refreshes the block in both files when the vendored SHA changes; reuses the existing pre-upgrade backup.
- **doctor** — new `check_karpathy_guidelines` reports `ok` / `stale` / `missing` per file.
- **CLI** — `tapps-mcp upgrade` and `tapps-mcp doctor` both render the new Karpathy rows.

Version bump: **2.8.0 → 2.9.0** across all three packages.

The four principles (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) are appended to this repo's own `CLAUDE.md` and `AGENTS.md` too, using the same in-branch helper.

## Test plan

- [x] 25 new unit tests in `test_karpathy_guidelines.py` — loader, install/refresh/idempotence, check, doctor, init wiring, upgrade wiring, dual-file scenarios
- [x] `uv run pytest` — 182 affected tests pass (karpathy + agents_md + doctor + init_bootstrap + upgrade_content_return)
- [x] `uv run mypy --strict` — clean on new files
- [x] `tapps-mcp upgrade --dry-run` on this repo renders the Karpathy section
- [x] `tapps-mcp doctor` on this repo reports `Karpathy guidelines: PASS — present in AGENTS.md, CLAUDE.md; pinned to c9a44ae`
- [x] `tapps-mcp --version` reports `2.9.0`

## Notes

- Rebased cleanly onto `origin/master` (no dependency on PR #105).
- License MIT preserved in the vendored markdown header.
- Opt-out: `tapps_init(include_karpathy=False)` skips the block everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)