### PR TITLE
[TAP-523] validate DSN + pool config at bridge startup

### DIFF
--- a/packages/tapps-core/src/tapps_core/brain_bridge.py
+++ b/packages/tapps-core/src/tapps_core/brain_bridge.py
@@ -712,6 +712,94 @@ class BrainBridge:
         return self._brain.store
 
     # -------------------------------------------------------------------------
+    # Startup health check (TAP-523)
+    # -------------------------------------------------------------------------
+
+    def health_check(self) -> dict[str, Any]:
+        """Synchronously probe DSN reachability and pool config validity.
+
+        Intended to run once at MCP server startup so misconfiguration is
+        surfaced at session-start time rather than inside the first memory
+        tool call. Returns a structured report; callers decide whether to
+        fail fast based on ``ok``.
+
+        Checks performed:
+
+        1. DSN reachability — calls ``store.count()`` to force a connection.
+        2. Pool config validity — inspects the
+           ``TAPPS_BRAIN_PG_POOL_MAX_WAITING`` and
+           ``TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS`` env vars (if set)
+           and rejects non-integer / negative values.
+        3. Optional native health — calls ``store.health()`` when available
+           for extra diagnostics (current count, schema version, etc.).
+        """
+        errors: list[str] = []
+        warnings: list[str] = []
+        details: dict[str, Any] = {}
+
+        # --- DSN reachability ------------------------------------------------
+        dsn_reachable = False
+        try:
+            entry_count = self._brain.store.count()
+            dsn_reachable = True
+            details["entry_count"] = int(entry_count)
+        except Exception as exc:
+            errors.append(f"dsn_unreachable: {exc}")
+
+        # --- Pool config validity -------------------------------------------
+        pool_config_valid = True
+        for env_name in (
+            "TAPPS_BRAIN_PG_POOL_MAX_WAITING",
+            "TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS",
+        ):
+            raw = os.environ.get(env_name, "")
+            if not raw:
+                continue
+            try:
+                value = int(raw)
+            except ValueError:
+                errors.append(f"invalid_pool_config: {env_name}={raw!r} is not an integer")
+                pool_config_valid = False
+                continue
+            if value < 0:
+                errors.append(f"invalid_pool_config: {env_name}={value} must be >= 0")
+                pool_config_valid = False
+                continue
+            details[env_name.lower()] = value
+            if env_name == "TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS" and 0 < value < 30:
+                warnings.append(
+                    f"{env_name}={value}s is unusually short "
+                    "(connections will churn heavily; minimum 30s recommended)"
+                )
+
+        # --- Optional native health ------------------------------------------
+        native_health_ok = False
+        health_fn = getattr(self._brain.store, "health", None)
+        if callable(health_fn):
+            try:
+                raw_health = health_fn()
+                native_health_ok = True
+                if hasattr(raw_health, "model_dump"):
+                    details["native_health"] = raw_health.model_dump()
+                elif isinstance(raw_health, dict):
+                    details["native_health"] = raw_health
+                else:
+                    details["native_health"] = {"value": str(raw_health)}
+            except Exception as exc:
+                warnings.append(f"native_health_probe_failed: {exc}")
+
+        ok = not errors and dsn_reachable and pool_config_valid
+        return {
+            "ok": ok,
+            "dsn_reachable": dsn_reachable,
+            "pool_config_valid": pool_config_valid,
+            "native_health_ok": native_health_ok,
+            "errors": errors,
+            "warnings": warnings,
+            "details": details,
+        }
+
+    # -------------------------------------------------------------------------
     # Lifecycle
     # -------------------------------------------------------------------------
 
@@ -924,11 +1012,29 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
             profile=profile,
             hive_dsn=hive_dsn,
         )
-        # Probe the store to fail fast on bad DSN before returning
-        brain.store.count()
     except Exception as exc:
         logger.warning("brain_bridge.init_failed", error=str(exc))
         return None
+
+    bridge = BrainBridge(brain)
+    # TAP-523: validate DSN reachability + pool config before returning so
+    # misconfiguration surfaces at startup rather than inside the first
+    # user-facing tool call.
+    report = bridge.health_check()
+    if not report["ok"]:
+        logger.warning(
+            "brain_bridge.health_check_failed",
+            errors=report["errors"],
+            warnings=report["warnings"],
+        )
+        with contextlib.suppress(Exception):
+            brain.close()
+        return None
+    if report["warnings"]:
+        logger.info(
+            "brain_bridge.health_check_warnings",
+            warnings=report["warnings"],
+        )
 
     # TAP-519: validate remote brain version when a HTTP URL is configured.
     # The probe is no-op for in-process AgentBrain deployments (url empty).
@@ -945,7 +1051,5 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
             floor=version_check["floor"],
             ceiling=version_check["ceiling"],
         )
-
-    bridge = BrainBridge(brain)
     bridge._set_version_check(version_check)
     return bridge

--- a/packages/tapps-core/tests/unit/test_brain_bridge_health_check.py
+++ b/packages/tapps-core/tests/unit/test_brain_bridge_health_check.py
@@ -1,0 +1,172 @@
+"""TAP-523: BrainBridge.health_check and startup fail-fast coverage.
+
+Probes:
+
+* DSN reachability check via ``store.count()``.
+* Pool config validation of
+  ``TAPPS_BRAIN_PG_POOL_MAX_WAITING`` and
+  ``TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS`` env vars.
+* Optional ``store.health()`` native probe.
+* ``create_brain_bridge`` fails fast (returns None + logs) when health is bad.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_brain(*, count_raises: Exception | None = None, health: Any = None) -> MagicMock:
+    brain = MagicMock()
+    store = MagicMock()
+    if count_raises is not None:
+        store.count.side_effect = count_raises
+    else:
+        store.count.return_value = 7
+    if health is None:
+        store.health.return_value = MagicMock(
+            model_dump=lambda: {"store_available": True, "current_count": 7}
+        )
+    else:
+        store.health.return_value = health
+    brain.store = store
+    brain.hive = None
+    return brain
+
+
+@pytest.fixture
+def bridge() -> Any:
+    from tapps_core.brain_bridge import BrainBridge
+
+    return BrainBridge(_make_brain())
+
+
+class TestHealthCheckDSN:
+    def test_ok_when_store_count_succeeds(self, bridge: Any) -> None:
+        report = bridge.health_check()
+        assert report["ok"] is True
+        assert report["dsn_reachable"] is True
+        assert report["details"]["entry_count"] == 7
+        assert report["errors"] == []
+
+    def test_fails_when_store_count_raises(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        b = BrainBridge(_make_brain(count_raises=RuntimeError("connection refused")))
+        report = b.health_check()
+        assert report["ok"] is False
+        assert report["dsn_reachable"] is False
+        assert any("dsn_unreachable" in e for e in report["errors"])
+
+
+class TestHealthCheckPoolConfig:
+    def test_accepts_valid_pool_vars(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", "15")
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "600")
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is True
+        assert report["ok"] is True
+        assert report["details"]["tapps_brain_pg_pool_max_waiting"] == 15
+        assert report["details"]["tapps_brain_pg_pool_max_lifetime_seconds"] == 600
+
+    def test_rejects_non_integer(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", "abc")
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is False
+        assert report["ok"] is False
+        assert any("is not an integer" in e for e in report["errors"])
+
+    def test_rejects_negative(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "-5")
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is False
+        assert report["ok"] is False
+        assert any("must be >= 0" in e for e in report["errors"])
+
+    def test_warns_on_short_lifetime(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "10")
+        report = bridge.health_check()
+        assert report["ok"] is True  # still valid, just suspicious
+        assert any("unusually short" in w for w in report["warnings"])
+
+    def test_ignores_unset_env_vars(self, bridge: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", raising=False)
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", raising=False)
+        report = bridge.health_check()
+        assert report["pool_config_valid"] is True
+
+
+class TestHealthCheckNativeProbe:
+    def test_native_health_ok_when_health_method_exists(self, bridge: Any) -> None:
+        report = bridge.health_check()
+        assert report["native_health_ok"] is True
+        assert "native_health" in report["details"]
+        assert report["details"]["native_health"]["store_available"] is True
+
+    def test_native_health_probe_failure_is_non_fatal(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        brain = _make_brain()
+        brain.store.health.side_effect = RuntimeError("rpc timeout")
+        b = BrainBridge(brain)
+
+        report = b.health_check()
+        assert report["ok"] is True  # native probe is advisory
+        assert report["native_health_ok"] is False
+        assert any("native_health_probe_failed" in w for w in report["warnings"])
+
+    def test_native_health_absent_is_non_fatal(self) -> None:
+        from tapps_core.brain_bridge import BrainBridge
+
+        brain = _make_brain()
+        del brain.store.health
+        b = BrainBridge(brain)
+
+        report = b.health_check()
+        assert report["ok"] is True
+        assert report["native_health_ok"] is False
+
+
+class TestCreateBrainBridgeStartupFailFast:
+    def test_returns_bridge_when_health_check_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://u:p@h/db")
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", raising=False)
+        monkeypatch.delenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", raising=False)
+        from tapps_core.brain_bridge import BrainBridge, create_brain_bridge
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            result = create_brain_bridge(settings=None)
+        assert isinstance(result, BrainBridge)
+
+    def test_returns_none_when_health_check_dsn_unreachable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://bad/dsn")
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        bad_brain = _make_brain(count_raises=RuntimeError("cannot connect"))
+        with patch("tapps_brain.AgentBrain", return_value=bad_brain):
+            result = create_brain_bridge(settings=None)
+        assert result is None
+        # Ensure brain.close was called to release the just-constructed pool
+        bad_brain.close.assert_called_once()
+
+    def test_returns_none_when_pool_config_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://u:p@h/db")
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_WAITING", "not-an-int")
+        from tapps_core.brain_bridge import create_brain_bridge
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            result = create_brain_bridge(settings=None)
+        assert result is None
+
+    def test_proceeds_with_warnings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TAPPS_BRAIN_DATABASE_URL", "postgresql://u:p@h/db")
+        monkeypatch.setenv("TAPPS_BRAIN_PG_POOL_MAX_LIFETIME_SECONDS", "5")
+        from tapps_core.brain_bridge import BrainBridge, create_brain_bridge
+
+        with patch("tapps_brain.AgentBrain", return_value=_make_brain()):
+            result = create_brain_bridge(settings=None)
+        assert isinstance(result, BrainBridge)

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -1338,6 +1338,29 @@ def _schedule_background_maintenance(
     task.add_done_callback(_background_tasks.discard)
 
 
+def _collect_brain_bridge_health() -> dict[str, Any]:
+    """TAP-523: run BrainBridge.health_check() at session start.
+
+    Reports DSN reachability and pool config validity. Non-blocking: probes
+    the cached BrainBridge singleton if available, otherwise reports
+    ``{enabled: False}``. Failures inside ``health_check`` surface as
+    ``ok: false`` with an ``errors`` list.
+    """
+    try:
+        from tapps_mcp.server_helpers import _get_brain_bridge
+
+        bridge = _get_brain_bridge()
+    except Exception as exc:
+        return {"enabled": False, "error": f"bridge_resolve_failed: {exc}"}
+    if bridge is None:
+        return {"enabled": False}
+    try:
+        report = bridge.health_check()
+    except Exception as exc:
+        return {"enabled": True, "ok": False, "errors": [f"health_check_raised: {exc}"]}
+    return {"enabled": True, **report}
+
+
 def _collect_memory_status(settings: Any) -> dict[str, Any]:
     """Collect memory subsystem status for session start."""
     status: dict[str, Any] = {"enabled": False}
@@ -1563,6 +1586,13 @@ async def tapps_session_start(
         _logger.debug("hive_status_check_failed", exc_info=True)
     timings["hive_status_ms"] = (time.perf_counter_ns() - phase_start) // 1_000_000
 
+    # TAP-523: surface BrainBridge health at startup so misconfiguration
+    # (bad DSN, invalid pool env vars) lands in session_start output instead
+    # of deep in the first memory tool call.
+    phase_start = time.perf_counter_ns()
+    brain_bridge_health = _collect_brain_bridge_health()
+    timings["brain_bridge_health_ms"] = (time.perf_counter_ns() - phase_start) // 1_000_000
+
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_session_start", start)
     timings["total_ms"] = elapsed_ms
@@ -1619,6 +1649,7 @@ async def tapps_session_start(
         "checklist_session_id": checklist_sid,
         "memory_status": memory_status,
         "hive_status": hive_status,
+        "brain_bridge_health": brain_bridge_health,
         "memory_gc": "background",
         "memory_consolidation": "background",
         "memory_doc_validation": "background",


### PR DESCRIPTION
## Summary

Cherry-picked from original PR #101 (now closed) onto current master to avoid a 400-file rebase churn. Branch #101 was cut pre-ruff-cleanup (d5562d5); the functional change is 3 files.

Adds `BrainBridge.health_check()` that validates DSN reachability + pool env-var config at startup. `create_brain_bridge` calls it and returns `None` on failure (preserves existing None-on-failure semantics); startup warnings are logged.

`tapps_session_start` surfaces the report via a new `brain_bridge_health` field.

Compatible with the `check_brain_version()` helper from #113 (TAP-519) — `health_check()` runs first (fail-fast on DSN/pool), then `version_check` logs on mismatch without blocking. Resolved cleanly in this cherry-pick.

## Test plan

- [x] 14 new tests in `test_brain_bridge_health_check.py` pass (DSN probe, pool config, native probe, startup fail-fast)
- [x] `uv run pytest packages/tapps-core/tests/ -m "not slow"` — 1132 passed
- [x] `uv run ruff check .` clean
- [x] `uv run mypy --strict` clean

Closes TAP-523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)