### PR TITLE
feat(docs-mcp): SVG animateMotion on flow panels (TAP-1038)

### DIFF
--- a/packages/docs-mcp/src/docs_mcp/generators/architecture.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/architecture.py
@@ -50,6 +50,32 @@ _COUPLING_LOW = 8
 _COUPLING_HIGH = 20
 _DEP_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+")
 
+# ---------------------------------------------------------------------------
+# Motion configuration (deterministic — never derived from time/random/env).
+# Used by _build_circular_dep_svg / _build_grid_dep_svg when motion is enabled.
+# ---------------------------------------------------------------------------
+
+_VALID_MOTION_VALUES: frozenset[str] = frozenset({"off", "subtle", "particles"})
+_ANIMATE_MOTION_DUR_S: float = 2.4
+_ANIMATE_MOTION_RADIUS: int = 3
+_ANIMATE_MOTION_FILL: str = "#fafafa"
+
+
+def _animate_motion_circle(edge_id: str) -> str:
+    """Return a ``<circle>`` with ``<animateMotion>`` tracing ``edge_id``.
+
+    The circle carries class ``anim-particle`` so the page-level reduced-
+    motion CSS rule can hide it when the user prefers no motion.
+    """
+    return (
+        f'<circle class="anim-particle" r="{_ANIMATE_MOTION_RADIUS}"'
+        f' fill="{_ANIMATE_MOTION_FILL}">'
+        f'<animateMotion dur="{_ANIMATE_MOTION_DUR_S}s" repeatCount="indefinite">'
+        f'<mpath href="#{edge_id}"/>'
+        f"</animateMotion>"
+        f"</circle>"
+    )
+
 # Directories to exclude from architecture analysis beyond SKIP_DIRS.
 _ARCH_SKIP_DIRS: frozenset[str] = frozenset(
     {
@@ -145,6 +171,7 @@ class ArchitectureGenerator:
         output_format: str = "html",
         title: str = "",
         subtitle: str = "",
+        motion: str = "off",
     ) -> ArchitectureResult:
         """Generate the architecture document.
 
@@ -153,6 +180,11 @@ class ArchitectureGenerator:
             output_format: Output format (currently only ``html``).
             title: Custom title override. Defaults to project name.
             subtitle: Custom subtitle / tagline.
+            motion: Motion intensity for SVG flow diagrams. ``"off"``
+                (default) keeps the printable report static — important
+                for PDF export. ``"subtle"`` / ``"particles"`` add SVG
+                ``<animateMotion>`` particles tracing each dependency-flow
+                edge and each pipeline / layered pattern-panel edge.
 
         Returns:
             An :class:`ArchitectureResult` with the rendered content.
@@ -193,7 +225,9 @@ class ArchitectureGenerator:
 
         # 5c. Classify architectural archetype — reuses already-built module_map
         # and dep_graph so no extra analysis cost (STORY-100.11).
-        archetype_html = self._build_archetype_hero_html(project_root, module_map, dep_graph)
+        archetype_html = self._build_archetype_hero_html(
+            project_root, module_map, dep_graph, motion=motion
+        )
 
         # 6. Render HTML (pass pre-collected packages to avoid re-collection)
         content = self._render_html(
@@ -206,6 +240,7 @@ class ArchitectureGenerator:
             api_info=api_info,
             packages=packages,
             archetype_html=archetype_html,
+            motion=motion,
         )
 
         edge_count = dep_graph.total_internal_imports if dep_graph else 0
@@ -507,6 +542,7 @@ class ArchitectureGenerator:
         api_info: list[dict[str, Any]],
         packages: list[dict[str, Any]] | None = None,
         archetype_html: str = "",
+        motion: str = "off",
     ) -> str:
         """Render the complete HTML architecture document."""
         safe_name = html.escape(proj_name)
@@ -564,7 +600,7 @@ class ArchitectureGenerator:
         sections.append(self._render_package_details(packages, module_map))
 
         # Dependency flow SVG
-        sections.append(self._render_dependency_flow(packages, dep_edges))
+        sections.append(self._render_dependency_flow(packages, dep_edges, motion=motion))
 
         # API surface (filtered + capped)
         if api_info:
@@ -680,6 +716,8 @@ class ArchitectureGenerator:
         project_root: Path,
         module_map: ModuleMap | None,
         dep_graph: ImportGraph | None,
+        *,
+        motion: str = "off",
     ) -> str:
         """Classify the project archetype and build hero badge + animated SVG panel.
 
@@ -722,7 +760,7 @@ class ArchitectureGenerator:
             )
 
             poster = ArchPatternPosterGenerator()
-            svg = poster._panel_svg(arch, [], w=360, h=257)
+            svg = poster._panel_svg(arch, [], w=360, h=257, motion=motion)
             return f"{badge}{svg}"
 
         except Exception:
@@ -908,6 +946,8 @@ class ArchitectureGenerator:
         self,
         packages: list[dict[str, Any]],
         edges: list[tuple[int, int]],
+        *,
+        motion: str = "off",
     ) -> str:
         """Render the dependency flow SVG diagram (or empty-state message)."""
         if not packages:
@@ -925,7 +965,7 @@ class ArchitectureGenerator:
         )
 
         if edges:
-            svg = self._build_dependency_svg(packages, edges)
+            svg = self._build_dependency_svg(packages, edges, motion=motion)
             parts.append('<figure role="figure" aria-labelledby="dep-flow-figcaption">')
             parts.append(f'<div class="diagram-container">{svg}</div>')
             parts.append(
@@ -1664,6 +1704,8 @@ class ArchitectureGenerator:
         self,
         packages: list[dict[str, Any]],
         edges: list[tuple[int, int]],
+        *,
+        motion: str = "off",
     ) -> str:
         """Build a dependency flow SVG with curved arrows."""
         count = len(packages)
@@ -1672,13 +1714,15 @@ class ArchitectureGenerator:
 
         # Layout: circular for <=10, grid for more
         if count <= _CIRCULAR_LAYOUT_THRESHOLD:
-            return self._build_circular_dep_svg(packages, edges)
-        return self._build_grid_dep_svg(packages, edges)
+            return self._build_circular_dep_svg(packages, edges, motion=motion)
+        return self._build_grid_dep_svg(packages, edges, motion=motion)
 
     def _build_circular_dep_svg(
         self,
         packages: list[dict[str, Any]],
         edges: list[tuple[int, int]],
+        *,
+        motion: str = "off",
     ) -> str:
         """Render dependencies in a circular layout."""
         count = len(packages)
@@ -1732,8 +1776,11 @@ class ArchitectureGenerator:
             py = cy + radius * math.sin(angle)
             positions.append((px, py))
 
-        # Draw edges (curved)
-        for src_idx, tgt_idx in edges:
+        # Draw edges (curved). Each edge gets a stable id so optional
+        # <animateMotion> particles can trace it.
+        motion_on = motion in _VALID_MOTION_VALUES and motion != "off"
+        edge_animations: list[str] = []
+        for edge_index, (src_idx, tgt_idx) in enumerate(edges):
             if src_idx >= count or tgt_idx >= count:
                 continue
             sx, sy = positions[src_idx]
@@ -1743,11 +1790,15 @@ class ArchitectureGenerator:
             ctrl_x = cx + (sx + tx - 2 * cx) * 0.3
             ctrl_y = cy + (sy + ty - 2 * cy) * 0.3
 
+            edge_id = f"dep-edge-{edge_index}"
             lines.append(
-                f'  <path d="M {sx:.0f} {sy:.0f} Q {ctrl_x:.0f} {ctrl_y:.0f} {tx:.0f} {ty:.0f}" '
+                f'  <path id="{edge_id}" '
+                f'd="M {sx:.0f} {sy:.0f} Q {ctrl_x:.0f} {ctrl_y:.0f} {tx:.0f} {ty:.0f}" '
                 f'fill="none" stroke="rgba(63,63,90,0.5)" stroke-width="2" '
                 f'stroke-dasharray="6,4" marker-end="url(#arrowhead)" opacity="0.7"/>'
             )
+            if motion_on:
+                edge_animations.append(_animate_motion_circle(edge_id))
 
         # Draw nodes
         for i, (px, py) in enumerate(positions):
@@ -1769,6 +1820,8 @@ class ArchitectureGenerator:
                 f'font-family="Outfit, Inter, system-ui, sans-serif">{display_name}</text>'
             )
 
+        # Particles ride on top of everything else.
+        lines.extend(edge_animations)
         lines.append("</svg>")
         return "\n".join(lines)
 
@@ -1776,6 +1829,8 @@ class ArchitectureGenerator:
         self,
         packages: list[dict[str, Any]],
         edges: list[tuple[int, int]],
+        *,
+        motion: str = "off",
     ) -> str:
         """Render dependencies in a grid layout for larger projects."""
         count = len(packages)
@@ -1828,18 +1883,24 @@ class ArchitectureGenerator:
             positions.append((x, y))
 
         # Edges
-        for src_idx, tgt_idx in edges:
+        motion_on = motion in _VALID_MOTION_VALUES and motion != "off"
+        edge_animations: list[str] = []
+        for edge_index, (src_idx, tgt_idx) in enumerate(edges):
             if src_idx >= count or tgt_idx >= count:
                 continue
             sx, sy = positions[src_idx]
             tx, ty = positions[tgt_idx]
             mid_x = (sx + tx) / 2
             mid_y = (sy + ty) / 2 - 20
+            edge_id = f"dep-edge-{edge_index}"
             lines.append(
-                f'  <path d="M {sx:.0f} {sy:.0f} Q {mid_x:.0f} {mid_y:.0f} {tx:.0f} {ty:.0f}" '
+                f'  <path id="{edge_id}" '
+                f'd="M {sx:.0f} {sy:.0f} Q {mid_x:.0f} {mid_y:.0f} {tx:.0f} {ty:.0f}" '
                 f'fill="none" stroke="rgba(63,63,90,0.5)" stroke-width="1.5" '
                 f'stroke-dasharray="5,3" marker-end="url(#garrow)" opacity="0.6"/>'
             )
+            if motion_on:
+                edge_animations.append(_animate_motion_circle(edge_id))
 
         # Nodes
         for i in range(count):
@@ -1863,6 +1924,8 @@ class ArchitectureGenerator:
                 f"{display}</text>"
             )
 
+        # Particles ride on top of everything else.
+        lines.extend(edge_animations)
         lines.append("</svg>")
         return "\n".join(lines)
 
@@ -2455,6 +2518,10 @@ body {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+  .anim-particle {
+    visibility: hidden !important;
+    animation-play-state: paused !important;
   }
 }
 

--- a/packages/docs-mcp/src/docs_mcp/generators/pattern_poster.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/pattern_poster.py
@@ -106,6 +106,19 @@ _BADGE_FG: dict[str, str] = {
 _W = 280  # panel width (SVG units)
 _H = 200  # panel height (SVG units)
 
+# ---------------------------------------------------------------------------
+# Motion configuration (deterministic — never derived from time/random/env).
+# Used by the _svg_layered and _svg_pipeline flow panels when motion is
+# enabled by the caller. Relationship-structural panels (hexagonal,
+# monolith, event_driven, microservice) never emit animateMotion.
+# ---------------------------------------------------------------------------
+
+_VALID_MOTION_VALUES: frozenset[str] = frozenset({"off", "subtle", "particles"})
+_ANIMATE_MOTION_DUR_S: float = 2.4
+_ANIMATE_MOTION_RADIUS: int = 3
+_ANIMATE_MOTION_FILL: str = "#fafafa"
+_FLOW_ARCHETYPES: frozenset[str] = frozenset({"layered", "pipeline"})
+
 
 class ArchPatternPosterGenerator:
     """Generates animated SVG topology diagrams for architectural archetypes.
@@ -128,12 +141,24 @@ class ArchPatternPosterGenerator:
         packages: list[tuple[str, str]],
         archetype_result: ArchetypeResult,
         adr_link: str | None = None,
+        *,
+        motion: str = "off",
     ) -> str:
-        """Return a self-contained HTML page for *archetype_result*."""
+        """Return a self-contained HTML page for *archetype_result*.
+
+        Args:
+            packages: Project packages with their inferred role.
+            archetype_result: Classification output (archetype + confidence).
+            adr_link: Optional path to a related ADR.
+            motion: Motion intensity. ``"off"`` (default) emits no
+                ``<animateMotion>`` elements. ``"subtle"`` / ``"particles"``
+                add an SVG-native moving particle along each flow edge for
+                ``layered`` and ``pipeline`` panels only.
+        """
         arch = str(archetype_result.archetype)
         label = _ARCHETYPE_LABELS.get(arch, arch.upper())
         pct = f"{archetype_result.confidence * 100:.0f}%"
-        svg = self._panel_svg(arch, packages, w=600, h=430)
+        svg = self._panel_svg(arch, packages, w=600, h=430, motion=motion)
         badge_bg = _BADGE_BG.get(arch, "#374151")
         badge_fg = _BADGE_FG.get(arch, "#fff")
         adr_html = (
@@ -153,13 +178,19 @@ class ArchPatternPosterGenerator:
 </div>"""
         return self._html_page(title=f"{label} Architecture", body=body, detected=arch)
 
-    def generate_comparison(self, detected_archetype: str = "") -> str:
-        """Return a self-contained HTML page with all six archetypes in a 2×3 grid."""
+    def generate_comparison(
+        self, detected_archetype: str = "", *, motion: str = "off"
+    ) -> str:
+        """Return a self-contained HTML page with all six archetypes in a 2×3 grid.
+
+        ``motion`` is forwarded to per-panel SVG renderers; only the
+        ``layered`` and ``pipeline`` panels honor it.
+        """
         panels: list[str] = []
         for arch in _GRID_ORDER:
             label = _ARCHETYPE_LABELS.get(arch, arch.upper())
             cls = "panel highlighted" if arch == detected_archetype else "panel"
-            svg = self._panel_svg(arch, [], w=_W, h=_H)
+            svg = self._panel_svg(arch, [], w=_W, h=_H, motion=motion)
             panels.append(
                 f'<div class="{cls}" data-arch="{arch}">'
                 f'<div class="panel-title">{label}</div>'
@@ -193,18 +224,29 @@ class ArchPatternPosterGenerator:
         *,
         w: int = _W,
         h: int = _H,
+        motion: str = "off",
     ) -> str:
-        """Return an inline ``<svg>`` element for one archetype panel."""
-        dispatch = {
-            "layered": self._svg_layered,
-            "event_driven": self._svg_event_driven,
-            "hexagonal": self._svg_hexagonal,
-            "microservice": self._svg_microservice,
-            "monolith": self._svg_monolith,
-            "pipeline": self._svg_pipeline,
-        }
-        renderer = dispatch.get(archetype, self._svg_layered)
-        inner = renderer(packages)
+        """Return an inline ``<svg>`` element for one archetype panel.
+
+        ``motion`` is forwarded to the per-archetype renderer. Only the
+        flow-direction archetypes (``layered``, ``pipeline``) honor it;
+        the rest ignore it and emit no ``<animateMotion>``.
+        """
+        flow_motion = motion if archetype in _FLOW_ARCHETYPES else "off"
+        if archetype == "layered":
+            inner = self._svg_layered(packages, motion=flow_motion)
+        elif archetype == "pipeline":
+            inner = self._svg_pipeline(packages, motion=flow_motion)
+        elif archetype == "event_driven":
+            inner = self._svg_event_driven(packages)
+        elif archetype == "hexagonal":
+            inner = self._svg_hexagonal(packages)
+        elif archetype == "microservice":
+            inner = self._svg_microservice(packages)
+        elif archetype == "monolith":
+            inner = self._svg_monolith(packages)
+        else:
+            inner = self._svg_layered(packages, motion=flow_motion)
         label = _ARCHETYPE_LABELS.get(archetype, archetype)
         return (
             f'<svg xmlns="http://www.w3.org/2000/svg"'
@@ -221,8 +263,15 @@ class ArchPatternPosterGenerator:
     # SVG topology renderers
     # ------------------------------------------------------------------
 
-    def _svg_layered(self, packages: list[tuple[str, str]]) -> str:
-        """Four horizontal bands stacked top-to-bottom."""
+    def _svg_layered(
+        self, packages: list[tuple[str, str]], *, motion: str = "off"
+    ) -> str:
+        """Four horizontal bands stacked top-to-bottom.
+
+        When ``motion`` is enabled (``"subtle"`` / ``"particles"``), each
+        inter-band edge is rendered as a ``<path id="lyr-edge-N">`` and a
+        ``<circle><animateMotion>`` is appended that traces it.
+        """
         bands = [
             ("presentation", "Presentation", "#F5A9D0", "#111"),
             ("business", "Business / Application", "#14B8A6", "#fff"),
@@ -236,6 +285,8 @@ class ArchPatternPosterGenerator:
         band_h, gap, x0, bw = 38, 6, 12, 256
         y0 = 12
         lines: list[str] = [f'<rect width="{_W}" height="{_H}" rx="10" fill="#0a0a0f"/>']
+        motion_on = motion in _VALID_MOTION_VALUES and motion != "off"
+        edge_animations: list[str] = []
 
         for i, (role, label, color, tc) in enumerate(bands):
             y = y0 + i * (band_h + gap)
@@ -264,13 +315,20 @@ class ArchPatternPosterGenerator:
             if i < len(bands) - 1:
                 ax = x0 + bw // 2
                 ay = y + band_h
+                edge_id = f"lyr-edge-{i}"
                 lines.append(
-                    f'<line x1="{ax}" y1="{ay}" x2="{ax}" y2="{ay + gap}"'
-                    f' stroke="#a1a1aa" stroke-width="1.5" marker-end="url(#pp-arr)"/>'
+                    f'<path id="{edge_id}" d="M {ax} {ay} L {ax} {ay + gap}"'
+                    f' fill="none" stroke="#a1a1aa" stroke-width="1.5"'
+                    f' marker-end="url(#pp-arr)"/>'
                 )
+                if motion_on:
+                    edge_animations.append(_animate_motion_circle(edge_id))
 
-        # Animated dot (positioned at origin; CSS moves it)
+        # Animated dot (positioned at origin; CSS moves it). Kept for
+        # back-compat with existing snapshot tests; the SMIL particle is
+        # additive on top of the existing CSS keyframe pulse.
         lines.append('<circle class="flow-dot dot-lyr" r="4" fill="#fff"/>')
+        lines.extend(edge_animations)
         return "\n".join(lines)
 
     def _svg_event_driven(self, packages: list[tuple[str, str]]) -> str:
@@ -610,8 +668,15 @@ class ArchPatternPosterGenerator:
         )
         return "\n".join(lines)
 
-    def _svg_pipeline(self, packages: list[tuple[str, str]]) -> str:
-        """Left-to-right sequential stages."""
+    def _svg_pipeline(
+        self, packages: list[tuple[str, str]], *, motion: str = "off"
+    ) -> str:
+        """Left-to-right sequential stages.
+
+        When ``motion`` is enabled, each stage-to-stage edge is rendered as
+        a ``<path id="pipe-edge-N">`` and a ``<circle><animateMotion>``
+        is appended per edge.
+        """
         lines: list[str] = [f'<rect width="{_W}" height="{_H}" rx="10" fill="#0a0a0f"/>']
 
         default_stages = [
@@ -635,6 +700,8 @@ class ArchPatternPosterGenerator:
         total_w = len(stage_names) * stg_w + (len(stage_names) - 1) * inter
         x0 = (_W - total_w) // 2
         y0 = 75
+        motion_on = motion in _VALID_MOTION_VALUES and motion != "off"
+        edge_animations: list[str] = []
 
         stage_xs: list[int] = []
         for i, (name, color) in enumerate(zip(stage_names, stage_colors, strict=True)):
@@ -655,10 +722,14 @@ class ArchPatternPosterGenerator:
             if i < len(stage_names) - 1:
                 ax = sx + stg_w
                 ay = sy + stg_h // 2
+                edge_id = f"pipe-edge-{i}"
                 lines.append(
-                    f'<line x1="{ax}" y1="{ay}" x2="{ax + inter}" y2="{ay}"'
-                    f' stroke="#a1a1aa" stroke-width="1.5" marker-end="url(#pp-arr)"/>'
+                    f'<path id="{edge_id}" d="M {ax} {ay} L {ax + inter} {ay}"'
+                    f' fill="none" stroke="#a1a1aa" stroke-width="1.5"'
+                    f' marker-end="url(#pp-arr)"/>'
                 )
+                if motion_on:
+                    edge_animations.append(_animate_motion_circle(edge_id))
 
         # Header label
         mid_x = x0 + total_w // 2
@@ -669,6 +740,7 @@ class ArchPatternPosterGenerator:
         )
 
         lines.append('<circle class="flow-dot dot-pipe" r="4" fill="#fff"/>')
+        lines.extend(edge_animations)
         return "\n".join(lines)
 
     # ------------------------------------------------------------------
@@ -697,6 +769,29 @@ class ArchPatternPosterGenerator:
             f"<body>\n{body}\n</body>\n"
             "</html>"
         )
+
+
+# ---------------------------------------------------------------------------
+# Motion helpers
+# ---------------------------------------------------------------------------
+
+
+def _animate_motion_circle(edge_id: str) -> str:
+    """Return a ``<circle>`` with ``<animateMotion>`` tracing ``edge_id``.
+
+    The circle carries class ``anim-particle`` so the page-level reduced-
+    motion CSS rule can hide it when the user prefers no motion (CSS
+    ``animation-play-state: paused`` is not honored uniformly for SMIL,
+    so we hide the host element instead — equivalent visual effect).
+    """
+    return (
+        f'<circle class="anim-particle" r="{_ANIMATE_MOTION_RADIUS}"'
+        f' fill="{_ANIMATE_MOTION_FILL}">'
+        f'<animateMotion dur="{_ANIMATE_MOTION_DUR_S}s" repeatCount="indefinite">'
+        f'<mpath href="#{edge_id}"/>'
+        f"</animateMotion>"
+        f"</circle>"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -890,6 +985,10 @@ body {
   .mono-ring {
     animation: none !important;
     opacity: 0 !important;
+  }
+  .anim-particle {
+    visibility: hidden !important;
+    animation-play-state: paused !important;
   }
 }
 """

--- a/packages/docs-mcp/src/docs_mcp/server_gen_tools.py
+++ b/packages/docs-mcp/src/docs_mcp/server_gen_tools.py
@@ -974,6 +974,7 @@ async def docs_generate_architecture(
     subtitle: str = "",
     output_path: str = "",
     project_root: str = "",
+    motion: str = "off",
 ) -> dict[str, Any]:
     """Generate a comprehensive, self-contained HTML architecture report.
 
@@ -995,6 +996,12 @@ async def docs_generate_architecture(
         output_path: File path to write the HTML report to. If empty, content
             is returned in the response without writing to disk.
         project_root: Override project root path (default: configured root).
+        motion: Motion intensity for SVG flow diagrams. ``"off"`` (default)
+            keeps the printable report static — important for PDF export.
+            ``"subtle"`` / ``"particles"`` add SVG-native ``<animateMotion>``
+            particles tracing each dependency-flow edge and each pipeline /
+            layered pattern-panel edge. All motion is gated by
+            ``prefers-reduced-motion``.
     """
     _record_call("docs_generate_architecture")
     start = time.perf_counter_ns()
@@ -1017,6 +1024,7 @@ async def docs_generate_architecture(
             root,
             title=title,
             subtitle=subtitle,
+            motion=motion,
         )
     except Exception as exc:
         return error_response(

--- a/packages/docs-mcp/tests/unit/test_architecture.py
+++ b/packages/docs-mcp/tests/unit/test_architecture.py
@@ -321,6 +321,131 @@ class TestCollectEdges:
 
 
 # ---------------------------------------------------------------------------
+# Motion (TAP-1038) — animateMotion on dependency-flow SVG
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyFlowMotion:
+    """``motion="subtle"`` adds path ids and animateMotion particles.
+
+    Default ``motion="off"`` must emit no animateMotion. The SMIL
+    pause-hook CSS rule must always be present.
+    """
+
+    def _packages(self, n: int) -> list[dict]:
+        return [{"name": f"pkg{i}", "module_count": 1} for i in range(n)]
+
+    def _edges(self, n: int) -> list[tuple[int, int]]:
+        return [(i, (i + 1) % n) for i in range(n)]
+
+    def test_circular_motion_subtle_emits_animatemotion(self) -> None:
+        gen = ArchitectureGenerator()
+        packages = self._packages(4)
+        edges = self._edges(4)
+        svg = gen._build_circular_dep_svg(packages, edges, motion="subtle")
+        assert 'id="dep-edge-0"' in svg
+        assert "<animateMotion" in svg
+        assert 'href="#dep-edge-0"' in svg
+        assert svg.count("<animateMotion") == 4
+
+    def test_circular_motion_off_emits_no_animatemotion(self) -> None:
+        gen = ArchitectureGenerator()
+        svg = gen._build_circular_dep_svg(
+            self._packages(4), self._edges(4), motion="off"
+        )
+        assert "<animateMotion" not in svg
+        # Path IDs are still present — gating only suppresses the particle.
+        assert 'id="dep-edge-0"' in svg
+
+    def test_grid_motion_subtle_emits_animatemotion(self) -> None:
+        gen = ArchitectureGenerator()
+        # >10 packages -> grid layout
+        packages = self._packages(12)
+        edges = self._edges(12)
+        svg = gen._build_grid_dep_svg(packages, edges, motion="subtle")
+        assert 'id="dep-edge-0"' in svg
+        assert "<animateMotion" in svg
+        assert svg.count("<animateMotion") == 12
+
+    def test_grid_motion_off_emits_no_animatemotion(self) -> None:
+        gen = ArchitectureGenerator()
+        svg = gen._build_grid_dep_svg(
+            self._packages(12), self._edges(12), motion="off"
+        )
+        assert "<animateMotion" not in svg
+
+    def test_dur_is_module_constant(self) -> None:
+        from docs_mcp.generators.architecture import _ANIMATE_MOTION_DUR_S
+
+        gen = ArchitectureGenerator()
+        svg = gen._build_circular_dep_svg(
+            self._packages(3), self._edges(3), motion="subtle"
+        )
+        assert f'dur="{_ANIMATE_MOTION_DUR_S}s"' in svg
+
+    def test_invalid_motion_emits_no_animatemotion(self) -> None:
+        gen = ArchitectureGenerator()
+        svg = gen._build_circular_dep_svg(
+            self._packages(3), self._edges(3), motion="bogus"
+        )
+        assert "<animateMotion" not in svg
+
+    def test_particles_value_treated_as_subtle(self) -> None:
+        gen = ArchitectureGenerator()
+        svg = gen._build_circular_dep_svg(
+            self._packages(3), self._edges(3), motion="particles"
+        )
+        assert "<animateMotion" in svg
+
+    def test_two_runs_produce_identical_svg(self) -> None:
+        gen = ArchitectureGenerator()
+        a = gen._build_circular_dep_svg(
+            self._packages(3), self._edges(3), motion="subtle"
+        )
+        b = gen._build_circular_dep_svg(
+            self._packages(3), self._edges(3), motion="subtle"
+        )
+        assert a == b
+
+
+class TestArchitectureGenerateMotionDefault:
+    """Top-level ``generate(motion=...)`` defaults to ``"off"``."""
+
+    def test_generate_default_motion_off_emits_no_animatemotion(
+        self, arch_project: Path
+    ) -> None:
+        gen = ArchitectureGenerator()
+        result = gen.generate(arch_project)
+        assert "<animateMotion" not in result.content
+
+    def test_reduced_motion_css_block_contains_smil_pause_hook(
+        self, arch_project: Path
+    ) -> None:
+        gen = ArchitectureGenerator()
+        result = gen.generate(arch_project)
+        # Find the @media (prefers-reduced-motion: reduce) block. The body
+        # must mention the SMIL host class so reduced-motion users see no
+        # particle even when motion is enabled.
+        idx = result.content.find("prefers-reduced-motion: reduce")
+        assert idx != -1
+        block_start = result.content.find("{", idx)
+        depth = 0
+        end = -1
+        for i in range(block_start, len(result.content)):
+            ch = result.content[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        assert end > block_start
+        block = result.content[block_start:end]
+        assert "anim-particle" in block
+
+
+# ---------------------------------------------------------------------------
 # MCP tool tests
 # ---------------------------------------------------------------------------
 

--- a/packages/docs-mcp/tests/unit/test_pattern_poster.py
+++ b/packages/docs-mcp/tests/unit/test_pattern_poster.py
@@ -228,6 +228,130 @@ class TestPanelSvgTopologies:
 
 
 # ---------------------------------------------------------------------------
+# Motion (TAP-1038) — animateMotion on flow panels
+# ---------------------------------------------------------------------------
+
+
+class TestPanelMotion:
+    """``motion="subtle"`` adds path ids + ``<animateMotion>`` on flow panels.
+
+    Default ``motion="off"`` must emit no animateMotion. Relationship-
+    structural archetypes (``hexagonal``, ``monolith``, ``event_driven``,
+    ``microservice``) must never emit animateMotion regardless of motion.
+    """
+
+    def _svg(self, arch: str, *, motion: str = "off") -> str:
+        return ArchPatternPosterGenerator()._panel_svg(
+            arch, [], w=280, h=200, motion=motion
+        )
+
+    def test_layered_motion_subtle_emits_path_id_and_animatemotion(self) -> None:
+        svg = self._svg("layered", motion="subtle")
+        assert 'id="lyr-edge-0"' in svg
+        assert "<animateMotion" in svg
+        assert 'href="#lyr-edge-0"' in svg
+        # All three inter-band edges get particles.
+        assert svg.count("<animateMotion") == 3
+
+    def test_layered_motion_subtle_emits_no_line_edges(self) -> None:
+        svg = self._svg("layered", motion="subtle")
+        # The inter-band edges previously emitted as <line>; assert they
+        # are now <path id="lyr-edge-...">.
+        assert "<line" not in svg
+
+    def test_layered_motion_off_emits_no_animatemotion(self) -> None:
+        svg = self._svg("layered", motion="off")
+        assert "<animateMotion" not in svg
+        # But the path id is still there — only the particle is gated.
+        assert 'id="lyr-edge-0"' in svg
+
+    def test_pipeline_motion_subtle_emits_path_id_and_animatemotion(self) -> None:
+        svg = self._svg("pipeline", motion="subtle")
+        assert 'id="pipe-edge-0"' in svg
+        assert "<animateMotion" in svg
+        # Four inter-stage edges get particles.
+        assert svg.count("<animateMotion") == 4
+
+    def test_pipeline_motion_off_emits_no_animatemotion(self) -> None:
+        svg = self._svg("pipeline", motion="off")
+        assert "<animateMotion" not in svg
+        assert 'id="pipe-edge-0"' in svg
+
+    def test_pipeline_dur_is_module_constant(self) -> None:
+        from docs_mcp.generators.pattern_poster import _ANIMATE_MOTION_DUR_S
+
+        svg = self._svg("pipeline", motion="subtle")
+        assert f'dur="{_ANIMATE_MOTION_DUR_S}s"' in svg
+
+    def test_hexagonal_never_emits_animatemotion(self) -> None:
+        svg = self._svg("hexagonal", motion="subtle")
+        assert "<animateMotion" not in svg
+
+    def test_monolith_never_emits_animatemotion(self) -> None:
+        svg = self._svg("monolith", motion="subtle")
+        assert "<animateMotion" not in svg
+
+    def test_event_driven_never_emits_animatemotion(self) -> None:
+        svg = self._svg("event_driven", motion="subtle")
+        assert "<animateMotion" not in svg
+
+    def test_microservice_never_emits_animatemotion(self) -> None:
+        svg = self._svg("microservice", motion="subtle")
+        assert "<animateMotion" not in svg
+
+    def test_particles_treated_as_subtle_for_layered(self) -> None:
+        svg = self._svg("layered", motion="particles")
+        assert "<animateMotion" in svg
+
+    def test_invalid_motion_emits_no_animatemotion(self) -> None:
+        svg = self._svg("layered", motion="bogus")
+        assert "<animateMotion" not in svg
+
+    def test_generate_single_default_off_emits_no_animatemotion(self) -> None:
+        gen = ArchPatternPosterGenerator()
+        html = gen.generate_single([], _mock_result("layered", 0.9))
+        assert "<animateMotion" not in html
+
+    def test_generate_single_motion_subtle_emits_animatemotion(self) -> None:
+        gen = ArchPatternPosterGenerator()
+        html = gen.generate_single(
+            [], _mock_result("layered", 0.9), motion="subtle"
+        )
+        assert "<animateMotion" in html
+
+    def test_reduced_motion_css_contains_smil_pause_hook(self) -> None:
+        gen = ArchPatternPosterGenerator()
+        html = gen.generate_single(
+            [], _mock_result("layered", 0.9), motion="subtle"
+        )
+        # Find the @media (prefers-reduced-motion: reduce) block. The body
+        # must mention the SMIL host class so reduced-motion users see no
+        # particle.
+        idx = html.find("prefers-reduced-motion: reduce")
+        assert idx != -1
+        block_start = html.find("{", idx)
+        depth = 0
+        end = -1
+        for i in range(block_start, len(html)):
+            ch = html[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        assert end > block_start
+        block = html[block_start:end]
+        assert "anim-particle" in block
+
+    def test_motion_subtle_two_runs_produce_identical_svg(self) -> None:
+        a = self._svg("layered", motion="subtle")
+        b = self._svg("layered", motion="subtle")
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
 # DiagramGenerator integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 2 of the docs-mcp graph-motion epic ([TAP-1036](https://linear.app/tappscodingagents/issue/TAP-1036)).

- Adds `motion: "off" | "subtle" | "particles"` arg to `docs_generate_architecture` (default `"off"` to keep PDF export still by default).
- Dependency-flow SVG (circular + grid) emits each edge as `<path id="dep-edge-N">` and appends a `<circle class="anim-particle"><animateMotion ... mpath href="#dep-edge-N">` per edge.
- `_svg_layered` and `_svg_pipeline` pattern panels get the same treatment (`lyr-edge-N` / `pipe-edge-N`).
- Relationship-structural archetypes (hexagonal, monolith, event_driven, microservice) never emit animateMotion regardless of motion value — gated in `_panel_svg`.
- Animation `dur` is a module-level constant (`_ANIMATE_MOTION_DUR_S = 2.4`) in both generators — fully deterministic.
- Reduced-motion CSS hides `.anim-particle` to suppress SMIL particles for users who prefer no motion.

Closes [TAP-1038](https://linear.app/tappscodingagents/issue/TAP-1038). Independent of TAP-1039 — can land after TAP-1037 in either order relative to TAP-1039.

## Test plan

- [x] 26 new tests across `test_architecture.py` and `test_pattern_poster.py` (motion on/off × layout × archetype) all passing
- [x] Existing pattern_poster + architecture tests (73) still pass — no regressions
- [x] `uv run pytest packages/docs-mcp/tests/unit/ -m "not slow"` passes (only pre-existing CLI failures unrelated to this PR)
- [x] `uv run mypy --strict` clean for changed files (only pre-existing pattern_poster type-ignore unused-ignore)
- [x] `tapps_validate_changed` — all 5 files score 100, gate passes
- [ ] Open the rendered HTML in a browser, confirm particles trace each edge under `prefers-reduced-motion: no-preference` and disappear under `reduce`
- [ ] Print preview confirms no animateMotion artifacts (motion default-off keeps PDF identical to today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)