### PR TITLE
feat(docs-mcp): JS particle layer for motion=particles (TAP-1039)

### DIFF
--- a/packages/docs-mcp/src/docs_mcp/generators/interactive_html.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/interactive_html.py
@@ -31,6 +31,15 @@ _MOTION_DURATION_S: float = 1.2
 _MOTION_DASHARRAY: str = "4 8"
 _MOTION_DASHOFFSET_END: int = -12
 
+# Particle-layer constants for motion="particles". All values are deterministic
+# module-level constants — never derive from `Date.now()`, `Math.random()`,
+# or any wall-clock value. Particle phase is staggered by index, not random.
+_PARTICLES_PER_EDGE: int = 3
+_PARTICLE_SPEED_UNITS_PER_S: float = 60.0
+_PARTICLE_RADIUS: int = 2
+_PARTICLE_FILL: str = "#fafafa"
+_PARTICLE_CLASS: str = "tapps-particle"
+
 # Diagram-type gating: motion is only meaningful for flow-direction diagrams.
 _FLOW_DIAGRAM_TYPES: frozenset[str] = frozenset(
     {"dependency", "module_map", "sequence", "c4_container"}
@@ -161,6 +170,73 @@ document.getElementById('zoom-reset')?.addEventListener('click', () => {
 });
 """
 
+# Opt-in JS particle layer for motion="particles". Walks every Mermaid
+# `.edgePath path` element after render, calls `getTotalLength()`, then
+# spawns N=`_PARTICLES_PER_EDGE` particles per edge that advance via
+# `requestAnimationFrame`. Skipped entirely when the user prefers reduced
+# motion. A `MutationObserver` on each diagram wrapper re-spawns particles
+# when Mermaid re-renders the SVG. All speed/count values are constants.
+_PARTICLE_JS = (
+    "(function() {\n"
+    "    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {\n"
+    "        return;\n"
+    "    }\n"
+    f"    const PARTICLES_PER_EDGE = {_PARTICLES_PER_EDGE};\n"
+    f"    const PARTICLE_SPEED = {_PARTICLE_SPEED_UNITS_PER_S};\n"
+    f"    const PARTICLE_RADIUS = {_PARTICLE_RADIUS};\n"
+    f"    const PARTICLE_FILL = '{_PARTICLE_FILL}';\n"
+    f"    const PARTICLE_CLASS = '{_PARTICLE_CLASS}';\n"
+    "    const SVG_NS = 'http://www.w3.org/2000/svg';\n"
+    "    function spawnParticles(svg) {\n"
+    "        svg.querySelectorAll('.' + PARTICLE_CLASS).forEach(p => p.remove());\n"
+    "        const edges = svg.querySelectorAll('.edgePath path, .flowchart-link');\n"
+    "        const states = [];\n"
+    "        edges.forEach(path => {\n"
+    "            let length;\n"
+    "            try { length = path.getTotalLength(); } catch (e) { return; }\n"
+    "            if (!length) return;\n"
+    "            for (let i = 0; i < PARTICLES_PER_EDGE; i++) {\n"
+    "                const c = document.createElementNS(SVG_NS, 'circle');\n"
+    "                c.setAttribute('r', PARTICLE_RADIUS);\n"
+    "                c.setAttribute('fill', PARTICLE_FILL);\n"
+    "                c.classList.add(PARTICLE_CLASS);\n"
+    "                path.parentNode.appendChild(c);\n"
+    "                states.push({\n"
+    "                    circle: c,\n"
+    "                    path: path,\n"
+    "                    length: length,\n"
+    "                    phase: i / PARTICLES_PER_EDGE,\n"
+    "                });\n"
+    "            }\n"
+    "        });\n"
+    "        if (states.length === 0) return;\n"
+    "        let last = null;\n"
+    "        function step(now) {\n"
+    "            if (last === null) { last = now; }\n"
+    "            const dt = (now - last) / 1000;\n"
+    "            last = now;\n"
+    "            states.forEach(s => {\n"
+    "                s.phase = (s.phase + dt * PARTICLE_SPEED / s.length) % 1;\n"
+    "                const pt = s.path.getPointAtLength(s.phase * s.length);\n"
+    "                s.circle.setAttribute('cx', pt.x);\n"
+    "                s.circle.setAttribute('cy', pt.y);\n"
+    "            });\n"
+    "            requestAnimationFrame(step);\n"
+    "        }\n"
+    "        requestAnimationFrame(step);\n"
+    "    }\n"
+    "    document.querySelectorAll('.diagram-wrapper').forEach(wrapper => {\n"
+    "        const svg = wrapper.querySelector('svg');\n"
+    "        if (svg) { spawnParticles(svg); }\n"
+    "        const observer = new MutationObserver(() => {\n"
+    "            const newSvg = wrapper.querySelector('svg');\n"
+    "            if (newSvg) { spawnParticles(newSvg); }\n"
+    "        });\n"
+    "        observer.observe(wrapper, { childList: true, subtree: true });\n"
+    "    });\n"
+    "})();\n"
+)
+
 
 class InteractiveHtmlGenerator:
     """Generates self-contained interactive HTML with Mermaid.js diagrams.
@@ -197,11 +273,15 @@ class InteractiveHtmlGenerator:
             subtitle: Page subtitle.
             theme: Mermaid theme (default, dark, forest, neutral).
             motion: Motion intensity for edge animations.
-                ``"off"`` emits no animation CSS. ``"subtle"`` (default) adds
-                a CSS marching-ants effect on Mermaid edge paths via
-                ``stroke-dashoffset``. ``"particles"`` falls back to ``"subtle"``
-                in this generator (Phase 3 will add a JS particle layer).
-                All motion is gated by ``prefers-reduced-motion``.
+                ``"off"`` emits no animation CSS or JS. ``"subtle"`` (default)
+                adds a CSS marching-ants effect on Mermaid edge paths via
+                ``stroke-dashoffset``. ``"particles"`` keeps the marching-ants
+                CSS and additionally injects a JS particle layer that walks
+                each ``.edgePath path``, calls ``getTotalLength()``, and
+                advances ``_PARTICLES_PER_EDGE`` particles per edge via
+                ``requestAnimationFrame``. The particle setup is skipped
+                entirely when the browser reports
+                ``prefers-reduced-motion: reduce``.
             diagram_types: Optional list of canonical diagram-type identifiers
                 (e.g. ``"dependency"``, ``"class_hierarchy"``) used to gate
                 motion. When every requested type is relationship-only
@@ -222,6 +302,7 @@ class InteractiveHtmlGenerator:
             )
 
         motion_css = _resolve_motion_css(motion, diagram_types)
+        particle_js = _resolve_particle_js(motion, diagram_types)
 
         parts: list[str] = []
 
@@ -278,6 +359,12 @@ class InteractiveHtmlGenerator:
         js = _VIEWER_JS % {"mermaid_cdn": _MERMAID_CDN}
         parts.append(f'<script type="module">{js}</script>')
 
+        # Opt-in particle layer for motion="particles". Plain script (no
+        # imports) so it runs in any browser; the IIFE handles its own
+        # reduced-motion gate.
+        if particle_js:
+            parts.append(f"<script>{particle_js}</script>")
+
         parts.append("</body>")
         parts.append("</html>")
 
@@ -312,3 +399,19 @@ def _resolve_motion_css(motion: str, diagram_types: list[str] | None) -> str:
         if requested and not (requested & _FLOW_DIAGRAM_TYPES):
             return ""
     return _MOTION_CSS
+
+
+def _resolve_particle_js(motion: str, diagram_types: list[str] | None) -> str:
+    """Return the particle-layer JS when ``motion == "particles"``.
+
+    Returns ``""`` for any other motion value, or when every requested
+    diagram type is relationship-only (gating mirrors ``_resolve_motion_css``
+    so the JS never runs on a page that has no flow edges to trace).
+    """
+    if motion != "particles":
+        return ""
+    if diagram_types is not None:
+        requested = {dt.strip() for dt in diagram_types if dt.strip()}
+        if requested and not (requested & _FLOW_DIAGRAM_TYPES):
+            return ""
+    return _PARTICLE_JS

--- a/packages/docs-mcp/tests/integration/test_interactive_html_perf.py
+++ b/packages/docs-mcp/tests/integration/test_interactive_html_perf.py
@@ -1,0 +1,98 @@
+"""Performance smoke test for the interactive viewer's JS particle layer (TAP-1039).
+
+Renders a 50-edge dependency diagram with ``motion="particles"`` in headless
+Chromium via ``playwright`` and asserts that the page sustains > 30 fps for
+~5 seconds. The test is gated on ``playwright`` being importable AND on the
+Chromium browser being installed locally — otherwise it ``skip``s.
+
+Marked ``slow`` so the default test run does not pull it in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+# Skip the entire module when playwright is not installed.
+playwright = pytest.importorskip("playwright.async_api")
+
+
+_FPS_FLOOR: float = 30.0
+_SOAK_SECONDS: float = 5.0
+
+
+def _make_50_edge_diagram() -> tuple[str, list[tuple[str, str]]]:
+    """Return a (title, [(label, mermaid_content)]) tuple with 50 edges."""
+    nodes = [f"N{i}" for i in range(51)]
+    edges_md = "\n".join(f"  {nodes[i]} --> {nodes[i + 1]}" for i in range(50))
+    mermaid_src = f"graph LR\n{edges_md}\n"
+    return ("Dependency Graph", [("Dependency Graph", mermaid_src)])
+
+
+_FPS_MEASURE_JS = """
+async () => {
+    return new Promise((resolve) => {
+        let frames = 0;
+        const start = performance.now();
+        function tick() {
+            frames++;
+            const elapsed = performance.now() - start;
+            if (elapsed >= """ + str(int(_SOAK_SECONDS * 1000)) + """) {
+                resolve(frames / (elapsed / 1000));
+                return;
+            }
+            requestAnimationFrame(tick);
+        }
+        requestAnimationFrame(tick);
+    });
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_50_edge_diagram_sustains_30fps_with_particles() -> None:
+    """Headless Chromium fps smoke test for the particle layer.
+
+    Skips if Chromium is not installed locally (``playwright install``
+    has not been run). Asserts > 30 fps over a 5-second sample.
+    """
+    from playwright.async_api import async_playwright
+
+    from docs_mcp.generators.interactive_html import InteractiveHtmlGenerator
+
+    page_title, diagrams = _make_50_edge_diagram()
+    gen = InteractiveHtmlGenerator()
+    result = gen.generate(
+        diagrams,
+        title=page_title,
+        motion="particles",
+        diagram_types=["dependency"],
+    )
+
+    async with async_playwright() as pw:
+        try:
+            browser = await pw.chromium.launch(headless=True)
+        except Exception as exc:  # noqa: BLE001
+            pytest.skip(f"Chromium not installed for playwright: {exc}")
+
+        try:
+            context = await browser.new_context(
+                viewport={"width": 1280, "height": 800},
+                reduced_motion="no-preference",
+            )
+            page = await context.new_page()
+            await page.set_content(result.content, wait_until="networkidle")
+            # Give Mermaid a moment to render the SVG.
+            await page.wait_for_selector(".diagram-wrapper svg", timeout=15_000)
+            # Let the particle layer settle.
+            await asyncio.sleep(0.5)
+            fps = await page.evaluate(_FPS_MEASURE_JS)
+        finally:
+            await browser.close()
+
+    assert isinstance(fps, (int, float))
+    assert fps > _FPS_FLOOR, f"FPS {fps:.1f} below floor {_FPS_FLOOR}"

--- a/packages/docs-mcp/tests/unit/test_interactive_html.py
+++ b/packages/docs-mcp/tests/unit/test_interactive_html.py
@@ -1,10 +1,11 @@
-"""Tests for the interactive HTML viewer's motion layer (TAP-1037).
+"""Tests for the interactive HTML viewer's motion layer (TAP-1037 + TAP-1039).
 
 Covers the four ``motion`` values (``off``/``subtle``/``particles``/invalid)
 crossed with the two diagram-type sets: flow-direction (dependency,
 module_map, sequence, c4_container) and relationship-only (class_hierarchy,
 er_diagram, c4_context). Also asserts that the ``@media print`` block
-disables animations and that ``prefers-reduced-motion`` gates motion CSS.
+disables animations, ``prefers-reduced-motion`` gates motion CSS, and (for
+TAP-1039) the JS particle layer is present only for ``motion="particles"``.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ from __future__ import annotations
 from docs_mcp.generators.interactive_html import (
     _MOTION_DASHARRAY,
     _MOTION_DURATION_S,
+    _PARTICLE_SPEED_UNITS_PER_S,
+    _PARTICLES_PER_EDGE,
     InteractiveHtmlGenerator,
 )
 
@@ -19,10 +22,21 @@ _FLOW_TYPES = ["dependency", "module_map", "sequence", "c4_container"]
 _RELATIONSHIP_ONLY_TYPES = ["class_hierarchy", "er_diagram", "c4_context"]
 _SAMPLE_DIAGRAM = [("Test Diagram", "graph TD\n  A --> B")]
 _KEYFRAMES_NAME = "tapps-marching-ants"
+_PARTICLE_SENTINEL = "tapps-particle"
 
 
 def _animation_present(html: str) -> bool:
     return _KEYFRAMES_NAME in html
+
+
+def _particle_js_present(html: str) -> bool:
+    """Particle JS block is uniquely identified by its module-level constants
+    being inlined into the script body."""
+    return (
+        _PARTICLE_SENTINEL in html
+        and "getPointAtLength" in html
+        and "requestAnimationFrame" in html
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +225,138 @@ class TestMotionDeterminism:
         b = gen.generate(
             _SAMPLE_DIAGRAM,
             motion="subtle",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert a.content == b.content
+
+
+# ---------------------------------------------------------------------------
+# Particle JS layer (TAP-1039) — opt-in for motion="particles"
+# ---------------------------------------------------------------------------
+
+
+class TestParticleJsLayer:
+    """Particle JS is present only for ``motion="particles"``."""
+
+    def test_particles_emits_particle_js_for_flow_types(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert _particle_js_present(result.content)
+        # CSS marching-ants is also still emitted (particles is additive).
+        assert _animation_present(result.content)
+
+    def test_subtle_emits_no_particle_js(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="subtle",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert not _particle_js_present(result.content)
+
+    def test_off_emits_no_particle_js(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="off",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert not _particle_js_present(result.content)
+
+    def test_invalid_motion_emits_no_particle_js(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="bogus",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert not _particle_js_present(result.content)
+
+    def test_particles_suppressed_for_relationship_only_types(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_RELATIONSHIP_ONLY_TYPES,
+        )
+        # No CSS animation AND no particle JS for relationship-only diagrams.
+        assert not _animation_present(result.content)
+        assert not _particle_js_present(result.content)
+
+    def test_particles_per_edge_constant_inlined(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert _PARTICLES_PER_EDGE == 3
+        assert f"const PARTICLES_PER_EDGE = {_PARTICLES_PER_EDGE};" in result.content
+
+    def test_particle_speed_constant_inlined(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        assert f"const PARTICLE_SPEED = {_PARTICLE_SPEED_UNITS_PER_S};" in result.content
+
+    def test_particle_js_skips_under_reduced_motion(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        # The IIFE early-returns if matchMedia('(prefers-reduced-motion: reduce)') matches.
+        assert "prefers-reduced-motion: reduce" in result.content
+        assert "matchMedia" in result.content
+
+    def test_particle_js_uses_mutation_observer(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        # Mermaid re-render hook: MutationObserver on each .diagram-wrapper.
+        assert "MutationObserver" in result.content
+        assert ".diagram-wrapper" in result.content
+
+    def test_particle_js_no_random_or_clock_seeds(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        result = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        # Determinism guard: no Math.random / Date.now / performance.now()
+        # used as a seed in the particle JS body. (They may legitimately
+        # appear elsewhere in the page; we look only inside the IIFE.)
+        idx = result.content.find("(function() {")
+        assert idx != -1
+        end = result.content.find("})();", idx)
+        assert end != -1
+        body = result.content[idx:end]
+        assert "Math.random" not in body
+        assert "Date.now" not in body
+        assert "performance.now" not in body
+
+    def test_particles_two_runs_produce_identical_html(self) -> None:
+        gen = InteractiveHtmlGenerator()
+        a = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
+            diagram_types=_FLOW_TYPES,
+        )
+        b = gen.generate(
+            _SAMPLE_DIAGRAM,
+            motion="particles",
             diagram_types=_FLOW_TYPES,
         )
         assert a.content == b.content


### PR DESCRIPTION
## Summary

Phase 3 of the docs-mcp graph-motion epic ([TAP-1036](https://linear.app/tappscodingagents/issue/TAP-1036)).

Replaces auto-closed [#130](https://github.com/wtthornton/TappsMCP/pull/130) (the original PR was auto-closed when its TAP-1037 base branch was deleted on merge). This PR is now rebased onto master.

- Adds an opt-in JavaScript particle layer to the interactive HTML viewer. When `motion="particles"`, an IIFE walks every Mermaid `.edgePath path`, calls `getTotalLength()`, spawns N=3 particles per edge, and advances them via `requestAnimationFrame` using `getPointAtLength(phase * len)`.
- A `MutationObserver` on each `.diagram-wrapper` re-spawns particles whenever Mermaid re-renders the SVG.
- Setup is skipped entirely (no RAF loop, no DOM nodes) when `window.matchMedia('(prefers-reduced-motion: reduce)').matches`.
- All counts / speeds are module-level constants — no `Math.random()` / `Date.now()` / `performance.now()` seeds.
- Adds a headless-Chromium fps smoke test (`@pytest.mark.slow`, auto-skips when `playwright` is unavailable).

Closes [TAP-1039](https://linear.app/tappscodingagents/issue/TAP-1039).

## Test plan

- [x] 11 new unit tests for particle JS presence/absence × all four motion values
- [x] Existing TAP-1037 unit tests still pass
- [x] `mypy --strict` clean for `interactive_html.py`
- [x] `tapps_validate_changed` — all 3 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)