### PR TITLE
[TAP-518] persist stable agent_id in .tapps-mcp/agent.id

### DIFF
--- a/packages/tapps-core/src/tapps_core/agent_identity.py
+++ b/packages/tapps-core/src/tapps_core/agent_identity.py
@@ -1,0 +1,116 @@
+"""Stable agent identity persisted to ``.tapps-mcp/agent.id``.
+
+Replaces the PID-based fallback (``f"agent-{os.getpid()}"``) that changed on
+every MCP server restart, causing Hive memory attribution drift and duplicate
+agent registrations.
+
+Final agent_id shape::
+
+    f"{project_slug}-{uuid_hex_8}"
+
+where ``project_slug`` is ``settings.memory.project_id`` when set, else the
+project root directory name; and ``uuid_hex_8`` is the first 8 hex chars of a
+UUID4 persisted to ``{project_root}/.tapps-mcp/agent.id`` on first call.
+
+See TAP-518.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from tapps_core.config.settings import TappsMCPSettings
+
+logger = structlog.get_logger(__name__)
+
+_AGENT_ID_RELATIVE_PATH = Path(".tapps-mcp") / "agent.id"
+_UUID_SHORT_LEN = 8
+_SLUG_INVALID_RE = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+def _slugify(value: str) -> str:
+    """Reduce a string to a safe agent-id prefix (alnum/dash/underscore)."""
+    cleaned = _SLUG_INVALID_RE.sub("-", value).strip("-_")
+    return cleaned or "tapps-mcp"
+
+
+def _project_slug(settings: TappsMCPSettings) -> str:
+    """Derive the project-name prefix for the agent id.
+
+    Prefers ``settings.memory.project_id`` (the registered tapps-brain slug);
+    falls back to the project root directory name.
+    """
+    memory = getattr(settings, "memory", None)
+    project_id = str(getattr(memory, "project_id", "") or "").strip()
+    if project_id:
+        return _slugify(project_id)
+    root = Path(getattr(settings, "project_root", Path.cwd()))
+    return _slugify(root.name)
+
+
+def _read_uuid(path: Path) -> str | None:
+    """Return the persisted UUID hex (stripped), or None if unreadable/empty."""
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return raw or None
+
+
+def _write_uuid(path: Path, value: str) -> None:
+    """Persist *value* to *path*, creating the parent directory as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value + "\n", encoding="utf-8")
+
+
+def get_stable_agent_id(settings: TappsMCPSettings) -> str:
+    """Return the stable agent id, honouring ``CLAUDE_AGENT_ID`` overrides.
+
+    Precedence:
+
+    1. ``CLAUDE_AGENT_ID`` environment variable (unchanged from prior behaviour).
+    2. ``f"{project_slug}-{uuid8}"`` with UUID persisted to
+       ``{project_root}/.tapps-mcp/agent.id``.
+
+    The file is created on first call. Subsequent calls read the same UUID so
+    the agent id survives MCP server restarts.
+    """
+    override = os.environ.get("CLAUDE_AGENT_ID", "").strip()
+    if override:
+        return override
+
+    project_root = Path(getattr(settings, "project_root", Path.cwd()))
+    id_path = project_root / _AGENT_ID_RELATIVE_PATH
+
+    uuid_hex = _read_uuid(id_path)
+    if uuid_hex is None:
+        uuid_hex = uuid.uuid4().hex
+        try:
+            _write_uuid(id_path, uuid_hex)
+            logger.info(
+                "agent_identity.created",
+                path=str(id_path),
+            )
+        except OSError as exc:
+            # Read-only FS or permission denied — fall back to an in-memory
+            # UUID so the caller still gets a non-PID identifier for this
+            # process. It won't persist, but it won't collide with other
+            # concurrent sessions either.
+            logger.warning(
+                "agent_identity.persist_failed",
+                path=str(id_path),
+                error=str(exc),
+            )
+
+    short = uuid_hex[:_UUID_SHORT_LEN]
+    return f"{_project_slug(settings)}-{short}"
+
+
+__all__ = ["get_stable_agent_id"]

--- a/packages/tapps-core/tests/unit/test_agent_identity.py
+++ b/packages/tapps-core/tests/unit/test_agent_identity.py
@@ -1,0 +1,121 @@
+"""Tests for ``tapps_core.agent_identity`` (TAP-518)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tapps_core.agent_identity import get_stable_agent_id
+from tapps_core.config.settings import TappsMCPSettings
+
+if TYPE_CHECKING:
+    import pytest
+
+_AGENT_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+-[0-9a-f]{8}$")
+
+
+def _make_settings(project_root: Path, *, project_id: str = "") -> TappsMCPSettings:
+    """Build a minimal settings object anchored at *project_root*."""
+    settings = TappsMCPSettings(project_root=project_root)
+    # ``project_id`` lives on MemorySettings; override post-construction so we
+    # don't depend on env vars leaking into the test runner.
+    settings.memory.project_id = project_id
+    return settings
+
+
+def test_agent_id_created_on_first_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """First call writes ``.tapps-mcp/agent.id`` with a UUID4 hex."""
+    monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
+    project = tmp_path / "proj"
+    project.mkdir()
+    settings = _make_settings(project, project_id="tapps-mcp")
+
+    id_path = project / ".tapps-mcp" / "agent.id"
+    assert not id_path.exists()
+
+    agent_id = get_stable_agent_id(settings)
+
+    assert id_path.exists(), "agent.id should be created on first call"
+    persisted = id_path.read_text(encoding="utf-8").strip()
+    assert len(persisted) == 32, "persisted UUID should be 32 hex chars"
+    assert agent_id.endswith(persisted[:8])
+
+
+def test_agent_id_stable_across_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-reading the persisted file yields the same agent_id across instances."""
+    monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    first = get_stable_agent_id(_make_settings(project, project_id="tapps-mcp"))
+    # Fresh settings instance — simulates MCP server restart.
+    second = get_stable_agent_id(_make_settings(project, project_id="tapps-mcp"))
+
+    assert first == second
+    # Third call on the same instance is also stable.
+    settings = _make_settings(project, project_id="tapps-mcp")
+    assert get_stable_agent_id(settings) == get_stable_agent_id(settings)
+
+
+def test_agent_id_format(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returned id has shape ``<slug>-<8 hex chars>``."""
+    monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
+    project = tmp_path / "proj"
+    project.mkdir()
+    settings = _make_settings(project, project_id="tapps-mcp")
+
+    agent_id = get_stable_agent_id(settings)
+
+    assert _AGENT_ID_RE.match(agent_id), f"unexpected format: {agent_id!r}"
+    assert agent_id.startswith("tapps-mcp-")
+
+
+def test_agent_id_falls_back_to_project_root_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``memory.project_id`` is empty, the project root dir name is used."""
+    monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
+    project = tmp_path / "my-app"
+    project.mkdir()
+    settings = _make_settings(project, project_id="")
+
+    agent_id = get_stable_agent_id(settings)
+
+    assert agent_id.startswith("my-app-")
+    assert _AGENT_ID_RE.match(agent_id)
+
+
+def test_agent_id_respects_claude_agent_id_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CLAUDE_AGENT_ID`` env var still takes precedence (unchanged contract)."""
+    monkeypatch.setenv("CLAUDE_AGENT_ID", "explicit-override")
+    project = tmp_path / "proj"
+    project.mkdir()
+    settings = _make_settings(project, project_id="tapps-mcp")
+
+    agent_id = get_stable_agent_id(settings)
+
+    assert agent_id == "explicit-override"
+    # No file should be created when the env var short-circuits.
+    assert not (project / ".tapps-mcp" / "agent.id").exists()
+
+
+def test_agent_id_slugifies_unsafe_project_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Characters outside ``[A-Za-z0-9_-]`` are collapsed into dashes."""
+    monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
+    project = tmp_path / "proj"
+    project.mkdir()
+    settings = _make_settings(project, project_id="my project/v2")
+
+    agent_id = get_stable_agent_id(settings)
+
+    assert agent_id.startswith("my-project-v2-")
+    assert _AGENT_ID_RE.match(agent_id)

--- a/packages/tapps-core/tests/unit/test_agent_identity.py
+++ b/packages/tapps-core/tests/unit/test_agent_identity.py
@@ -24,9 +24,7 @@ def _make_settings(project_root: Path, *, project_id: str = "") -> TappsMCPSetti
     return settings
 
 
-def test_agent_id_created_on_first_call(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_agent_id_created_on_first_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """First call writes ``.tapps-mcp/agent.id`` with a UUID4 hex."""
     monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
     project = tmp_path / "proj"
@@ -44,9 +42,7 @@ def test_agent_id_created_on_first_call(
     assert agent_id.endswith(persisted[:8])
 
 
-def test_agent_id_stable_across_calls(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_agent_id_stable_across_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Re-reading the persisted file yields the same agent_id across instances."""
     monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
     project = tmp_path / "proj"

--- a/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
@@ -418,8 +418,10 @@ def collect_session_hive_status(settings: TappsMCPSettings) -> dict[str, Any]:
 
         from tapps_brain.models import AgentRegistration
 
+        from tapps_core.agent_identity import get_stable_agent_id
+
         active_profile = settings.memory.profile or "repo-brain"
-        agent_id = os.environ.get("CLAUDE_AGENT_ID", f"agent-{os.getpid()}")
+        agent_id = get_stable_agent_id(settings)
         agent_name = os.environ.get("CLAUDE_AGENT_NAME", "unnamed")
         registry.register(
             AgentRegistration(

--- a/packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py
@@ -1983,8 +1983,10 @@ async def _handle_hive_status(store: MemoryStore, _p: _Params) -> dict[str, Any]
             "store_metadata": _store_metadata(store),
         }
 
+    from tapps_core.agent_identity import get_stable_agent_id
+
     settings = load_settings()
-    agent_id = os.environ.get("CLAUDE_AGENT_ID", f"agent-{os.getpid()}")
+    agent_id = get_stable_agent_id(settings)
     agent_name = os.environ.get("CLAUDE_AGENT_NAME", "unnamed")
 
     status = await bridge.hive_status(
@@ -2091,9 +2093,11 @@ async def _handle_hive_propagate(store: MemoryStore, p: _Params) -> dict[str, An
             "store_metadata": _store_metadata(store),
         }
 
+    from tapps_core.agent_identity import get_stable_agent_id
+
     settings = load_settings()
     active_profile = settings.memory.profile or "repo-brain"
-    agent_id = os.environ.get("CLAUDE_AGENT_ID", f"agent-{os.getpid()}")
+    agent_id = get_stable_agent_id(settings)
 
     cap = p.limit if p.limit > 0 else _HIVE_PROPAGATE_DEFAULT_LIMIT
     entries = store.snapshot().entries[:cap]


### PR DESCRIPTION
## Summary

- Replaces the PID-based `agent_id` fallback (`f"agent-{os.getpid()}"`) that changed on every MCP server restart, which was drifting Hive memory attribution and duplicating agent registrations across sessions.
- Adds `tapps_core.agent_identity.get_stable_agent_id(settings)` which persists a UUID4 to `{project_root}/.tapps-mcp/agent.id` on first call and reuses it thereafter. Final id shape: `f"{project_slug}-{uuid_hex_8}"` per TAP-518 spec.
- Wires all three existing call sites (`server_helpers.hive_status`, `server_memory_tools._handle_tapps_memory_hive_status`, `_handle_hive_propagate`) to the new helper. `CLAUDE_AGENT_ID` env override is preserved.

Project slug prefers `settings.memory.project_id` (the registered tapps-brain slug); falls back to the project root directory name when unset. Characters outside `[A-Za-z0-9_-]` are collapsed into dashes so the id is always safe.

Degrades gracefully: when `.tapps-mcp/agent.id` can't be written (read-only FS), the caller still receives a fresh UUID-based id for the process, just not persisted — still better than the PID that different sessions would collide on.

`.tapps-mcp/` is already in `.gitignore`; no ignore change needed.

## Test plan

- [x] `uv run ruff check packages/tapps-core/src/ packages/tapps-mcp/src/` — clean
- [x] `uv run mypy --strict packages/tapps-core/src/tapps_core/` — clean (95 files)
- [x] `uv run pytest packages/tapps-core/tests/ -k "agent_id or identity" -v` — 28 passed, 4 skipped (6 new `test_agent_identity.py` tests + existing memory-reexport tests)
- [x] `uv run pytest packages/tapps-mcp/tests/ -k "hive or agent_register"` — 18 passed (regression on changed call sites)
- [ ] Full `packages/tapps-mcp/tests/ -m "not slow"` — skipped: exceeded 2 min locally; `not slow` subset of memory/hive tests exercised instead

Closes TAP-518.

Co-located with TAP-519 and TAP-521 which may also touch `brain_bridge.py`; kept scope tight (only the three PID sites + one new helper module + tests) so rebase stays trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)