### PR TITLE
[TAP-572] stop probing Postgres DSN client-side for Hive status

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import Context
-    from tapps_brain import HiveBackend as _HiveStoreType
-    from tapps_brain.backends import AgentRegistry as _HiveAgentRegistryType
 
     from tapps_core.brain_bridge import BrainBridge as _BrainBridgeType
     from tapps_core.config.settings import TappsMCPSettings
@@ -277,13 +275,13 @@ def build_impact_memory_context(
 
 # ---------------------------------------------------------------------------
 # Hive (tapps_brain.hive) — optional; gated by Agent Teams env (Epic M3)
+#
+# TAP-572: tapps-mcp is a *client* of tapps-brain. Hive lives server-side,
+# behind the BrainBridge / brain MCP surface. We no longer instantiate a
+# local Postgres-backed Hive backend from this process; session-level Hive
+# status is obtained via ``BrainBridge.hive_status``. ``_reset_hive_store_cache``
+# is retained as a no-op compat shim for the test conftest autouse fixture.
 # ---------------------------------------------------------------------------
-
-_hive_store: Any | None = None
-_hive_registry: Any | None = None
-_hive_import_error: str | None = None
-_hive_init_error: str | None = None
-_hive_lock = threading.Lock()
 
 
 def _agent_teams_env_enabled() -> bool:
@@ -292,93 +290,13 @@ def _agent_teams_env_enabled() -> bool:
 
 
 def _reset_hive_store_cache() -> None:
-    """Reset Hive singletons and cached error state (for testing)."""
-    global _hive_store, _hive_registry, _hive_import_error, _hive_init_error
-    with _hive_lock:
-        if _hive_store is not None:
-            with contextlib.suppress(Exception):
-                _hive_store.close()
-        _hive_store = None
-        _hive_registry = None
-        _hive_import_error = None
-        _hive_init_error = None
+    """Compat no-op (TAP-572 removed client-side Hive singletons).
 
-
-def _ensure_hive_singletons() -> tuple[
-    _HiveStoreType | None,
-    _HiveAgentRegistryType | None,
-    str | None,
-]:
-    """Lazily construct Hive store and agent registry.
-
-    Returns ``(hive_store, agent_registry, error_message)``. *error_message*
-    is populated with an actionable reason when init cannot complete: missing
-    tapps-brain import, missing/invalid ``TAPPS_BRAIN_DATABASE_URL``, or a
-    ``create_hive_backend`` failure. Backend-init failures are cached so we
-    don't retry a known-broken DSN on every call; DSN-missing is *not* cached
-    (env may be set later by a fixture or sidecar).
+    Kept so ``packages/tapps-mcp/tests/conftest.py`` continues to import
+    and call it from the autouse cache-reset fixture without needing a
+    coordinated change.
     """
-    global _hive_store, _hive_registry, _hive_import_error, _hive_init_error
-    if not _agent_teams_env_enabled():
-        return None, None, None
-    if _hive_import_error is not None:
-        return None, None, _hive_import_error
-    with _hive_lock:
-        if _hive_import_error is not None:
-            return None, None, _hive_import_error
-        try:
-            # tapps-brain v3: AgentRegistry moved from hive to backends.
-            # File-backed HiveStore was removed (ADR-007); postgres hive is
-            # available via create_hive_backend() when DATABASE_URL is set.
-            from tapps_brain.backends import AgentRegistry
-        except ImportError as exc:
-            _hive_import_error = str(exc)
-            return None, None, _hive_import_error
-        if _hive_store is None:
-            dsn = os.environ.get("TAPPS_BRAIN_DATABASE_URL", "")
-            if not dsn:
-                return (
-                    None,
-                    None,
-                    (
-                        "TAPPS_BRAIN_DATABASE_URL not configured "
-                        "(Postgres DSN required for Hive; ADR-007)"
-                    ),
-                )
-            if not dsn.startswith(("postgres://", "postgresql://")):
-                scheme = dsn.split("://", 1)[0] if "://" in dsn else "<none>"
-                return (
-                    None,
-                    None,
-                    (
-                        f"TAPPS_BRAIN_DATABASE_URL scheme '{scheme}' not supported "
-                        "(Hive requires postgres:// or postgresql://)"
-                    ),
-                )
-            if _hive_init_error is not None:
-                return None, None, _hive_init_error
-            try:
-                from tapps_brain.backends import create_hive_backend
-
-                _hive_store = create_hive_backend(dsn)
-            except Exception as exc:
-                _hive_init_error = f"create_hive_backend failed: {exc}"
-                return None, None, _hive_init_error
-        if _hive_registry is None:
-            _hive_registry = AgentRegistry()
-    return _hive_store, _hive_registry, None
-
-
-def _get_hive_store() -> _HiveStoreType | None:
-    """Return :class:`HiveStore` singleton when Agent Teams env is set, else None."""
-    store, _, _err = _ensure_hive_singletons()
-    return store
-
-
-def _get_hive_registry() -> _HiveAgentRegistryType | None:
-    """Return :class:`AgentRegistry` singleton when Agent Teams env is set, else None."""
-    _, registry, _err = _ensure_hive_singletons()
-    return registry
+    return None
 
 
 def initial_session_hive_status() -> dict[str, Any]:
@@ -389,63 +307,78 @@ def initial_session_hive_status() -> dict[str, Any]:
     return {"enabled": False}
 
 
-def collect_session_hive_status(settings: TappsMCPSettings) -> dict[str, Any]:
+async def collect_session_hive_status(settings: TappsMCPSettings) -> dict[str, Any]:
     """Build ``hive_status`` payload for :func:`tapps_session_start`.
 
-    When ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`` is unset, returns
-    ``{"enabled": False}``. When set, registers this process as a Hive agent
-    (best-effort) and returns namespace / agent counts. On failure, returns
-    ``degraded: true`` with an actionable message (non-fatal), matching other
-    optional tapps-brain integrations.
+    TAP-572: tapps-mcp is a **client** of tapps-brain — Hive lives server-side.
+    This helper no longer probes a Postgres DSN directly; it asks the
+    :class:`BrainBridge` for Hive status (``bridge.hive_status``) and reports
+    whatever the brain says. When the bridge is not available (brain not
+    configured / unreachable), we report ``enabled: "unknown"`` rather than
+    fabricating a client-side DSN error — per the memory rule *"no client-side
+    mirror of server-enforced rules"*.
+
+    Behavior:
+
+    * ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`` unset -> ``{"enabled": False}``.
+    * Agent Teams on, bridge unavailable -> ``enabled: "unknown"``,
+      ``degraded: true``, message points at brain connectivity
+      (``TAPPS_BRAIN_BASE_URL`` / ``TAPPS_BRAIN_AUTH_TOKEN`` /
+      ``TAPPS_BRAIN_DATABASE_URL`` on the brain server) — not a local DSN.
+    * Agent Teams on, bridge available -> pass through
+      ``bridge.hive_status(...)`` result, with ``agent_id`` surfaced for the
+      session-start payload.
 
     Propagation tier rules (``auto_propagate_tiers`` / ``private_tiers``) are
     intentionally not mirrored here: tapps-brain's ``PropagationEngine``
     enforces them server-side on every ``hive_propagate`` / ``hive_push`` call.
-    Clients read the propagation outcome from the response, not the rules.
     """
     if not _agent_teams_env_enabled():
         return initial_session_hive_status()
 
-    try:
-        store, registry, init_err = _ensure_hive_singletons()
-        if init_err or store is None or registry is None:
-            reason = init_err or "Hive singletons unavailable"
-            return {
-                "enabled": True,
-                "degraded": True,
-                "message": f"Hive unavailable: {reason}",
-            }
+    from tapps_core.agent_identity import get_stable_agent_id
 
-        from tapps_brain.models import AgentRegistration
-
-        from tapps_core.agent_identity import get_stable_agent_id
-
-        active_profile = settings.memory.profile or "repo-brain"
-        agent_id = get_stable_agent_id(settings)
-        agent_name = os.environ.get("CLAUDE_AGENT_NAME", "unnamed")
-        registry.register(
-            AgentRegistration(
-                id=agent_id,
-                name=agent_name,
-                profile=active_profile,
-                project_root=str(settings.project_root),
-            )
-        )
-        namespaces = store.list_namespaces()
-        agents = registry.list_agents()
+    bridge = _get_brain_bridge()
+    agent_id = get_stable_agent_id(settings)
+    if bridge is None:
         return {
-            "enabled": True,
-            "degraded": False,
-            "agent_id": agent_id,
-            "namespaces": namespaces,
-            "registered_agents_count": len(agents),
+            "enabled": "unknown",
+            "degraded": True,
+            "message": (
+                "Hive status unknown: tapps-brain not reachable from this "
+                "MCP server. Configure TAPPS_BRAIN_BASE_URL / "
+                "TAPPS_BRAIN_AUTH_TOKEN (remote brain) or "
+                "TAPPS_BRAIN_DATABASE_URL (in-process brain) so the brain "
+                "can answer hive queries."
+            ),
         }
+
+    agent_name = os.environ.get("CLAUDE_AGENT_NAME", "unnamed")
+    active_profile = settings.memory.profile or "repo-brain"
+    try:
+        result = await bridge.hive_status(
+            agent_id=agent_id,
+            agent_name=agent_name,
+            agent_profile=active_profile,
+            project_root=str(settings.project_root),
+            register=True,
+        )
     except Exception as exc:
         return {
             "enabled": True,
             "degraded": True,
             "message": f"Hive status failed: {exc}",
         }
+
+    # bridge.hive_status returns dict with enabled/degraded/namespaces/agents.
+    # Surface agent_id for the session-start payload (clients use it to
+    # correlate subsequent hive_push / hive_propagate calls).
+    if isinstance(result, dict):
+        result.setdefault("agent_id", agent_id)
+        agents = result.get("agents")
+        if isinstance(agents, list):
+            result.setdefault("registered_agents_count", len(agents))
+    return result
 
 
 # STORY-101.4 — actionable error envelope.

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -1558,7 +1558,7 @@ async def tapps_session_start(
     phase_start = time.perf_counter_ns()
     hive_status: dict[str, Any] = initial_session_hive_status()
     try:
-        hive_status = collect_session_hive_status(settings)
+        hive_status = await collect_session_hive_status(settings)
     except Exception:
         _logger.debug("hive_status_check_failed", exc_info=True)
     timings["hive_status_ms"] = (time.perf_counter_ns() - phase_start) // 1_000_000
@@ -1700,7 +1700,7 @@ async def _session_start_quick(
 
     hive_status: dict[str, Any] = initial_session_hive_status()
     try:
-        hive_status = collect_session_hive_status(settings)
+        hive_status = await collect_session_hive_status(settings)
     except Exception:
         _logger.debug("hive_status_check_failed_quick", exc_info=True)
 

--- a/packages/tapps-mcp/tests/unit/test_memory_hive_session.py
+++ b/packages/tapps-mcp/tests/unit/test_memory_hive_session.py
@@ -1,179 +1,238 @@
-"""Hive / Agent Teams session wiring (Epic M3 chunk B)."""
+"""Hive / Agent Teams session wiring (TAP-572).
+
+tapps-mcp is a client of tapps-brain. Hive status is reported by asking the
+BrainBridge, not by reading ``TAPPS_BRAIN_DATABASE_URL`` locally. These tests
+prove ``collect_session_hive_status`` never touches the Postgres DSN directly
+and instead routes through ``BrainBridge.hive_status``.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from tapps_core.config.settings import load_settings
 
 
-def test_collect_session_hive_status_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_collect_session_hive_status_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Agent Teams flag unset -> baseline (no probe, no bridge touch)."""
     monkeypatch.delenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", raising=False)
-    from tapps_mcp.server_helpers import _reset_hive_store_cache, collect_session_hive_status
+    from tapps_mcp.server_helpers import collect_session_hive_status
 
-    _reset_hive_store_cache()
     settings = load_settings()
-    out = collect_session_hive_status(settings)
-    assert out["enabled"] is False
-    assert "propagation_config" not in out
-
-
-def test_collect_session_hive_status_happy_path(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Happy-path hive status — mocks the hive store (v3 removed file-backed HiveStore).
-
-    tapps-brain v3 (ADR-007) removed the file-backed HiveStore; a Postgres DSN is
-    required for a real hive backend.  The test mocks _ensure_hive_singletons to
-    inject a minimal stub and a real AgentRegistry, exercising the non-degraded
-    code path without requiring Postgres.
-    """
-    from unittest.mock import MagicMock
-
-    from tapps_brain.backends import AgentRegistry
-
-    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from tapps_mcp.server_helpers import _reset_hive_store_cache, collect_session_hive_status
-
-    _reset_hive_store_cache()
-    settings = load_settings()
-
-    # Stub hive store with list_namespaces (file-backed store removed in v3).
-    mock_store = MagicMock()
-    mock_store.list_namespaces.return_value = ["universal", "test"]
-    real_registry = AgentRegistry(registry_path=tmp_path / "agents.yaml")
-
-    with patch(
-        "tapps_mcp.server_helpers._ensure_hive_singletons",
-        return_value=(mock_store, real_registry, None),
-    ):
-        result = collect_session_hive_status(settings)
-
-    assert result["enabled"] is True
-    assert result.get("degraded") is False
-    assert "agent_id" in result
-    assert isinstance(result.get("namespaces"), list)
-    assert result.get("registered_agents_count", 0) >= 1
-    assert "propagation_config" not in result
-
-
-def test_collect_session_hive_status_degraded_on_import_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
-    from tapps_mcp.server_helpers import _reset_hive_store_cache, collect_session_hive_status
-
-    _reset_hive_store_cache()
-
-    def _boom() -> tuple[None, None, str]:
-        return None, None, "simulated import failure"
-
-    with patch("tapps_mcp.server_helpers._ensure_hive_singletons", _boom):
-        settings = load_settings()
-        result = collect_session_hive_status(settings)
-    assert result["enabled"] is True
-    assert result.get("degraded") is True
-    assert "simulated import failure" in (result.get("message") or "")
-    assert "propagation_config" not in result
-
-
-def test_collect_session_hive_status_reports_missing_dsn(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When Agent Teams is on but TAPPS_BRAIN_DATABASE_URL is unset, the status
-    message must name the missing DSN — not the misleading
-    ``Hive singleton initialization failed`` that masked the real cause.
-    """
-    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
-    monkeypatch.delenv("TAPPS_BRAIN_DATABASE_URL", raising=False)
-    from tapps_mcp.server_helpers import _reset_hive_store_cache, collect_session_hive_status
-
-    _reset_hive_store_cache()
-    settings = load_settings()
-    result = collect_session_hive_status(settings)
-
-    assert result["enabled"] is True
-    assert result.get("degraded") is True
-    message = result.get("message") or ""
-    assert "TAPPS_BRAIN_DATABASE_URL" in message
-    assert "not configured" in message
-
-
-def test_collect_session_hive_status_reports_bad_dsn_scheme(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Non-postgres DSN schemes must be reported by name, not swallowed."""
-    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
-    monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "sqlite:///tmp/brain.db")
-    from tapps_mcp.server_helpers import _reset_hive_store_cache, collect_session_hive_status
-
-    _reset_hive_store_cache()
-    settings = load_settings()
-    result = collect_session_hive_status(settings)
-
-    assert result["enabled"] is True
-    assert result.get("degraded") is True
-    message = result.get("message") or ""
-    assert "sqlite" in message
-    assert "postgres" in message
-
-
-def test_ensure_hive_singletons_caches_backend_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``create_hive_backend`` raising should surface the exception message and
-    cache it so we don't retry a known-broken DSN on every call.
-    """
-    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
-    monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://nope:5432/x")
-    from tapps_mcp import server_helpers
-    from tapps_mcp.server_helpers import _ensure_hive_singletons, _reset_hive_store_cache
-
-    _reset_hive_store_cache()
-
-    call_count = {"n": 0}
-
-    def _boom(_dsn: str) -> object:
-        call_count["n"] += 1
-        raise RuntimeError("connection refused")
-
-    monkeypatch.setattr("tapps_brain.backends.create_hive_backend", _boom, raising=True)
-
-    _, _, err1 = _ensure_hive_singletons()
-    _, _, err2 = _ensure_hive_singletons()
-
-    assert err1 is not None
-    assert "connection refused" in err1
-    assert err1 == err2
-    assert call_count["n"] == 1, "backend failure should be cached, not retried"
-    assert server_helpers._hive_init_error is not None
+    out = await collect_session_hive_status(settings)
+    assert out == {"enabled": False}
 
 
 @pytest.mark.asyncio
-async def test_session_start_quick_includes_hive_status(
+async def test_collect_session_hive_status_unknown_when_bridge_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Agent Teams on + brain unreachable -> ``enabled: "unknown"``.
+
+    TAP-572: client must not fabricate a DSN-required error. When the
+    BrainBridge is ``None`` we report ``enabled: "unknown"`` with a message
+    pointing at brain connectivity (``TAPPS_BRAIN_BASE_URL`` /
+    ``TAPPS_BRAIN_AUTH_TOKEN`` / ``TAPPS_BRAIN_DATABASE_URL`` on the brain
+    server) — never at a missing local DSN.
+    """
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    monkeypatch.delenv("TAPPS_BRAIN_DATABASE_URL", raising=False)
+    from tapps_mcp.server_helpers import collect_session_hive_status
+
+    with patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=None):
+        settings = load_settings()
+        result = await collect_session_hive_status(settings)
+
+    assert result["enabled"] == "unknown"
+    assert result.get("degraded") is True
+    message = result.get("message") or ""
+    # Must NOT claim a local DSN is required.
+    assert "Postgres DSN required" not in message
+    assert "ADR-007" not in message
+    # Must point at brain connectivity.
+    assert "tapps-brain" in message
+
+
+def test_server_helpers_removed_client_side_dsn_probe() -> None:
+    """Regression for TAP-572: the prior DSN-probing ``_ensure_hive_singletons``
+    helper (and its file-backed Hive backend construction) must be removed
+    from the client module. Clients route via :class:`BrainBridge`, not via
+    their own Postgres-backed Hive backend.
+    """
+    from tapps_mcp import server_helpers
+
+    assert not hasattr(server_helpers, "_ensure_hive_singletons"), (
+        "_ensure_hive_singletons was a client-side DSN probe — "
+        "removed by TAP-572."
+    )
+    assert not hasattr(server_helpers, "_get_hive_store"), (
+        "_get_hive_store backed a client-side Hive backend — "
+        "removed by TAP-572."
+    )
+    assert not hasattr(server_helpers, "_get_hive_registry"), (
+        "_get_hive_registry backed a client-side Hive backend — "
+        "removed by TAP-572."
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_session_hive_status_delegates_to_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: bridge present -> delegates to ``bridge.hive_status``.
+
+    The client reads whatever the brain returns; it does not second-guess
+    the result with a local DSN check.
+    """
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    monkeypatch.setenv("CLAUDE_AGENT_ID", "agent-test-1")
+    monkeypatch.setenv("CLAUDE_AGENT_NAME", "test-agent")
+    from tapps_mcp.server_helpers import collect_session_hive_status
+
+    brain_response: dict[str, Any] = {
+        "enabled": True,
+        "degraded": False,
+        "namespaces": ["universal", "repo-brain"],
+        "namespace_count": 2,
+        "agents": [{"id": "agent-test-1", "name": "test-agent"}],
+        "agent_count": 1,
+    }
+    fake_bridge = MagicMock()
+    fake_bridge.hive_status = AsyncMock(return_value=brain_response)
+
+    with patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=fake_bridge):
+        settings = load_settings()
+        result = await collect_session_hive_status(settings)
+
+    fake_bridge.hive_status.assert_awaited_once()
+    call_kwargs = fake_bridge.hive_status.await_args.kwargs
+    assert call_kwargs["agent_id"] == "agent-test-1"
+    assert call_kwargs["agent_name"] == "test-agent"
+    assert call_kwargs["register"] is True
+
+    assert result["enabled"] is True
+    assert result["degraded"] is False
+    assert result["namespaces"] == ["universal", "repo-brain"]
+    assert result["agent_id"] == "agent-test-1"
+    assert result["registered_agents_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_session_hive_status_forwards_bridge_degraded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If brain says hive is degraded, tapps-mcp forwards that verbatim —
+    no client-side "DSN required" rewriting.
+    """
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    from tapps_mcp.server_helpers import collect_session_hive_status
+
+    brain_response: dict[str, Any] = {
+        "enabled": True,
+        "degraded": True,
+        "message": "Hive backend not available (no DSN or init failed).",
+    }
+    fake_bridge = MagicMock()
+    fake_bridge.hive_status = AsyncMock(return_value=brain_response)
+
+    with patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=fake_bridge):
+        settings = load_settings()
+        result = await collect_session_hive_status(settings)
+
+    assert result["enabled"] is True
+    assert result["degraded"] is True
+    assert result["message"] == "Hive backend not available (no DSN or init failed)."
+
+
+@pytest.mark.asyncio
+async def test_collect_session_hive_status_handles_bridge_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceptions from the bridge surface as ``degraded: true`` with the
+    exception message, matching other optional tapps-brain integrations.
+    """
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    from tapps_mcp.server_helpers import collect_session_hive_status
+
+    fake_bridge = MagicMock()
+    fake_bridge.hive_status = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=fake_bridge):
+        settings = load_settings()
+        result = await collect_session_hive_status(settings)
+
+    assert result["enabled"] is True
+    assert result["degraded"] is True
+    assert "boom" in (result.get("message") or "")
+
+
+@pytest.mark.asyncio
+async def test_session_start_quick_does_not_require_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TAP-572: ``_session_start_quick`` must complete successfully without
+    ``TAPPS_BRAIN_DATABASE_URL`` set, whether or not Agent Teams is on.
+    """
     monkeypatch.delenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", raising=False)
-    from tapps_mcp.server_helpers import _reset_hive_store_cache
+    monkeypatch.delenv("TAPPS_BRAIN_DATABASE_URL", raising=False)
+
     from tapps_mcp.server_pipeline_tools import _session_start_quick
 
-    _reset_hive_store_cache()
     start_ns = 0
 
     def _noop_record(_tool: str, _ns: int) -> None:
         return None
 
-    def _noop_nudges(_tool: str, resp: dict, _ctx: dict) -> dict:
+    def _noop_nudges(_tool: str, resp: dict[str, Any], _ctx: dict[str, Any]) -> dict[str, Any]:
         return resp
 
     result = await _session_start_quick(start_ns, _noop_record, _noop_nudges)
     assert result["success"] is True
     hs = result["data"].get("hive_status")
     assert hs is not None
+    # Agent Teams off -> baseline
     assert hs.get("enabled") is False
-    assert "propagation_config" not in hs
+
+
+@pytest.mark.asyncio
+async def test_session_start_quick_hive_unknown_when_agent_teams_without_brain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TAP-572: Agent Teams on + no brain -> ``hive_status.enabled == "unknown"``.
+
+    The prior behavior produced
+    ``"Hive unavailable: TAPPS_BRAIN_DATABASE_URL not configured ..."`` —
+    this test is the regression proof that no such message is emitted.
+    """
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    monkeypatch.delenv("TAPPS_BRAIN_DATABASE_URL", raising=False)
+
+    from tapps_mcp.server_pipeline_tools import _session_start_quick
+
+    with patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=None):
+        start_ns = 0
+
+        def _noop_record(_tool: str, _ns: int) -> None:
+            return None
+
+        def _noop_nudges(
+            _tool: str,
+            resp: dict[str, Any],
+            _ctx: dict[str, Any],
+        ) -> dict[str, Any]:
+            return resp
+
+        result = await _session_start_quick(start_ns, _noop_record, _noop_nudges)
+
+    assert result["success"] is True
+    hs = result["data"].get("hive_status")
+    assert hs is not None
+    assert hs.get("enabled") == "unknown"
+    assert hs.get("degraded") is True
+    message = hs.get("message") or ""
+    assert "Postgres DSN required" not in message
+    assert "ADR-007" not in message

--- a/packages/tapps-mcp/tests/unit/test_memory_hive_session.py
+++ b/packages/tapps-mcp/tests/unit/test_memory_hive_session.py
@@ -66,16 +66,13 @@ def test_server_helpers_removed_client_side_dsn_probe() -> None:
     from tapps_mcp import server_helpers
 
     assert not hasattr(server_helpers, "_ensure_hive_singletons"), (
-        "_ensure_hive_singletons was a client-side DSN probe — "
-        "removed by TAP-572."
+        "_ensure_hive_singletons was a client-side DSN probe — removed by TAP-572."
     )
     assert not hasattr(server_helpers, "_get_hive_store"), (
-        "_get_hive_store backed a client-side Hive backend — "
-        "removed by TAP-572."
+        "_get_hive_store backed a client-side Hive backend — removed by TAP-572."
     )
     assert not hasattr(server_helpers, "_get_hive_registry"), (
-        "_get_hive_registry backed a client-side Hive backend — "
-        "removed by TAP-572."
+        "_get_hive_registry backed a client-side Hive backend — removed by TAP-572."
     )
 
 


### PR DESCRIPTION
## Summary

tapps-mcp is a **client** of tapps-brain; Hive lives inside the brain server. Previously `tapps_session_start` emitted:

```
hive_status: { enabled: true, degraded: true,
  message: "Hive unavailable: TAPPS_BRAIN_DATABASE_URL not configured (Postgres DSN required for Hive; ADR-007)" }
```

That is an architectural smell — the client was reaching for the server's Postgres DSN to report something the server already owns.

This PR:
- Rewrites `collect_session_hive_status` to route through `BrainBridge.hive_status()` (existing method — no new brain endpoints).
- When the bridge is unavailable, returns `enabled: "unknown"` with a message pointing at **brain connectivity** (`TAPPS_BRAIN_BASE_URL` / `TAPPS_BRAIN_AUTH_TOKEN` / `TAPPS_BRAIN_DATABASE_URL` on the brain server) — never at a local DSN.
- Removes the dead `_ensure_hive_singletons` / `_get_hive_store` / `_get_hive_registry` helpers (they were the DSN-probing path and had no production callers after this refactor).
- Keeps `_reset_hive_store_cache` as a no-op compat shim so `packages/tapps-mcp/tests/conftest.py` autouse fixture keeps importing cleanly.
- Makes `collect_session_hive_status` `async`; updates its two call sites in `server_pipeline_tools.py` to `await` it.

Honors the "no client-side mirror of server-enforced rules" memory: we call the bridge, read its response, and forward it verbatim.

## Files changed

- `packages/tapps-mcp/src/tapps_mcp/server_helpers.py`
- `packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py`
- `packages/tapps-mcp/tests/unit/test_memory_hive_session.py`

## Test plan

- [x] `uv run ruff check packages/tapps-mcp/src/ packages/tapps-core/src/` — clean
- [x] `uv run mypy --strict packages/tapps-mcp/src/tapps_mcp/server_helpers.py packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py` — clean (pre-existing unrelated errors in `cli.py` and `docs-mcp/pattern_poster.py` not introduced by this PR)
- [x] `uv run pytest packages/tapps-mcp/tests/ -k "session_start or hive" -v` — 58 passed
- [x] `uv run pytest packages/tapps-mcp/tests/ -m "not slow"` — 3863 passed, 24 skipped, 0 failures
- [x] New tests prove: session_start no longer requires `TAPPS_BRAIN_DATABASE_URL`; bridge is the single source of truth for hive status; prior DSN-probing singletons are gone.

Closes TAP-572

🤖 Generated with [Claude Code](https://claude.com/claude-code)