### PR TITLE
[TAP-517] drain offline write queue on shutdown; surface bridge state

### DIFF
--- a/packages/tapps-core/src/tapps_core/brain_bridge.py
+++ b/packages/tapps-core/src/tapps_core/brain_bridge.py
@@ -15,9 +15,12 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import atexit
 import contextlib
 import os
 import random
+import signal
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -53,6 +56,11 @@ _WRITE_QUEUE_CAP: int = 100
 _BRAIN_VERSION_FLOOR: str = "3.7.2"
 _BRAIN_VERSION_CEILING: str = "4.0.0"
 _BRAIN_HEALTH_TIMEOUT_SECONDS: float = 5.0
+
+# --- Shutdown drain ---------------------------------------------------------
+# Bounded deadline (seconds) that ``close`` / ``drain_blocking`` waits for the
+# offline write queue to drain on shutdown before giving up (TAP-517).
+_DRAIN_DEADLINE_SECONDS: float = 5.0
 
 
 class BrainBridgeUnavailable(Exception):  # noqa: N818  (public API name predates the lint rule; renaming would break consumers)
@@ -125,6 +133,27 @@ class BrainBridge:
         """Populate the version-check payload (factory-only helper)."""
         self._version_check = result
 
+    @property
+    def circuit_state(self) -> str:
+        """Circuit state as a stable string — ``"open"`` or ``"closed"``.
+
+        Exposed via :meth:`status` for server_info consumers so they do not
+        need to consume the mutating :attr:`circuit_open` check.
+        """
+        return "open" if self.circuit_open else "closed"
+
+    def status(self) -> dict[str, Any]:
+        """Non-blocking diagnostic snapshot of bridge health (TAP-517).
+
+        Safe to call from read-only paths like ``tapps_server_info``.
+        """
+        return {
+            "queue_depth": self.queue_depth,
+            "queue_cap": _WRITE_QUEUE_CAP,
+            "circuit_state": self.circuit_state,
+            "failures": self._failures,
+        }
+
     def _record_success(self) -> None:
         self._failures = 0
 
@@ -169,11 +198,21 @@ class BrainBridge:
     # -------------------------------------------------------------------------
 
     def _enqueue_write(self, entry: dict[str, Any]) -> bool:
-        """Queue a write for later drain. Returns False when queue is full."""
+        """Queue a write for later drain. Returns False when queue is full.
+
+        Logs a ``brain_write_queue_full`` warning on overflow (TAP-517) so
+        operators can see when the offline buffer is dropping writes.
+        """
         try:
             self._write_queue.put_nowait(entry)
             return True
         except asyncio.QueueFull:
+            logger.warning(
+                "brain_write_queue_full",
+                queue_depth=self._write_queue.qsize(),
+                queue_cap=_WRITE_QUEUE_CAP,
+                dropped_key=entry.get("key"),
+            )
             return False
 
     async def _drain_write_queue(self) -> None:
@@ -715,8 +754,51 @@ class BrainBridge:
     # Lifecycle
     # -------------------------------------------------------------------------
 
-    def close(self) -> None:
-        """Close the underlying AgentBrain connection pool."""
+    def drain_blocking(self, timeout: float = _DRAIN_DEADLINE_SECONDS) -> dict[str, int]:
+        """Synchronously drain the offline write queue (TAP-517).
+
+        Bypasses ``_call`` / ``asyncio.to_thread`` because this path runs from
+        shutdown hooks (atexit / SIGTERM) where the event loop may already be
+        gone. Bounded by *timeout* seconds; remaining entries are left on the
+        queue and reported in the return dict.
+        """
+        deadline = time.monotonic() + max(0.0, timeout)
+        drained = 0
+        dropped = 0
+        while not self._write_queue.empty():
+            if time.monotonic() >= deadline:
+                break
+            try:
+                entry = self._write_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            try:
+                self._brain.store.save(**entry)
+                drained += 1
+            except Exception as exc:
+                logger.warning(
+                    "brain_bridge.drain_blocking_entry_failed",
+                    error=str(exc),
+                    key=entry.get("key"),
+                )
+                dropped += 1
+        remaining = self._write_queue.qsize()
+        if drained or dropped or remaining:
+            logger.info(
+                "brain_bridge.drain_blocking_complete",
+                drained=drained,
+                dropped=dropped,
+                remaining=remaining,
+                deadline_exceeded=time.monotonic() >= deadline,
+            )
+        return {"drained": drained, "dropped": dropped, "remaining": remaining}
+
+    def close(self, drain_timeout: float = _DRAIN_DEADLINE_SECONDS) -> None:
+        """Drain queued writes (bounded) then close the AgentBrain pool."""
+        try:
+            self.drain_blocking(drain_timeout)
+        except Exception as exc:
+            logger.warning("brain_bridge.drain_on_close_failed", error=str(exc))
         try:
             self._brain.close()
         except Exception as exc:
@@ -948,4 +1030,38 @@ def create_brain_bridge(settings: Any = None) -> BrainBridge | None:
 
     bridge = BrainBridge(brain)
     bridge._set_version_check(version_check)
+    # TAP-517: register shutdown hooks so the offline write queue is drained
+    # on interpreter shutdown / SIGTERM before the process exits.
+    _register_shutdown_hooks(bridge)
     return bridge
+
+
+_shutdown_hooks_registered: bool = False
+
+
+def _register_shutdown_hooks(bridge: BrainBridge) -> None:
+    """Wire atexit + SIGTERM drain hooks for *bridge* (TAP-517).
+
+    atexit covers normal interpreter shutdown and ``sys.exit``. SIGTERM by
+    default kills the process without running atexit, so we route it through
+    ``sys.exit(0)`` to get the bounded drain. Signal registration only works
+    on the main thread of the main interpreter, so we swallow failures from
+    worker threads / embedded contexts.
+    """
+    global _shutdown_hooks_registered
+    if _shutdown_hooks_registered:
+        return
+
+    atexit.register(bridge.close)
+
+    def _sigterm_drain_exit(_signum: int, _frame: Any) -> None:
+        sys.exit(0)
+
+    try:
+        signal.signal(signal.SIGTERM, _sigterm_drain_exit)
+    except (OSError, ValueError):
+        # Non-main-thread, embedded interpreter, or platform without
+        # SIGTERM — atexit still covers normal shutdown paths.
+        logger.debug("brain_bridge.sigterm_register_skipped")
+
+    _shutdown_hooks_registered = True

--- a/packages/tapps-core/tests/unit/test_brain_bridge_shutdown.py
+++ b/packages/tapps-core/tests/unit/test_brain_bridge_shutdown.py
@@ -1,0 +1,278 @@
+"""Shutdown-drain, queue overflow, and status snapshot coverage (TAP-517).
+
+These tests target the behaviours added for TAP-517:
+
+* Enqueue overflow emits a structured warning.
+* ``status()`` exposes ``queue_depth`` and ``circuit_state``.
+* ``drain_blocking()`` drains the offline queue under a bounded deadline.
+* ``close()`` runs the drain before closing the underlying brain.
+* ``_register_shutdown_hooks`` wires atexit idempotently.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_brain() -> MagicMock:
+    brain = MagicMock()
+    store = MagicMock()
+    store.count.return_value = 0
+    save_entry = MagicMock()
+    save_entry.model_dump.return_value = {"key": "k", "value": "v"}
+    store.save.return_value = save_entry
+    brain.store = store
+    brain.hive = None
+    return brain
+
+
+@pytest.fixture
+def bridge() -> Any:
+    from tapps_core.brain_bridge import BrainBridge
+
+    return BrainBridge(_make_brain())
+
+
+# ---------------------------------------------------------------------------
+# Enqueue overflow warning
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueOverflowWarning:
+    def test_warning_logged_when_queue_full(self, bridge: Any) -> None:
+        from tapps_core.brain_bridge import _WRITE_QUEUE_CAP
+
+        for i in range(_WRITE_QUEUE_CAP):
+            assert bridge._enqueue_write({"key": f"k{i}", "value": "v"}) is True
+
+        with patch("tapps_core.brain_bridge.logger") as mock_logger:
+            overflow = bridge._enqueue_write({"key": "overflow", "value": "v"})
+
+        assert overflow is False
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args.args[0] == "brain_write_queue_full"
+        assert call_args.kwargs["queue_depth"] == _WRITE_QUEUE_CAP
+        assert call_args.kwargs["queue_cap"] == _WRITE_QUEUE_CAP
+        assert call_args.kwargs["dropped_key"] == "overflow"
+
+
+# ---------------------------------------------------------------------------
+# Status snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestStatusSnapshot:
+    def test_status_returns_expected_keys(self, bridge: Any) -> None:
+        snapshot = bridge.status()
+        assert snapshot == {
+            "queue_depth": 0,
+            "queue_cap": 100,
+            "circuit_state": "closed",
+            "failures": 0,
+        }
+
+    def test_circuit_state_closed_initially(self, bridge: Any) -> None:
+        assert bridge.circuit_state == "closed"
+
+    def test_circuit_state_open_after_threshold_failures(self, bridge: Any) -> None:
+        from tapps_core.brain_bridge import _CB_FAILURE_THRESHOLD
+
+        for _ in range(_CB_FAILURE_THRESHOLD):
+            bridge._record_failure()
+        assert bridge.circuit_state == "open"
+
+    def test_status_reflects_queued_writes(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v"})
+        bridge._enqueue_write({"key": "k2", "value": "v"})
+        assert bridge.status()["queue_depth"] == 2
+
+
+# ---------------------------------------------------------------------------
+# drain_blocking
+# ---------------------------------------------------------------------------
+
+
+class TestDrainBlocking:
+    def test_drain_empties_queue_and_persists_entries(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v1"})
+        bridge._enqueue_write({"key": "k2", "value": "v2"})
+
+        result = bridge.drain_blocking(timeout=1.0)
+
+        assert result["drained"] == 2
+        assert result["dropped"] == 0
+        assert result["remaining"] == 0
+        assert bridge.queue_depth == 0
+        assert bridge._brain.store.save.call_count == 2
+
+    def test_drain_counts_dropped_on_store_exception(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v1"})
+        bridge._brain.store.save.side_effect = RuntimeError("postgres is down")
+
+        result = bridge.drain_blocking(timeout=1.0)
+
+        assert result["drained"] == 0
+        assert result["dropped"] == 1
+        assert result["remaining"] == 0
+
+    def test_drain_respects_timeout_deadline(self, bridge: Any) -> None:
+        """Timeout=0 means we should not drain anything — deadline check fires first."""
+        for i in range(5):
+            bridge._enqueue_write({"key": f"k{i}", "value": "v"})
+
+        # Timeout=0: deadline is exceeded immediately, nothing drains.
+        result = bridge.drain_blocking(timeout=0.0)
+
+        assert result["drained"] == 0
+        assert result["remaining"] == 5
+        assert bridge._brain.store.save.call_count == 0
+
+    def test_drain_on_empty_queue_is_noop(self, bridge: Any) -> None:
+        result = bridge.drain_blocking(timeout=1.0)
+        assert result == {"drained": 0, "dropped": 0, "remaining": 0}
+        assert bridge._brain.store.save.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# close() drains before closing
+# ---------------------------------------------------------------------------
+
+
+class TestCloseDrains:
+    def test_close_invokes_drain_blocking_before_brain_close(self, bridge: Any) -> None:
+        bridge._enqueue_write({"key": "k1", "value": "v1"})
+
+        call_order: list[str] = []
+
+        original_save = bridge._brain.store.save
+        original_brain_close = bridge._brain.close
+
+        def _save(*a: Any, **kw: Any) -> Any:
+            call_order.append("store.save")
+            return original_save(*a, **kw)
+
+        def _brain_close() -> None:
+            call_order.append("brain.close")
+            original_brain_close()
+
+        bridge._brain.store.save = _save
+        bridge._brain.close = _brain_close
+
+        bridge.close()
+
+        assert call_order == ["store.save", "brain.close"]
+        assert bridge.queue_depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Shutdown-hook registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterShutdownHooks:
+    def test_registers_atexit_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tapps_core.brain_bridge as bb
+
+        monkeypatch.setattr(bb, "_shutdown_hooks_registered", False)
+
+        registered: list[Any] = []
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.atexit.register",
+            lambda fn: registered.append(fn),
+        )
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.signal.signal",
+            lambda *_a, **_kw: None,
+        )
+
+        b = bb.BrainBridge(_make_brain())
+        bb._register_shutdown_hooks(b)
+
+        assert b.close in registered
+
+    def test_registration_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tapps_core.brain_bridge as bb
+
+        monkeypatch.setattr(bb, "_shutdown_hooks_registered", False)
+        call_count = {"n": 0}
+
+        def _count(_fn: Any) -> None:
+            call_count["n"] += 1
+
+        monkeypatch.setattr("tapps_core.brain_bridge.atexit.register", _count)
+        monkeypatch.setattr(
+            "tapps_core.brain_bridge.signal.signal",
+            lambda *_a, **_kw: None,
+        )
+
+        b = bb.BrainBridge(_make_brain())
+        bb._register_shutdown_hooks(b)
+        bb._register_shutdown_hooks(b)  # second call should be a no-op
+
+        assert call_count["n"] == 1
+
+    def test_sigterm_register_failure_is_tolerated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Signal registration from non-main threads raises ValueError; must be swallowed."""
+        import tapps_core.brain_bridge as bb
+
+        monkeypatch.setattr(bb, "_shutdown_hooks_registered", False)
+        monkeypatch.setattr("tapps_core.brain_bridge.atexit.register", lambda _fn: None)
+
+        def _raise(*_a: Any, **_kw: Any) -> None:
+            raise ValueError("signal only works in main thread")
+
+        monkeypatch.setattr("tapps_core.brain_bridge.signal.signal", _raise)
+
+        b = bb.BrainBridge(_make_brain())
+        bb._register_shutdown_hooks(b)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Integration: BrainBridge.status() is stable across circuit transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_updates_after_circuit_opens_and_writes_queue(bridge: Any) -> None:
+    from tapps_core.brain_bridge import _CB_FAILURE_THRESHOLD
+
+    for _ in range(_CB_FAILURE_THRESHOLD):
+        bridge._record_failure()
+    assert bridge.status()["circuit_state"] == "open"
+
+    await bridge.save(key="k1", value="v1")
+
+    snap = bridge.status()
+    assert snap["circuit_state"] == "open"
+    assert snap["queue_depth"] == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_blocking_clears_entries_queued_via_save(bridge: Any) -> None:
+    from tapps_core.brain_bridge import _CB_FAILURE_THRESHOLD
+
+    for _ in range(_CB_FAILURE_THRESHOLD):
+        bridge._record_failure()
+    await bridge.save(key="k1", value="v1")
+    await bridge.save(key="k2", value="v2")
+
+    result = bridge.drain_blocking(timeout=1.0)
+    assert result["drained"] == 2
+    assert bridge.queue_depth == 0
+
+
+def test_drain_blocking_finishes_well_within_timeout(bridge: Any) -> None:
+    """Sanity check: drain_blocking returns quickly on a small queue."""
+    for i in range(3):
+        bridge._enqueue_write({"key": f"k{i}", "value": "v"})
+
+    start = time.monotonic()
+    bridge.drain_blocking(timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0

--- a/packages/tapps-mcp/src/tapps_mcp/server.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server.py
@@ -417,6 +417,7 @@ def _build_server_info_data(
         ),
         "docs_provider": _current_docs_provider_summary(),
         "diagnostics": diagnostics.model_dump(),
+        "brain_bridge": _brain_bridge_status_for_server_info(),
         "recommended_workflow": RECOMMENDED_WORKFLOW_TEXT,
         "quick_start": list(DAILY_STEPS),
         "critical_rules": [
@@ -437,6 +438,24 @@ def _build_server_info_data(
             "prompts_available": True,
         },
     }
+
+
+def _brain_bridge_status_for_server_info() -> dict[str, Any]:
+    """Non-blocking BrainBridge snapshot for ``tapps_server_info`` (TAP-517).
+
+    Peeks the cached singleton so the info tool does not force a Postgres
+    connection just to answer a status query. When the bridge has not been
+    initialized yet, reports ``{"initialized": False}``.
+    """
+    try:
+        from tapps_mcp.server_helpers import _peek_brain_bridge
+
+        bridge = _peek_brain_bridge()
+    except Exception as exc:
+        return {"initialized": False, "error": str(exc)}
+    if bridge is None:
+        return {"initialized": False}
+    return {"initialized": True, **bridge.status()}
 
 
 _checklist_state: dict[str, bool] = {"persist_configured": False}

--- a/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
@@ -157,6 +157,16 @@ def _reset_brain_bridge_cache() -> None:
         _brain_bridge = None
 
 
+def _peek_brain_bridge() -> _BrainBridgeType | None:
+    """Return the cached :class:`BrainBridge` without forcing init (TAP-517).
+
+    Used by read-only consumers like ``tapps_server_info`` that need to
+    report bridge state but must not incur a Postgres connection just to
+    answer a diagnostics query.
+    """
+    return _brain_bridge
+
+
 def _get_memory_store() -> _MemoryStoreType:
     """Return the Postgres-backed :class:`MemoryStore` from the BrainBridge.
 

--- a/packages/tapps-mcp/tests/integration/test_mcp_handshake.py
+++ b/packages/tapps-mcp/tests/integration/test_mcp_handshake.py
@@ -75,3 +75,15 @@ class TestMCPHandshake:
         except AttributeError:
             # If internal API changes, at least verify the tool function exists
             assert callable(tapps_server_info)
+
+    @pytest.mark.asyncio
+    async def test_server_info_includes_brain_bridge_snapshot(self):
+        """TAP-517: server_info must expose BrainBridge queue_depth + circuit_state."""
+        result = await tapps_server_info()
+        bb = result["data"].get("brain_bridge")
+        assert bb is not None
+        assert "initialized" in bb
+        if bb["initialized"]:
+            assert bb["circuit_state"] in {"open", "closed"}
+            assert isinstance(bb["queue_depth"], int)
+            assert isinstance(bb["queue_cap"], int)


### PR DESCRIPTION
## Summary

Cherry-picked from original PR #100 (now closed) onto current master. Functional change is 5 files.

### Queue overflow warning
`_enqueue_write` now logs `brain_write_queue_full` with `queue_depth` when the offline queue fills (cap 100). Prevents silent data loss.

### Bounded shutdown drain
Adds `BrainBridge.drain_blocking(timeout)` and `close(drain_timeout)`. `create_brain_bridge` wires `atexit` + SIGTERM hooks via a new `_register_shutdown_hooks` (idempotent, main-thread-only; tolerates embedded interpreters).

### Bridge state surfaced via server_info
New non-blocking `BrainBridge.status()` (`queue_depth`, `queue_cap`, `circuit_state`, `failures`) and `circuit_state` stable-string property. `tapps_server_info` now includes a top-level `brain_bridge` field sourced via a read-only `_peek_brain_bridge` helper — no forced Postgres connection from info queries.

### Integration with other merged PRs
- Merges cleanly with #113's `version_check` property (both properties coexist on `BrainBridge`).
- `_register_shutdown_hooks(bridge)` is called at the end of `create_brain_bridge`, after `_set_version_check`.
- Rejected conflict-side code that was removed by #115 (`_ensure_hive_singletons`, `_get_hive_store`, `_get_hive_registry` — all DSN-probing paths correctly stay deleted).

## Test plan

- [x] `packages/tapps-core/tests/unit/test_brain_bridge_shutdown.py` — 16 tests pass (enqueue overflow warning, status snapshot, drain/timeout/error-counting, close ordering, atexit/SIGTERM idempotent + error-tolerant)
- [x] `packages/tapps-mcp/tests/integration/test_mcp_handshake.py` — extended with `brain_bridge` field assertion
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] Import sanity: all affected modules import clean

Closes TAP-517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)