### PR TITLE
[TAP-519] validate tapps-brain version at BrainBridge startup

### DIFF
--- a/packages/tapps-core/src/tapps_core/brain_bridge.py
+++ b/packages/tapps-core/src/tapps_core/brain_bridge.py
@@ -23,7 +23,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import httpx
 import structlog
+from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from tapps_brain import AgentBrain
@@ -43,6 +45,14 @@ _RETRY_MAX: float = 8.0
 
 # --- Write queue -------------------------------------------------------------
 _WRITE_QUEUE_CAP: int = 100
+
+# --- Remote brain version probe (TAP-519) ------------------------------------
+# Keep in sync with the ``tapps-brain`` pin in
+# ``packages/tapps-core/pyproject.toml``. The floor is the minimum version
+# known to ship all fields tapps-mcp consumes; the ceiling is the next major.
+_BRAIN_VERSION_FLOOR: str = "3.7.2"
+_BRAIN_VERSION_CEILING: str = "4.0.0"
+_BRAIN_HEALTH_TIMEOUT_SECONDS: float = 5.0
 
 
 class BrainBridgeUnavailable(Exception):  # noqa: N818  (public API name predates the lint rule; renaming would break consumers)
@@ -67,6 +77,20 @@ class BrainBridge:
         self._open_at: float | None = None
         self._write_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_WRITE_QUEUE_CAP)
         self._drain_task: asyncio.Task[None] | None = None
+        # TAP-519: populated by ``create_brain_bridge`` when a remote brain
+        # HTTP URL is configured. Callers (e.g. tapps_session_start) can read
+        # ``bridge.version_check`` to surface the result in their health field.
+        self._version_check: dict[str, Any] = {
+            "ok": True,
+            "skipped": True,
+            "degraded": False,
+            "url": "",
+            "floor": _BRAIN_VERSION_FLOOR,
+            "ceiling": _BRAIN_VERSION_CEILING,
+            "version": None,
+            "errors": [],
+            "warnings": [],
+        }
 
     # -------------------------------------------------------------------------
     # Circuit breaker
@@ -87,6 +111,19 @@ class BrainBridge:
     def queue_depth(self) -> int:
         """Number of writes currently queued."""
         return self._write_queue.qsize()
+
+    @property
+    def version_check(self) -> dict[str, Any]:
+        """Result of the remote tapps-brain version probe (TAP-519).
+
+        When no ``brain_http_url`` was configured at factory time, this
+        returns a ``{"ok": True, "skipped": True, ...}`` sentinel.
+        """
+        return dict(self._version_check)
+
+    def _set_version_check(self, result: dict[str, Any]) -> None:
+        """Populate the version-check payload (factory-only helper)."""
+        self._version_check = result
 
     def _record_success(self) -> None:
         self._failures = 0
@@ -687,6 +724,129 @@ class BrainBridge:
 
 
 # -----------------------------------------------------------------------------
+# Remote brain version probe (TAP-519)
+# -----------------------------------------------------------------------------
+
+
+def check_brain_version(
+    brain_http_url: str,
+    *,
+    floor: str = _BRAIN_VERSION_FLOOR,
+    ceiling: str = _BRAIN_VERSION_CEILING,
+    timeout: float = _BRAIN_HEALTH_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Probe a remote tapps-brain's ``/health`` endpoint and validate its version.
+
+    Intended for startup use: GETs ``{brain_http_url}/health`` (no auth — the
+    endpoint is unauthenticated as of tapps-brain v3.8.0) and compares the
+    reported ``version`` against the pinned floor/ceiling range declared in
+    ``packages/tapps-core/pyproject.toml``.
+
+    Return shape matches the ``health_check()`` style used elsewhere in this
+    module so callers can fold the result into a larger health payload::
+
+        {
+            "ok": bool,
+            "skipped": bool,        # True when brain_http_url is empty
+            "degraded": bool,       # True on network / parse failure (non-fatal)
+            "url": str,
+            "floor": str,
+            "ceiling": str,
+            "version": str | None,  # reported by brain, may be None on failure
+            "errors": list[str],
+            "warnings": list[str],
+        }
+
+    When ``brain_http_url`` is empty (the default for in-process AgentBrain
+    deployments) the probe is skipped and ``ok`` is True — the caller has no
+    remote brain to validate.
+    """
+    result: dict[str, Any] = {
+        "ok": True,
+        "skipped": False,
+        "degraded": False,
+        "url": brain_http_url,
+        "floor": floor,
+        "ceiling": ceiling,
+        "version": None,
+        "errors": [],
+        "warnings": [],
+    }
+
+    if not brain_http_url:
+        result["skipped"] = True
+        return result
+
+    health_url = brain_http_url.rstrip("/") + "/health"
+
+    try:
+        response = httpx.get(health_url, timeout=timeout)
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPError as exc:
+        # Network / HTTP failure — don't block bridge creation, but mark
+        # degraded so operators see the issue in any surfacing health field.
+        msg = f"tapps-brain health probe failed at {health_url}: {exc}"
+        logger.warning("brain_bridge.version_check.network_error", error=str(exc), url=health_url)
+        result["ok"] = False
+        result["degraded"] = True
+        result["warnings"].append(msg)
+        return result
+    except ValueError as exc:
+        # JSON decode failure
+        msg = f"tapps-brain health response at {health_url} was not valid JSON: {exc}"
+        logger.warning("brain_bridge.version_check.bad_json", error=str(exc), url=health_url)
+        result["ok"] = False
+        result["degraded"] = True
+        result["warnings"].append(msg)
+        return result
+
+    raw_version = payload.get("version") if isinstance(payload, dict) else None
+    if not isinstance(raw_version, str) or not raw_version:
+        msg = f"tapps-brain health response at {health_url} missing 'version' field"
+        logger.error("brain_bridge.version_check.missing_version", url=health_url, payload=payload)
+        result["ok"] = False
+        result["errors"].append(msg)
+        return result
+
+    result["version"] = raw_version
+
+    try:
+        actual = Version(raw_version)
+        floor_v = Version(floor)
+        ceiling_v = Version(ceiling)
+    except InvalidVersion as exc:
+        msg = f"tapps-brain reported unparseable version {raw_version!r}: {exc}"
+        logger.error("brain_bridge.version_check.invalid_version", version=raw_version)
+        result["ok"] = False
+        result["errors"].append(msg)
+        return result
+
+    if actual < floor_v or actual >= ceiling_v:
+        msg = (
+            f"tapps-brain version {raw_version} does not satisfy required range "
+            f">={floor},<{ceiling} (pinned in packages/tapps-core/pyproject.toml)"
+        )
+        logger.error(
+            "brain_bridge.version_check.mismatch",
+            actual=raw_version,
+            floor=floor,
+            ceiling=ceiling,
+        )
+        result["ok"] = False
+        result["errors"].append(msg)
+        return result
+
+    logger.info(
+        "brain_bridge.version_check.ok",
+        version=raw_version,
+        floor=floor,
+        ceiling=ceiling,
+    )
+    return result
+
+
+# -----------------------------------------------------------------------------
 # Factory
 # -----------------------------------------------------------------------------
 
@@ -725,6 +885,7 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
     project_id: str = ""
     pg_pool_max_waiting: int = 0
     pg_pool_max_lifetime_seconds: int = 0
+    brain_http_url: str = ""
 
     if settings is not None:
         project_root = str(getattr(settings, "project_root", None) or "")
@@ -738,6 +899,7 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
             pg_pool_max_lifetime_seconds = int(
                 getattr(memory, "pg_pool_max_lifetime_seconds", 0) or 0
             )
+            brain_http_url = str(getattr(memory, "brain_http_url", "") or "")
 
     # ADR-010 / EPIC-069: declare the registered project slug on the wire so
     # AgentBrain hits the project registry instead of deriving a per-directory
@@ -764,7 +926,26 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
         )
         # Probe the store to fail fast on bad DSN before returning
         brain.store.count()
-        return BrainBridge(brain)
     except Exception as exc:
         logger.warning("brain_bridge.init_failed", error=str(exc))
         return None
+
+    # TAP-519: validate remote brain version when a HTTP URL is configured.
+    # The probe is no-op for in-process AgentBrain deployments (url empty).
+    # A mismatch is logged loudly but does not block bridge creation — the
+    # structured result is exposed for callers (e.g. tapps_session_start)
+    # that want to surface it to operators.
+    version_check = check_brain_version(brain_http_url)
+    if not version_check["ok"] and not version_check["skipped"]:
+        logger.error(
+            "brain_bridge.version_check_failed",
+            errors=version_check["errors"],
+            warnings=version_check["warnings"],
+            version=version_check["version"],
+            floor=version_check["floor"],
+            ceiling=version_check["ceiling"],
+        )
+
+    bridge = BrainBridge(brain)
+    bridge._set_version_check(version_check)
+    return bridge

--- a/packages/tapps-core/src/tapps_core/config/settings.py
+++ b/packages/tapps-core/src/tapps_core/config/settings.py
@@ -555,6 +555,21 @@ class MemorySettings(BaseSettings):
         ),
     )
 
+    # TAP-519: remote brain version probe. When set, BrainBridge startup GETs
+    # {brain_http_url}/health and validates the returned ``version`` against the
+    # tapps-brain floor pinned in packages/tapps-core/pyproject.toml. In-process
+    # AgentBrain deployments leave this empty and skip the HTTP probe.
+    brain_http_url: str = Field(
+        default="",
+        description=(
+            "Optional base URL for the remote tapps-brain HTTP API (no trailing "
+            "slash). When set, BrainBridge startup probes {brain_http_url}/health "
+            "and fails loudly when the reported version is below the pinned floor "
+            "in packages/tapps-core/pyproject.toml. Leave empty for in-process "
+            "AgentBrain deployments. Env: TAPPS_MCP_MEMORY_BRAIN_HTTP_URL."
+        ),
+    )
+
     # EPIC-069 / ADR-010: multi-tenant project_id on the wire.
     project_id: str = Field(
         default="",

--- a/packages/tapps-core/tests/unit/test_brain_version.py
+++ b/packages/tapps-core/tests/unit/test_brain_version.py
@@ -1,0 +1,342 @@
+"""Tests for the remote tapps-brain version probe (TAP-519).
+
+Covers:
+
+- ``check_brain_version`` skips cleanly when the URL is empty.
+- Returns ``ok=True`` when the reported version satisfies the pinned floor.
+- Returns ``ok=False`` with a descriptive error when the version is below the floor.
+- Returns ``ok=False`` + ``degraded=True`` on HTTP/network failure (non-fatal).
+- ``create_brain_bridge`` wires the probe and stashes the result on the bridge.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_brain() -> MagicMock:
+    brain = MagicMock()
+    store = MagicMock()
+    store.count.return_value = 0
+    store.project_root = "."
+    brain.store = store
+    brain.hive = None
+    return brain
+
+
+def _mock_http_response(
+    *,
+    status_code: int = 200,
+    json_payload: dict[str, Any] | None = None,
+    raise_exc: Exception | None = None,
+) -> Any:
+    """Build a patchable replacement for ``httpx.get``."""
+
+    def _fake_get(url: str, timeout: float) -> httpx.Response:  # noqa: ARG001
+        if raise_exc is not None:
+            raise raise_exc
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            status_code=status_code,
+            json=json_payload if json_payload is not None else {},
+            request=request,
+        )
+
+    return _fake_get
+
+
+# ---------------------------------------------------------------------------
+# check_brain_version
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBrainVersion:
+    def test_skipped_when_url_empty(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        result = check_brain_version("")
+        assert result["ok"] is True
+        assert result["skipped"] is True
+        assert result["degraded"] is False
+        assert result["errors"] == []
+        assert result["version"] is None
+
+    def test_version_check_passes_when_floor_met(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(
+            json_payload={"status": "ok", "service": "tapps-brain", "version": "3.8.0"},
+        )
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example/")
+
+        assert result["ok"] is True
+        assert result["skipped"] is False
+        assert result["version"] == "3.8.0"
+        assert result["errors"] == []
+
+    def test_version_check_passes_at_exact_floor(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(
+            json_payload={"version": "3.7.2"},
+        )
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is True
+        assert result["version"] == "3.7.2"
+
+    def test_version_check_fails_when_below_floor(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(json_payload={"version": "3.6.0"})
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is False
+        assert result["version"] == "3.6.0"
+        assert len(result["errors"]) == 1
+        assert "3.6.0" in result["errors"][0]
+        assert ">=3.7.2" in result["errors"][0]
+
+    def test_version_check_fails_at_or_above_ceiling(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(json_payload={"version": "4.0.0"})
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is False
+        assert result["version"] == "4.0.0"
+        assert "4.0.0" in result["errors"][0]
+
+    def test_version_check_network_error_marks_degraded(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(raise_exc=httpx.ConnectError("connection refused"))
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is False
+        assert result["degraded"] is True
+        assert result["version"] is None
+        assert len(result["warnings"]) == 1
+        assert "connection refused" in result["warnings"][0]
+        # Network failure is reported as a warning, not an error — it's
+        # non-fatal in the health contract.
+        assert result["errors"] == []
+
+    def test_version_check_http_error_marks_degraded(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(status_code=500, json_payload={"detail": "boom"})
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is False
+        assert result["degraded"] is True
+        assert result["warnings"] != []
+
+    def test_version_check_missing_version_field_errors(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(json_payload={"status": "ok"})  # no "version"
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is False
+        assert result["degraded"] is False  # protocol-level error, not transport
+        assert "missing 'version'" in result["errors"][0]
+
+    def test_version_check_unparseable_version_errors(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(json_payload={"version": "not-a-version"})
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version("http://brain.example")
+
+        assert result["ok"] is False
+        assert "not-a-version" in result["errors"][0]
+
+    def test_trailing_slash_stripped(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        called_url: list[str] = []
+
+        def _capture(url: str, timeout: float) -> httpx.Response:  # noqa: ARG001
+            called_url.append(url)
+            return httpx.Response(
+                status_code=200,
+                json={"version": "3.8.0"},
+                request=httpx.Request("GET", url),
+            )
+
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=_capture):
+            check_brain_version("http://brain.example/")
+
+        assert called_url == ["http://brain.example/health"]
+
+    def test_custom_floor_and_ceiling(self) -> None:
+        from tapps_core.brain_bridge import check_brain_version
+
+        fake_get = _mock_http_response(json_payload={"version": "5.1.0"})
+        with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
+            result = check_brain_version(
+                "http://brain.example", floor="5.0.0", ceiling="6.0.0"
+            )
+
+        assert result["ok"] is True
+        assert result["floor"] == "5.0.0"
+        assert result["ceiling"] == "6.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Factory integration
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryWiring:
+    def test_bridge_stashes_skipped_result_when_url_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://x/db")
+
+        settings = MagicMock()
+        settings.memory.database_url = "postgresql://x/db"
+        settings.memory.profile = "repo-brain"
+        settings.memory.hive_dsn = ""
+        settings.memory.project_id = ""
+        settings.memory.pg_pool_max_waiting = 0
+        settings.memory.pg_pool_max_lifetime_seconds = 0
+        settings.memory.brain_http_url = ""
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            bridge = create_brain_bridge(settings=settings)
+
+        assert bridge is not None
+        assert bridge.version_check["skipped"] is True
+        assert bridge.version_check["ok"] is True
+
+    def test_bridge_stashes_ok_result_when_version_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://x/db")
+
+        settings = MagicMock()
+        settings.memory.database_url = "postgresql://x/db"
+        settings.memory.profile = "repo-brain"
+        settings.memory.hive_dsn = ""
+        settings.memory.project_id = ""
+        settings.memory.pg_pool_max_waiting = 0
+        settings.memory.pg_pool_max_lifetime_seconds = 0
+        settings.memory.brain_http_url = "http://brain.example"
+
+        fake_get = _mock_http_response(json_payload={"version": "3.8.0"})
+        with (
+            patch("tapps_brain.AgentBrain", return_value=_make_brain()),
+            patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get),
+        ):
+            bridge = create_brain_bridge(settings=settings)
+
+        assert bridge is not None
+        assert bridge.version_check["ok"] is True
+        assert bridge.version_check["version"] == "3.8.0"
+        assert bridge.version_check["skipped"] is False
+
+    def test_bridge_still_returned_when_version_below_floor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Version mismatch is logged loudly but does not block the bridge.
+
+        Callers (e.g. ``tapps_session_start``) surface ``bridge.version_check``
+        to operators. Blocking bridge creation would hide other memory
+        operations that might still work against an older brain.
+        """
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://x/db")
+
+        settings = MagicMock()
+        settings.memory.database_url = "postgresql://x/db"
+        settings.memory.profile = "repo-brain"
+        settings.memory.hive_dsn = ""
+        settings.memory.project_id = ""
+        settings.memory.pg_pool_max_waiting = 0
+        settings.memory.pg_pool_max_lifetime_seconds = 0
+        settings.memory.brain_http_url = "http://brain.example"
+
+        fake_get = _mock_http_response(json_payload={"version": "3.6.0"})
+        with (
+            patch("tapps_brain.AgentBrain", return_value=_make_brain()),
+            patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get),
+        ):
+            bridge = create_brain_bridge(settings=settings)
+
+        assert bridge is not None
+        assert bridge.version_check["ok"] is False
+        assert "3.6.0" in bridge.version_check["errors"][0]
+
+    def test_bridge_still_returned_on_network_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://x/db")
+
+        settings = MagicMock()
+        settings.memory.database_url = "postgresql://x/db"
+        settings.memory.profile = "repo-brain"
+        settings.memory.hive_dsn = ""
+        settings.memory.project_id = ""
+        settings.memory.pg_pool_max_waiting = 0
+        settings.memory.pg_pool_max_lifetime_seconds = 0
+        settings.memory.brain_http_url = "http://brain.example"
+
+        fake_get = _mock_http_response(raise_exc=httpx.ConnectError("no route"))
+        with (
+            patch("tapps_brain.AgentBrain", return_value=_make_brain()),
+            patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get),
+        ):
+            bridge = create_brain_bridge(settings=settings)
+
+        assert bridge is not None
+        assert bridge.version_check["ok"] is False
+        assert bridge.version_check["degraded"] is True
+
+
+# ---------------------------------------------------------------------------
+# version_check property snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestVersionCheckProperty:
+    def test_default_version_check_is_skipped_sentinel(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        bridge = BrainBridge(_make_brain())
+        snapshot = bridge.version_check
+        assert snapshot["skipped"] is True
+        assert snapshot["ok"] is True
+
+    def test_version_check_returns_copy(self) -> None:
+        """The property must return a defensive copy so callers can't mutate the cached result."""
+        from tapps_core.brain_bridge import BrainBridge
+
+        bridge = BrainBridge(_make_brain())
+        snapshot = bridge.version_check
+        snapshot["ok"] = False  # mutate the copy
+        assert bridge.version_check["ok"] is True  # original untouched

--- a/packages/tapps-core/tests/unit/test_brain_version.py
+++ b/packages/tapps-core/tests/unit/test_brain_version.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -41,7 +40,7 @@ def _mock_http_response(
 ) -> Any:
     """Build a patchable replacement for ``httpx.get``."""
 
-    def _fake_get(url: str, timeout: float) -> httpx.Response:  # noqa: ARG001
+    def _fake_get(url: str, timeout: float) -> httpx.Response:
         if raise_exc is not None:
             raise raise_exc
         request = httpx.Request("GET", url)
@@ -173,7 +172,7 @@ class TestCheckBrainVersion:
 
         called_url: list[str] = []
 
-        def _capture(url: str, timeout: float) -> httpx.Response:  # noqa: ARG001
+        def _capture(url: str, timeout: float) -> httpx.Response:
             called_url.append(url)
             return httpx.Response(
                 status_code=200,
@@ -191,9 +190,7 @@ class TestCheckBrainVersion:
 
         fake_get = _mock_http_response(json_payload={"version": "5.1.0"})
         with patch("tapps_core.brain_bridge.httpx.get", side_effect=fake_get):
-            result = check_brain_version(
-                "http://brain.example", floor="5.0.0", ceiling="6.0.0"
-            )
+            result = check_brain_version("http://brain.example", floor="5.0.0", ceiling="6.0.0")
 
         assert result["ok"] is True
         assert result["floor"] == "5.0.0"
@@ -290,9 +287,7 @@ class TestFactoryWiring:
         assert bridge.version_check["ok"] is False
         assert "3.6.0" in bridge.version_check["errors"][0]
 
-    def test_bridge_still_returned_on_network_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_bridge_still_returned_on_network_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from tapps_core.brain_bridge import create_brain_bridge
 
         monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://x/db")


### PR DESCRIPTION
## Summary

Closes [TAP-519](https://linear.app/tappscodingagents/issue/TAP-519).

`packages/tapps-core/pyproject.toml` pins `tapps-brain>=3.7.2,<4`, but nothing verified at runtime that the deployed brain actually satisfies the floor. A misconfigured deployment could silently run against an older brain and only surface the mismatch deep in a user's session. tapps-brain v3.8.0 ships an unauthenticated `GET /health` — this PR probes it at BrainBridge startup.

### What lands
- **`check_brain_version(brain_http_url)`** in `tapps_core.brain_bridge`: GETs `{url}/health`, parses `version`, compares against the pinned floor/ceiling via `packaging.version.Version`.
- **Factory wiring**: `create_brain_bridge` calls it after the existing DSN probe. Result is stashed on the bridge and exposed via a `BrainBridge.version_check` property so callers (e.g. `tapps_session_start`) can surface it.
- **New setting**: `MemorySettings.brain_http_url` (empty default, env `TAPPS_MCP_MEMORY_BRAIN_HTTP_URL`). Empty = skip probe (in-process `AgentBrain` deployments).

### Return shape
```python
{
  "ok": bool,
  "skipped": bool,        # True when brain_http_url is empty
  "degraded": bool,       # True on network/parse failure (non-fatal)
  "url": str,
  "floor": "3.7.2",
  "ceiling": "4.0.0",
  "version": str | None,  # reported by brain
  "errors": list[str],
  "warnings": list[str],
}
```

### Behaviour
- Empty URL (default) -> skipped, `ok=True`.
- Version below floor or >= ceiling -> `ok=False`, descriptive error logged via `structlog.error`; bridge still returned so unrelated memory ops work.
- Network / HTTP 5xx / bad JSON -> `ok=False`, `degraded=True`, warning logged; bridge returned.
- Missing `version` field / unparseable version -> `ok=False` with an error in the payload.

### Rebase note (TAP-523 / PR #101)
PR #101 (TAP-523) adds a `health_check()` method that validates DSN + pool config and surfaces results in `tapps_session_start` under a `brain_bridge_health` field. This PR is based on `master` since #101 isn't merged yet. Once #101 lands, the version-check payload should be folded into `health_check()` — the shape already matches (`ok`/`errors`/`warnings`/`details`), so it's a mechanical merge. The dedicated `version_check` property can either remain (small defensive accessor) or be collapsed into `health_check()`'s `details` block.

## Test plan

- [x] `packages/tapps-core/tests/unit/test_brain_version.py` — 17 new unit tests:
  - `test_skipped_when_url_empty`
  - `test_version_check_passes_when_floor_met` / `_at_exact_floor` / custom-bounds
  - `test_version_check_fails_when_below_floor` / `_at_or_above_ceiling`
  - `test_version_check_network_error_marks_degraded`
  - `test_version_check_http_error_marks_degraded`
  - `test_version_check_missing_version_field_errors`
  - `test_version_check_unparseable_version_errors`
  - `test_trailing_slash_stripped`
  - `TestFactoryWiring` — 4 tests covering skipped / ok / below-floor / network-error paths through `create_brain_bridge`
  - `TestVersionCheckProperty` — default sentinel + defensive-copy semantics
- [x] `uv run ruff check packages/tapps-core/src/` — clean
- [x] `uv run mypy --strict packages/tapps-core/src/tapps_core/` — clean (94 files)
- [x] `uv run pytest packages/tapps-core/tests/ -k "brain_bridge or version" -v` — 72 pass, 1 skipped, 0 fail
- [x] `uv run pytest packages/tapps-core/tests/ -m "not slow"` — 1112 pass, 6 skipped, 0 regressions

Mocking uses `unittest.mock.patch` against `tapps_core.brain_bridge.httpx.get`, matching the patch-at-source style already used in `test_brain_cridge.py`'s factory tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)