### PR TITLE
fix(init): generate CI workflows that install tapps-mcp from git URLs

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/ci_install.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/ci_install.py
@@ -1,0 +1,62 @@
+"""Shared install-step renderer for generated GitHub CI workflows.
+
+tapps-mcp is not published to PyPI. Consumers installing via `pip install
+tapps-mcp` fail at dependency resolution. This module renders a pip install
+step that points at the three source repositories directly (tapps-brain,
+tapps-core, tapps-mcp) with pinned refs matching the current release.
+
+The generator modules (github_ci, github_copilot, platform_bundles) splice
+the rendered block into their workflow templates at write-time so the pins
+track the installed tapps-mcp version.
+
+Keep ``TAPPS_BRAIN_REV`` in sync with the ``rev`` declared for tapps-brain
+in the workspace ``pyproject.toml`` (root ``[tool.uv.sources]`` table).
+"""
+
+from __future__ import annotations
+
+from tapps_mcp import __version__
+
+TAPPS_BRAIN_REV = "a3654693df32d64f65cd3d97e7e28b2499a5308b"
+"""tapps-brain commit SHA matching ``[tool.uv.sources]`` in the root pyproject."""
+
+TAPPS_MCP_REPO = "https://github.com/wtthornton/TappsMCP.git"
+TAPPS_BRAIN_REPO = "https://github.com/wtthornton/tapps-brain.git"
+
+
+def render_install_step(
+    *,
+    indent: str = "      ",
+    step_name: str = "Install TappsMCP and checkers",
+    include_checkers: bool = True,
+) -> str:
+    """Return a GitHub Actions ``steps:`` entry that installs tapps-mcp.
+
+    The entry is emitted at the given indent (default 6 spaces, matching
+    the existing templates' ``jobs.<id>.steps:`` depth). It installs
+    tapps-brain, tapps-core, and tapps-mcp from git URLs pinned to the
+    current release, because none are published to PyPI.
+
+    ``include_checkers`` controls whether the quality checker packages
+    (ruff, mypy, bandit, radon, vulture) are installed in the same pip
+    invocation. Disable for workflows that install checkers separately.
+    """
+    tag = f"v{__version__}"
+    core_url = f"tapps-core @ git+{TAPPS_MCP_REPO}@{tag}#subdirectory=packages/tapps-core"
+    mcp_url = f"tapps-mcp @ git+{TAPPS_MCP_REPO}@{tag}#subdirectory=packages/tapps-mcp"
+    brain_url = f"tapps-brain @ git+{TAPPS_BRAIN_REPO}@{TAPPS_BRAIN_REV}"
+
+    lines = [
+        f"{indent}- name: {step_name}",
+        f"{indent}  run: |",
+        f"{indent}    pip install --upgrade pip",
+        f"{indent}    pip install \\",
+        f'{indent}      "{brain_url}" \\',
+        f'{indent}      "{core_url}" \\',
+    ]
+    if include_checkers:
+        lines.append(f'{indent}      "{mcp_url}" \\')
+        lines.append(f"{indent}      ruff mypy bandit radon vulture")
+    else:
+        lines.append(f'{indent}      "{mcp_url}"')
+    return "\n".join(lines) + "\n"

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/github_ci.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/github_ci.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from tapps_mcp.pipeline.ci_install import render_install_step
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -63,17 +65,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install TappsMCP and checkers
-        run: |
-          pip install tapps-mcp
-          pip install ruff mypy bandit radon vulture
-
+{INSTALL_STEP}
       - name: Run TappsMCP quality gate
         env:
           TAPPS_MCP_PROJECT_ROOT: ${{ github.workspace }}
-        run: |
-          tapps-mcp validate-changed \\
-            --preset ${{ inputs.preset || 'staging' }}
+        run: tapps-mcp validate-changed --full
 
       - name: Upload quality report
         if: always()
@@ -277,17 +273,11 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Install TappsMCP and checkers
-        run: |
-          pip install tapps-mcp
-          pip install ruff mypy bandit radon vulture
-
+{INSTALL_STEP}
       - name: Run quality gate
         env:
           TAPPS_MCP_PROJECT_ROOT: ${{ github.workspace }}
-        run: |
-          tapps-mcp validate-changed \\
-            --preset ${{ inputs.preset }}
+        run: tapps-mcp validate-changed --full
 """
 
 
@@ -308,7 +298,10 @@ def generate_enhanced_ci_workflow(project_root: Path) -> dict[str, Any]:
     wf_dir.mkdir(parents=True, exist_ok=True)
     target = wf_dir / "tapps-quality.yml"
     existed = target.exists()
-    target.write_text(_QUALITY_WORKFLOW, encoding="utf-8")
+    target.write_text(
+        _QUALITY_WORKFLOW.replace("{INSTALL_STEP}", render_install_step()),
+        encoding="utf-8",
+    )
     return {
         "file": str(target.relative_to(project_root)),
         "action": "updated" if existed else "created",
@@ -362,7 +355,10 @@ def generate_reusable_quality_workflow(project_root: Path) -> dict[str, Any]:
     wf_dir = project_root / ".github" / "workflows"
     wf_dir.mkdir(parents=True, exist_ok=True)
     target = wf_dir / "tapps-quality-reusable.yml"
-    target.write_text(_REUSABLE_QUALITY_WORKFLOW, encoding="utf-8")
+    target.write_text(
+        _REUSABLE_QUALITY_WORKFLOW.replace("{INSTALL_STEP}", render_install_step()),
+        encoding="utf-8",
+    )
     return {"file": str(target.relative_to(project_root)), "action": "created"}
 
 

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/github_copilot.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/github_copilot.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from tapps_mcp import __version__
+from tapps_mcp.pipeline.ci_install import render_install_step
 from tapps_mcp.pipeline.platform_generators import _add_version_marker, _check_version_marker
 
 if TYPE_CHECKING:
@@ -229,15 +230,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tools
-        run: |
-          pip install tapps-mcp ruff mypy bandit radon vulture
-
+{INSTALL_STEP}
       - name: Run quality analysis on changed files
         env:
           TAPPS_MCP_PROJECT_ROOT: ${{ github.workspace }}
-        run: |
-          tapps-mcp validate-changed --preset strict
+        run: tapps-mcp validate-changed --full
 """
 
 # ---------------------------------------------------------------------------
@@ -359,7 +356,13 @@ def generate_agentic_workflow(project_root: Path) -> dict[str, Any]:
     wf_dir = project_root / ".github" / "workflows"
     wf_dir.mkdir(parents=True, exist_ok=True)
     target = wf_dir / "agentic-pr-review.yml"
-    target.write_text(_AGENTIC_PR_REVIEW, encoding="utf-8")
+    target.write_text(
+        _AGENTIC_PR_REVIEW.replace(
+            "{INSTALL_STEP}",
+            render_install_step(step_name="Install TappsMCP and checkers"),
+        ),
+        encoding="utf-8",
+    )
     return {"file": str(target.relative_to(project_root)), "action": "created"}
 
 

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_bundles.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_bundles.py
@@ -13,6 +13,7 @@ import json
 import stat
 from typing import TYPE_CHECKING, Any
 
+from tapps_mcp.pipeline.ci_install import render_install_step
 from tapps_mcp.pipeline.platform_hook_templates import (
     AGENT_TEAMS_CLAUDE_MD_SECTION,
     AGENT_TEAMS_HOOK_SCRIPTS,
@@ -395,15 +396,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install TappsMCP
-        run: pip install tapps-mcp
-
+{INSTALL_STEP}
       - name: Run TappsMCP quality gate
         env:
           TAPPS_MCP_PROJECT_ROOT: ${{ github.workspace }}
-        run: |
-          tapps-mcp validate-changed \\
-            --preset staging
+        run: tapps-mcp validate-changed --full
 """
 
 _CI_CLAUDE_MD_SECTION = """\
@@ -457,7 +454,10 @@ def generate_ci_workflow(project_root: Path) -> dict[str, Any]:
     wf_dir = project_root / ".github" / "workflows"
     wf_dir.mkdir(parents=True, exist_ok=True)
     target = wf_dir / "tapps-quality.yml"
-    target.write_text(_CI_WORKFLOW, encoding="utf-8")
+    target.write_text(
+        _CI_WORKFLOW.replace("{INSTALL_STEP}", render_install_step()),
+        encoding="utf-8",
+    )
     return {"file": str(target), "action": "created"}
 
 

--- a/packages/tapps-mcp/tests/unit/test_ci_install.py
+++ b/packages/tapps-mcp/tests/unit/test_ci_install.py
@@ -1,0 +1,98 @@
+"""Regression tests for the shared CI install-step renderer.
+
+tapps-mcp is not published to PyPI. The generated CI workflows must
+install tapps-brain, tapps-core, and tapps-mcp directly from git URLs.
+If a future refactor drops these URLs (or reintroduces
+`pip install tapps-mcp`), every consuming project's CI silently breaks
+again — the tests below exist to catch that regression at PR time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tapps_mcp import __version__
+from tapps_mcp.pipeline.ci_install import (
+    TAPPS_BRAIN_REPO,
+    TAPPS_BRAIN_REV,
+    TAPPS_MCP_REPO,
+    render_install_step,
+)
+from tapps_mcp.pipeline.github_ci import (
+    generate_enhanced_ci_workflow,
+    generate_reusable_quality_workflow,
+)
+from tapps_mcp.pipeline.github_copilot import generate_agentic_workflow
+from tapps_mcp.pipeline.platform_bundles import generate_ci_workflow
+
+
+def _expected_urls() -> tuple[str, str, str]:
+    tag = f"v{__version__}"
+    return (
+        f"{TAPPS_BRAIN_REPO}@{TAPPS_BRAIN_REV}",
+        f"{TAPPS_MCP_REPO}@{tag}#subdirectory=packages/tapps-core",
+        f"{TAPPS_MCP_REPO}@{tag}#subdirectory=packages/tapps-mcp",
+    )
+
+
+def test_render_install_step_includes_all_three_git_urls() -> None:
+    rendered = render_install_step()
+    brain_url, core_url, mcp_url = _expected_urls()
+    assert brain_url in rendered
+    assert core_url in rendered
+    assert mcp_url in rendered
+    assert "pip install" in rendered
+
+
+def test_render_install_step_never_emits_bare_pypi_install() -> None:
+    """`pip install tapps-mcp` alone would fail — it must always use a URL."""
+    rendered = render_install_step()
+    for line in rendered.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("pip install") and "@ git+" not in stripped:
+            assert stripped == "pip install --upgrade pip" or stripped.endswith("\\"), (
+                f"found pip install without git URL: {stripped!r}"
+            )
+
+
+def test_render_install_step_omits_checkers_when_requested() -> None:
+    rendered = render_install_step(include_checkers=False)
+    assert "ruff mypy bandit radon vulture" not in rendered
+
+
+@pytest.mark.parametrize(
+    "generator_name",
+    [
+        "tapps-quality.yml",
+        "tapps-quality-reusable.yml",
+        "agentic-pr-review.yml",
+    ],
+)
+def test_generated_workflow_contains_git_urls(generator_name: str, tmp_path: Path) -> None:
+    generators = {
+        "tapps-quality.yml": generate_enhanced_ci_workflow,
+        "tapps-quality-reusable.yml": generate_reusable_quality_workflow,
+        "agentic-pr-review.yml": generate_agentic_workflow,
+    }
+    generators[generator_name](tmp_path)
+
+    workflow_text = (tmp_path / ".github" / "workflows" / generator_name).read_text()
+    brain_url, core_url, mcp_url = _expected_urls()
+    assert brain_url in workflow_text
+    assert core_url in workflow_text
+    assert mcp_url in workflow_text
+    assert "--preset" not in workflow_text
+    assert "validate-changed --full" in workflow_text
+
+
+def test_platform_bundles_ci_workflow_contains_git_urls(tmp_path: Path) -> None:
+    generate_ci_workflow(tmp_path)
+    workflow_text = (tmp_path / ".github" / "workflows" / "tapps-quality.yml").read_text()
+    brain_url, core_url, mcp_url = _expected_urls()
+    assert brain_url in workflow_text
+    assert core_url in workflow_text
+    assert mcp_url in workflow_text
+    assert "--preset" not in workflow_text
+    assert "validate-changed --full" in workflow_text


### PR DESCRIPTION
## Summary
Every consuming project that ran `tapps_init` got CI workflows that install tapps-mcp via `pip install tapps-mcp`. Since the package is not on PyPI (publish.yml was [removed in f369689](https://github.com/wtthornton/TappsMCP/commit/f369689)), those workflows fail immediately with `ERROR: Could not find a version that satisfies the requirement tapps-mcp`. Same workflows also pass `--preset` to `validate-changed`, which is not a real flag on the current CLI.

This PR fixes the generator, not the three workflows in this repo (that was [#122](https://github.com/wtthornton/TappsMCP/pull/122)).

## Changes
- New module `packages/tapps-mcp/src/tapps_mcp/pipeline/ci_install.py` — single source of truth for the install step. Pins:
  - `tapps-mcp` / `tapps-core` → `v{__version__}` + `#subdirectory=packages/...`
  - `tapps-brain` → commit SHA matching `[tool.uv.sources]` in the root `pyproject.toml` (kept in sync by hand at release time; there's a doc comment in the module)
- Four workflow templates updated to use `{INSTALL_STEP}` sentinel spliced at write-time:
  - `github_ci.py::_QUALITY_WORKFLOW`, `_REUSABLE_QUALITY_WORKFLOW`
  - `github_copilot.py::_AGENTIC_PR_REVIEW`
  - `platform_bundles.py::_CI_WORKFLOW` (legacy)
- `--preset` dropped from all four; call sites now run `tapps-mcp validate-changed --full`
- New `tests/unit/test_ci_install.py` (7 tests) asserting every generated workflow contains all three git URLs and never reintroduces `--preset` or bare `pip install tapps-mcp`

## Deliberately out of scope
- **Publishing to PyPI** — the user asked to skip this for now. If/when that happens, the generator can revert to a plain `pip install tapps-mcp` and delete `ci_install.py`.
- **Non-pip package managers** (poetry, uv workspaces in consumer repos) — consumers using something else will still need to adapt the `run: pip install ...` step. The generated workflow now works out-of-the-box on any runner with pip.

## Test plan
- [x] 70/70 local tests pass across `test_ci_install.py`, `test_github_ci_workflows.py`, `test_github_copilot_agents.py`, `test_ci_headless.py`
- [x] Generated YAML parses cleanly (yaml.safe_load)
- [x] ruff check + format pass; mypy --strict passes on new module
- [ ] CI passes on this PR
- [ ] After merge, `uv run tapps-mcp upgrade` on a consuming project regenerates workflows with the new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)