### PR TITLE
[TAP-521] add auth-token config + header-builder scaffolding for BrainBridge

### DIFF
--- a/packages/tapps-core/src/tapps_core/brain_auth.py
+++ b/packages/tapps-core/src/tapps_core/brain_auth.py
@@ -1,0 +1,128 @@
+"""Header-builder scaffolding for authenticated tapps-brain HTTP calls (TAP-521).
+
+``BrainBridge`` runs in-process today via :class:`tapps_brain.AgentBrain` +
+``asyncio.to_thread`` — no HTTP requests leave this process. This module is
+**scaffolding**: it configures the Bearer-token / ``X-Project-Id`` /
+``X-Agent-Id`` headers the bridge will need once it migrates to the tapps-brain
+HTTP adapter. Until that migration lands, ``build_brain_headers`` is importable
+but uncalled.
+
+Auth scheme (tapps-brain v3.8.0, ADR-010):
+
+- ``Authorization: Bearer <token>`` on every non-health endpoint.
+- ``X-Project-Id: <project_slug>`` on every data-plane (``/v1/*``, ``/snapshot``,
+  ``/info``) and MCP (``POST /mcp``) request.
+- ``X-Agent-Id: <agent_id>`` on MCP transport — sourced from
+  :func:`tapps_core.agent_identity.get_stable_agent_id`.
+- ``/admin/*`` reuses the same Bearer token; there is no separate system token.
+
+Strict vs. best-effort resolution:
+
+- ``TAPPS_BRAIN_STRICT=1`` → raise :class:`BrainAuthConfigError` when any
+  required value is missing. Use in CI / production where a misconfigured
+  tenant must fail loudly.
+- Otherwise → emit a ``structlog.warning`` and return a best-effort dict with
+  missing keys omitted. Back-compat during the migration window.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import structlog
+
+from tapps_core.agent_identity import get_stable_agent_id
+
+if TYPE_CHECKING:
+    from tapps_core.config.settings import TappsMCPSettings
+
+logger = structlog.get_logger(__name__)
+
+_STRICT_ENV_VAR = "TAPPS_BRAIN_STRICT"
+
+
+class BrainAuthConfigError(Exception):
+    """Raised in strict mode when required tapps-brain auth config is missing."""
+
+
+def _strict_mode() -> bool:
+    """Return True when ``TAPPS_BRAIN_STRICT`` is set to a truthy value."""
+    raw = os.environ.get(_STRICT_ENV_VAR, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def build_brain_headers(
+    settings: TappsMCPSettings,
+    *,
+    admin: bool = False,
+) -> dict[str, str]:
+    """Build headers for an outgoing tapps-brain HTTP call.
+
+    Returns a dict containing up to three keys: ``Authorization``,
+    ``X-Project-Id``, ``X-Agent-Id``. The Bearer token is read from
+    ``settings.memory.brain_auth_token`` (a :class:`pydantic.SecretStr`), the
+    project slug from ``settings.memory.brain_project_id``, and the agent id
+    from :func:`tapps_core.agent_identity.get_stable_agent_id`.
+
+    Args:
+        settings: The root TappsMCP settings object.
+        admin: Reserved for future symmetry between data-plane and ``/admin/*``
+            requests. Currently ignored — tapps-brain v3.8.0 reuses the same
+            Bearer token for both, so callers do not need to swap tokens.
+
+    Returns:
+        A header dict suitable for ``httpx.AsyncClient`` requests. Keys are
+        only present when the corresponding value is configured.
+
+    Raises:
+        BrainAuthConfigError: When ``TAPPS_BRAIN_STRICT`` is truthy and any
+            required value is missing.
+    """
+    del admin  # Reserved for future per-endpoint token scoping.
+
+    memory = settings.memory
+    token_secret = memory.brain_auth_token
+    project_id = memory.brain_project_id
+    agent_id = get_stable_agent_id(settings)
+
+    headers: dict[str, str] = {}
+    missing: list[str] = []
+
+    if token_secret is not None:
+        headers["Authorization"] = f"Bearer {token_secret.get_secret_value()}"
+    else:
+        missing.append("brain_auth_token")
+
+    if project_id:
+        headers["X-Project-Id"] = project_id
+    else:
+        missing.append("brain_project_id")
+
+    if agent_id:
+        headers["X-Agent-Id"] = agent_id
+    else:
+        # ``get_stable_agent_id`` always returns a non-empty string in
+        # practice, but guard against the degenerate case for completeness.
+        missing.append("agent_id")
+
+    if missing:
+        if _strict_mode():
+            # Never include the token value in the error message.
+            raise BrainAuthConfigError(
+                f"tapps-brain auth config incomplete (strict mode): missing={sorted(missing)}"
+            )
+        logger.warning(
+            "brain_auth.incomplete_config",
+            missing=sorted(missing),
+        )
+
+    return headers
+
+
+# TODO(TAP-596): wire into HTTP client when BrainBridge migrates from in-process
+# AgentBrain to the tapps-brain HTTP adapter. Every outgoing request should call
+# ``build_brain_headers(settings)`` and pass the result to the httpx client.
+
+
+__all__ = ["BrainAuthConfigError", "build_brain_headers"]

--- a/packages/tapps-core/src/tapps_core/config/settings.py
+++ b/packages/tapps-core/src/tapps_core/config/settings.py
@@ -570,6 +570,32 @@ class MemorySettings(BaseSettings):
         ),
     )
 
+    # TAP-521: auth-token scaffolding for the future tapps-brain HTTP migration.
+    # BrainBridge is in-process today (AgentBrain + asyncio.to_thread), so these
+    # values are not consumed at runtime yet — they configure the header builder
+    # in ``tapps_core.brain_auth`` so the HTTP migration is a drop-in swap.
+    brain_auth_token: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Bearer token for authenticated tapps-brain HTTP calls. Injected as "
+            "``Authorization: Bearer <token>`` by ``tapps_core.brain_auth."
+            "build_brain_headers``. Same token is reused for ``/admin/*`` paths "
+            "per tapps-brain v3.8.0 — there is no separate admin/system token. "
+            "Wrapped in ``SecretStr`` so it does not leak into logs/repr. "
+            "Env: TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN."
+        ),
+    )
+    brain_project_id: str = Field(
+        default="",
+        description=(
+            "Registered tapps-brain project slug sent as the ``X-Project-Id`` "
+            "header on every data-plane and MCP request (ADR-010). Distinct "
+            "from ``memory.project_id``, which is exported to "
+            "``TAPPS_BRAIN_PROJECT`` for the in-process AgentBrain path. "
+            "Env: TAPPS_MCP_MEMORY_BRAIN_PROJECT_ID."
+        ),
+    )
+
     # EPIC-069 / ADR-010: multi-tenant project_id on the wire.
     project_id: str = Field(
         default="",

--- a/packages/tapps-core/tests/unit/test_brain_auth.py
+++ b/packages/tapps-core/tests/unit/test_brain_auth.py
@@ -1,0 +1,138 @@
+"""Tests for ``tapps_core.brain_auth`` (TAP-521).
+
+Scaffolding-only coverage: ``BrainBridge`` is in-process today, so there is no
+HTTP path to assert against. These tests verify that ``build_brain_headers``
+produces the correct header dict, honors strict mode, and that ``SecretStr``
+protects the token from accidental leaks in logs / repr.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import SecretStr
+
+from tapps_core.brain_auth import BrainAuthConfigError, build_brain_headers
+from tapps_core.config.settings import TappsMCPSettings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_TOKEN_VALUE = "s3cr3t-bearer-token"
+_PROJECT_ID = "tapps-mcp"
+
+
+def _make_settings(
+    tmp_path: Path,
+    *,
+    token: str | None = _TOKEN_VALUE,
+    project_id: str = _PROJECT_ID,
+) -> TappsMCPSettings:
+    """Build a settings object with the brain-auth fields populated."""
+    settings = TappsMCPSettings(project_root=tmp_path)
+    settings.memory.brain_auth_token = SecretStr(token) if token is not None else None
+    settings.memory.brain_project_id = project_id
+    # Ensure agent_id generation has a stable project slug to chain off.
+    settings.memory.project_id = project_id
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Isolate each test from ambient ``TAPPS_BRAIN_STRICT`` / agent-id env."""
+    monkeypatch.delenv("TAPPS_BRAIN_STRICT", raising=False)
+    monkeypatch.delenv("CLAUDE_AGENT_ID", raising=False)
+    yield
+
+
+def test_headers_include_bearer_and_project_and_agent_id(tmp_path: Path) -> None:
+    """All three headers appear when all three values are configured."""
+    settings = _make_settings(tmp_path)
+
+    headers = build_brain_headers(settings)
+
+    assert headers["Authorization"] == f"Bearer {_TOKEN_VALUE}"
+    assert headers["X-Project-Id"] == _PROJECT_ID
+    assert headers["X-Agent-Id"].startswith(f"{_PROJECT_ID}-")
+
+
+def test_secret_str_not_leaked_in_repr(tmp_path: Path) -> None:
+    """``SecretStr`` masks the token value in ``repr(settings.memory)``."""
+    settings = _make_settings(tmp_path)
+
+    rendered = repr(settings.memory)
+
+    assert _TOKEN_VALUE not in rendered
+    # SecretStr renders as ``SecretStr('**********')`` — confirm the mask is
+    # actually present so we don't pass trivially when the field is missing.
+    assert "SecretStr" in rendered
+
+
+def test_strict_mode_raises_when_token_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Strict mode raises ``BrainAuthConfigError`` on missing token."""
+    monkeypatch.setenv("TAPPS_BRAIN_STRICT", "1")
+    settings = _make_settings(tmp_path, token=None)
+
+    with pytest.raises(BrainAuthConfigError) as excinfo:
+        build_brain_headers(settings)
+
+    assert "brain_auth_token" in str(excinfo.value)
+    # Token must never appear in the error — even the sentinel value from the
+    # default fixture should not be reachable here, but assert just in case.
+    assert _TOKEN_VALUE not in str(excinfo.value)
+
+
+def test_non_strict_warn_and_proceed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-strict mode returns best-effort headers with ``Authorization`` omitted.
+
+    structlog writes to stdout rather than the stdlib logging framework, so we
+    stub ``brain_auth.logger.warning`` directly to capture the call.
+    """
+    settings = _make_settings(tmp_path, token=None)
+
+    warnings: list[tuple[str, dict[str, Any]]] = []
+
+    def _record_warning(event: str, **kwargs: Any) -> None:
+        warnings.append((event, kwargs))
+
+    monkeypatch.setattr("tapps_core.brain_auth.logger.warning", _record_warning)
+
+    headers = build_brain_headers(settings)
+
+    assert "Authorization" not in headers
+    assert headers["X-Project-Id"] == _PROJECT_ID
+    assert headers["X-Agent-Id"].startswith(f"{_PROJECT_ID}-")
+    assert warnings, "expected a warning when required config is missing"
+    event, payload = warnings[0]
+    assert event == "brain_auth.incomplete_config"
+    assert "brain_auth_token" in payload["missing"]
+
+
+def test_admin_kwarg_uses_same_bearer(tmp_path: Path) -> None:
+    """``admin=True`` reuses the data-plane Bearer token (tapps-brain v3.8.0)."""
+    settings = _make_settings(tmp_path)
+
+    data_headers = build_brain_headers(settings)
+    admin_headers = build_brain_headers(settings, admin=True)
+
+    assert data_headers["Authorization"] == admin_headers["Authorization"]
+    assert admin_headers["Authorization"] == f"Bearer {_TOKEN_VALUE}"
+
+
+def test_x_agent_id_uses_stable_agent_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``X-Agent-Id`` is sourced from ``get_stable_agent_id``."""
+    settings = _make_settings(tmp_path)
+    expected_agent_id = "patched-agent-42"
+
+    monkeypatch.setattr(
+        "tapps_core.brain_auth.get_stable_agent_id",
+        lambda _settings: expected_agent_id,
+    )
+
+    headers = build_brain_headers(settings)
+
+    assert headers["X-Agent-Id"] == expected_agent_id


### PR DESCRIPTION
## Summary

Adds the config + header-building scaffolding tapps-mcp will need once BrainBridge migrates from the in-process `AgentBrain` to the tapps-brain HTTP adapter. This PR is **scaffolding only** — no runtime auth behaviour changes.

- `MemorySettings` gains `brain_auth_token` (SecretStr) and `brain_project_id` (str). Env: `TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN`, `TAPPS_MCP_MEMORY_BRAIN_PROJECT_ID`.
- New `tapps_core.brain_auth.build_brain_headers(settings, *, admin=False)` returns `Authorization: Bearer <token>` + `X-Project-Id` + `X-Agent-Id` per tapps-brain v3.8.0's single-Bearer scheme (ADR-010). `X-Agent-Id` is sourced from `tapps_core.agent_identity.get_stable_agent_id` (TAP-518).
- `TAPPS_BRAIN_STRICT=1` raises `BrainAuthConfigError` on missing values; otherwise emits a structlog warning and returns best-effort headers (missing keys omitted).
- `admin` kwarg exists for future symmetry but currently ignored — v3.8.0 reuses the same Bearer token for `/admin/*`.

**No runtime auth behaviour today** — BrainBridge is in-process via `asyncio.to_thread(fn)` over `tapps_brain.AgentBrain`. Headers activate when the HTTP migration lands (TAP-596). A `# TODO(TAP-596)` marker tracks the wiring point in `brain_auth.py`.

## Env vars added

| Variable | Purpose |
|---|---|
| `TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN` | Bearer token for authenticated tapps-brain HTTP calls. |
| `TAPPS_MCP_MEMORY_BRAIN_PROJECT_ID` | Registered project slug sent as `X-Project-Id` (ADR-010). |

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy --strict packages/tapps-core/src/tapps_core/` passes (96 files, no issues)
- [x] `uv run pytest packages/tapps-core/tests/unit/test_brain_auth.py -v` — 6/6 pass
- [x] `uv run pytest packages/tapps-core/tests/ -m "not slow" -x` — 1124 passed, 6 skipped (22s)
- [ ] Follow-up: TAP-596 will wire `build_brain_headers` into the HTTP client when BrainBridge migrates off in-process AgentBrain.

Closes TAP-521

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>