### PR TITLE
feat(docs-mcp): CSS marching-ants motion on Mermaid edges (TAP-1037)

### DIFF
--- a/packages/docs-mcp/src/docs_mcp/generators/interactive_html.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/interactive_html.py
@@ -25,6 +25,36 @@ class InteractiveHtmlResult(BaseModel):
 # Mermaid.js CDN URL (pinned version for stability)
 _MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
 
+# Motion configuration (deterministic — never derived from time/random/env).
+_VALID_MOTION_VALUES: frozenset[str] = frozenset({"off", "subtle", "particles"})
+_MOTION_DURATION_S: float = 1.2
+_MOTION_DASHARRAY: str = "4 8"
+_MOTION_DASHOFFSET_END: int = -12
+
+# Diagram-type gating: motion is only meaningful for flow-direction diagrams.
+_FLOW_DIAGRAM_TYPES: frozenset[str] = frozenset(
+    {"dependency", "module_map", "sequence", "c4_container"}
+)
+_RELATIONSHIP_ONLY_TYPES: frozenset[str] = frozenset(
+    {"class_hierarchy", "er_diagram", "c4_context"}
+)
+
+# Marching-ants CSS injected when motion is enabled. The animation is wrapped
+# in `@media (prefers-reduced-motion: no-preference)` so users with reduced-
+# motion preferences see a static diagram. Module-level constants keep the
+# CSS deterministic — never derive duration/dasharray from time or env.
+_MOTION_CSS = f"""\
+@media (prefers-reduced-motion: no-preference) {{
+    .edgePath path, .flowchart-link {{
+        stroke-dasharray: {_MOTION_DASHARRAY};
+        animation: tapps-marching-ants {_MOTION_DURATION_S}s linear infinite;
+    }}
+}}
+@keyframes tapps-marching-ants {{
+    to {{ stroke-dashoffset: {_MOTION_DASHOFFSET_END}; }}
+}}
+"""
+
 # Inline CSS for the interactive viewer
 _VIEWER_CSS = """\
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -76,6 +106,10 @@ body {
 @media print {
     .controls, .toc { display: none; }
     .diagram-section { break-inside: avoid; box-shadow: none; }
+    .edgePath path, .flowchart-link {
+        animation: none !important;
+        stroke-dasharray: none !important;
+    }
 }
 """
 
@@ -152,6 +186,8 @@ class InteractiveHtmlGenerator:
         title: str = "Architecture Diagrams",
         subtitle: str = "",
         theme: str = "default",
+        motion: str = "subtle",
+        diagram_types: list[str] | None = None,
     ) -> InteractiveHtmlResult:
         """Generate interactive HTML from Mermaid diagrams.
 
@@ -160,6 +196,17 @@ class InteractiveHtmlGenerator:
             title: Page title.
             subtitle: Page subtitle.
             theme: Mermaid theme (default, dark, forest, neutral).
+            motion: Motion intensity for edge animations.
+                ``"off"`` emits no animation CSS. ``"subtle"`` (default) adds
+                a CSS marching-ants effect on Mermaid edge paths via
+                ``stroke-dashoffset``. ``"particles"`` falls back to ``"subtle"``
+                in this generator (Phase 3 will add a JS particle layer).
+                All motion is gated by ``prefers-reduced-motion``.
+            diagram_types: Optional list of canonical diagram-type identifiers
+                (e.g. ``"dependency"``, ``"class_hierarchy"``) used to gate
+                motion. When every requested type is relationship-only
+                (``class_hierarchy``, ``er_diagram``, ``c4_context``), motion
+                CSS is suppressed entirely. ``None`` disables the gate.
 
         Returns:
             InteractiveHtmlResult with the self-contained HTML.
@@ -174,6 +221,8 @@ class InteractiveHtmlGenerator:
                 title=title,
             )
 
+        motion_css = _resolve_motion_css(motion, diagram_types)
+
         parts: list[str] = []
 
         # HTML head
@@ -183,7 +232,7 @@ class InteractiveHtmlGenerator:
         parts.append(f"<title>{_escape(title)}</title>")
         parts.append('<meta charset="utf-8">')
         parts.append('<meta name="viewport" content="width=device-width, initial-scale=1">')
-        parts.append(f"<style>{_VIEWER_CSS}</style>")
+        parts.append(f"<style>{_VIEWER_CSS}{motion_css}</style>")
         parts.append("</head>")
         parts.append("<body>")
 
@@ -246,3 +295,20 @@ def _escape(text: str) -> str:
     return (
         text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
     )
+
+
+def _resolve_motion_css(motion: str, diagram_types: list[str] | None) -> str:
+    """Resolve which motion CSS block (if any) to inject into the page.
+
+    Returns the marching-ants CSS block when motion is enabled and at least
+    one requested diagram type carries direction-of-flow. Returns ``""``
+    when motion is off, the value is unrecognized, or every requested type
+    is relationship-only.
+    """
+    if motion not in _VALID_MOTION_VALUES or motion == "off":
+        return ""
+    if diagram_types is not None:
+        requested = {dt.strip() for dt in diagram_types if dt.strip()}
+        if requested and not (requested & _FLOW_DIAGRAM_TYPES):
+            return ""
+    return _MOTION_CSS

--- a/packages/docs-mcp/src/docs_mcp/server_gen_tools.py
+++ b/packages/docs-mcp/src/docs_mcp/server_gen_tools.py
@@ -1896,6 +1896,7 @@ async def docs_generate_interactive_diagrams(
     title: str = "",
     output_path: str = "",
     project_root: str = "",
+    motion: str = "subtle",
 ) -> dict[str, Any]:
     """Generate an interactive HTML page with Mermaid.js diagrams.
 
@@ -1911,6 +1912,13 @@ async def docs_generate_interactive_diagrams(
         output_path: File path to write HTML (relative to project root).
             When empty, returns content only.
         project_root: Override project root path (default: configured root).
+        motion: Motion intensity for edge animations. ``"off"`` disables
+            all motion CSS. ``"subtle"`` (default) emits CSS marching-ants
+            on Mermaid edge paths, gated by ``prefers-reduced-motion``.
+            ``"particles"`` falls back to ``"subtle"`` until the JS particle
+            layer ships in a follow-up. Motion is suppressed automatically
+            when every requested ``diagram_types`` value is relationship-only
+            (``class_hierarchy``, ``er_diagram``, ``c4_context``).
     """
     _record_call("docs_generate_interactive_diagrams")
     start = time.perf_counter_ns()
@@ -1971,7 +1979,11 @@ async def docs_generate_interactive_diagrams(
     page_title = title or f"{root.name} Architecture"
     html_gen = InteractiveHtmlGenerator()
     html_result = html_gen.generate(
-        diagrams, title=page_title, subtitle=f"Generated from {root.name}"
+        diagrams,
+        title=page_title,
+        subtitle=f"Generated from {root.name}",
+        motion=motion,
+        diagram_types=types_list,
     )
     content = html_result.content
 

--- a/packages/docs-mcp/tests/unit/test_interactive_html.py
+++ b/packages/docs-mcp/tests/unit/test_interactive_html.py
@@ -1,0 +1,216 @@
+"""Tests for the interactive HTML viewer's motion layer (TAP-1037).
+
+Covers the four ``motion`` values (``off``/``subtle``/``particles``/invalid)
+crossed with the two diagram-type sets: flow-direction (dependency,
+module_map, sequence, c4_container) and relationship-only (class_hierarchy,
+er_diagram, c4_context). Also asserts that the ``@media print`` block
+disables animations and that ``prefers-reduced-motion`` gates motion CSS.
+"""
+
+from __future__ import annotations
+
+from docs_mcp.generators.interactive_html import (
+    _MOTION_DASHARRAY,
+    _MOTION_DURATION_S,
+    InteractiveHtmlGenerator,
+)
+
+_FLOW_TYPES = ["dependency", "module_map", "sequence", "c4_container"]
+_RELATIONSHIP_ONLY_TYPES = ["class_hierarchy", "er_diagram", "c4_context"]
+_SAMPLE_DIAGRAM = [("Test Diagram", "graph TD\n  A --> B")]
+_KEYFRAMES_NAME = "tapps-marching-ants"
+
+
+def _animation_present(html: str) -> bool:
+    return _KEYFRAMES_NAME in html
+
+
+# ---------------------------------------------------------------------------
+# motion="subtle" — flow-direction diagrams
+# ---------------------------------------------------------------------------
+
+
+class TestMotionSubtleFlow:
+    def test_subtle_emits_marching_ants_for_flow_types(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert _animation_present(result.content)
+        assert "stroke-dashoffset" in result.content
+        assert _MOTION_DASHARRAY in result.content
+        assert f"{_MOTION_DURATION_S}s linear infinite" in result.content
+        assert "prefers-reduced-motion: no-preference" in result.content
+        assert ".edgePath path" in result.content
+        assert ".flowchart-link" in result.content
+
+    def test_subtle_default_emits_motion_when_no_types_passed(self) -> None:
+        # With no diagram_types provided, the gate is disabled and motion
+        # CSS is emitted when motion is enabled (default = "subtle").
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(_SAMPLE_DIAGRAM)
+        assert _animation_present(result.content)
+
+
+# ---------------------------------------------------------------------------
+# motion="subtle" — relationship-only diagrams (gate suppresses CSS)
+# ---------------------------------------------------------------------------
+
+
+class TestMotionSubtleRelationshipOnly:
+    def test_subtle_suppressed_for_relationship_only_types(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=_RELATIONSHIP_ONLY_TYPES,
+        )
+        assert not _animation_present(result.content)
+        assert "stroke-dashoffset" not in result.content
+
+    def test_subtle_emits_when_mixed_types_include_flow(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=["class_hierarchy", "dependency"],
+        )
+        assert _animation_present(result.content)
+
+
+# ---------------------------------------------------------------------------
+# motion="off" — never emits animation, regardless of types
+# ---------------------------------------------------------------------------
+
+
+class TestMotionOff:
+    def test_off_for_flow_types_emits_no_animation(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="off",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert not _animation_present(result.content)
+        assert "stroke-dashoffset" not in result.content
+
+    def test_off_for_relationship_types_emits_no_animation(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="off",
+            diagram_types=_RELATIONSHIP_ONLY_TYPES,
+        )
+        assert not _animation_present(result.content)
+
+
+# ---------------------------------------------------------------------------
+# motion="particles" — Phase 1 falls back to "subtle"
+# ---------------------------------------------------------------------------
+
+
+class TestMotionParticlesFallback:
+    def test_particles_falls_back_to_subtle_for_flow_types(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert _animation_present(result.content)
+
+    def test_particles_respects_relationship_only_gate(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_RELATIONSHIP_ONLY_TYPES,
+        )
+        assert not _animation_present(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Invalid motion value — defensively treated as "off"
+# ---------------------------------------------------------------------------
+
+
+class TestMotionInvalid:
+    def test_invalid_value_emits_no_animation_for_flow(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="bogus",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert not _animation_present(result.content)
+
+    def test_invalid_value_emits_no_animation_for_relationship(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="bogus",
+            diagram_types=_RELATIONSHIP_ONLY_TYPES,
+        )
+        assert not _animation_present(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Print-media disable hook
+# ---------------------------------------------------------------------------
+
+
+class TestPrintDisablesAnimation:
+    def test_print_block_disables_animation(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=_FLOW_TYPES,
+        )
+        # Print block is in _VIEWER_CSS regardless of motion. Find it and
+        # assert the animation-disable selectors live inside it.
+        print_idx = result.content.find("@media print")
+        assert print_idx != -1
+        # Closing brace of the @media print block (first '}' after the
+        # opening '{' that follows '@media print', at nesting depth 0
+        # relative to the rule's body).
+        body_start = result.content.find("{", print_idx)
+        depth = 0
+        end = -1
+        for i in range(body_start, len(result.content)):
+            ch = result.content[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        assert end > body_start
+        block = result.content[body_start:end]
+        assert "animation: none" in block
+        assert ".edgePath path" in block
+        assert ".flowchart-link" in block
+
+
+# ---------------------------------------------------------------------------
+# Determinism — emitted CSS is byte-identical across calls
+# ---------------------------------------------------------------------------
+
+
+class TestMotionDeterminism:
+    def test_two_runs_produce_identical_motion_css(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        a = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=_FLOW_TYPES,
+        )
+        b = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert a.content == b.content


### PR DESCRIPTION
## Summary

Phase 1 of the docs-mcp graph-motion epic ([TAP-1036](https://linear.app/tappscodingagents/issue/TAP-1036)).

- Adds `motion: "off" | "subtle" | "particles"` arg to `docs_generate_interactive_diagrams` (default `"subtle"`).
- Injects a CSS marching-ants animation on `.edgePath path` and `.flowchart-link` when motion is enabled, wrapped in `@media (prefers-reduced-motion: no-preference)`.
- Animation params (1.2s linear infinite, dasharray "4 8") are module-level constants — fully deterministic.
- Suppresses motion entirely when every requested diagram type is relationship-only (class_hierarchy / er_diagram / c4_context).
- Extends `@media print` to disable animations for PDF export.
- `motion="particles"` falls back to "subtle" until [TAP-1039](https://linear.app/tappscodingagents/issue/TAP-1039) ships the JS layer.

Closes [TAP-1037](https://linear.app/tappscodingagents/issue/TAP-1037).

## Test plan

- [x] `uv run pytest packages/docs-mcp/tests/unit/test_interactive_html.py -v` (12/12 passing)
- [x] `uv run pytest packages/docs-mcp/tests/unit/test_c4_diagrams.py -v` (no regressions, 44/44)
- [x] `uv run mypy --strict` on `interactive_html.py` and `server_gen_tools.py` (clean)
- [x] `tapps_validate_changed` quality gate (interactive_html.py passes; server_gen_tools.py score unchanged from master baseline)
- [ ] Open the rendered HTML in a browser and confirm animation flows in-direction with `prefers-reduced-motion: no-preference`, halts under `reduce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)