### PR TITLE
fix(docs-mcp): add sh/bash/zsh to file-anchor extension allowlist

### DIFF
--- a/packages/docs-mcp/src/docs_mcp/linters/linear_issue.py
+++ b/packages/docs-mcp/src/docs_mcp/linters/linear_issue.py
@@ -46,8 +46,12 @@ _AUTOLINK_MANGLE_RE = re.compile(r"\[([^\]]+)\]\(<https?://([^>\s]+)>\)")
 _UUID_WRAPPED_REF_RE = re.compile(r'<issue\s+id="[^"]+"\s*>\s*(TAP-\d+)\s*</issue>')
 
 # Regex: file anchor — `path/to/file.ext:LINE` or `:LINE-LINE`.
+# Extension allowlist must include shell scripts (sh/bash/zsh) — without
+# them, every `## Where` anchor pointing at a shell file fails with
+# missing-file-anchor regardless of path shape (with or without a directory
+# component, with or without a `./` prefix). Tracked: TAP-1420.
 _FILE_ANCHOR_RE = re.compile(
-    r"[\w./\\-]+\.(?:py|pyi|ts|tsx|js|jsx|md|yaml|yml|toml|json|rs|go|java|rb|cpp|c|h):\d+(?:-\d+)?"
+    r"[\w./\\-]+\.(?:py|pyi|ts|tsx|js|jsx|md|yaml|yml|toml|json|rs|go|java|rb|cpp|c|h|sh|bash|zsh):\d+(?:-\d+)?"
 )
 
 # Regex: fenced code block opening fence (capturing position only).

--- a/packages/docs-mcp/tests/unit/test_linear_issue_linter.py
+++ b/packages/docs-mcp/tests/unit/test_linear_issue_linter.py
@@ -230,6 +230,32 @@ class TestMissingFileAnchor:
         rules = [f.rule for f in result.findings]
         assert RULE_MISSING_FILE_ANCHOR not in rules
 
+    def test_shell_script_anchor_passes(self) -> None:
+        # TAP-1420: shell-script extensions were missing from the regex
+        # allowlist, so every `## Where` anchor pointing at a .sh/.bash/.zsh
+        # file failed with missing-file-anchor regardless of path shape.
+        # Cover all three extensions and both with-dir / bare-filename paths.
+        for anchor in (
+            "lib/foo.sh:1-50",
+            "install.sh:42",
+            "scripts/setup.bash:10-20",
+            "tools/deploy.zsh:1",
+        ):
+            result = lint_issue(
+                title="x",
+                description=(
+                    f"## What\nthing\n## Where\n`{anchor}`\n"
+                    "## Acceptance\n- [ ] done\n"
+                ),
+                priority=3,
+                estimate=1.0,
+            )
+            rules = [f.rule for f in result.findings]
+            assert RULE_MISSING_FILE_ANCHOR not in rules, (
+                f"shell anchor {anchor!r} should satisfy file-anchor rule, "
+                f"got findings={rules}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Rule: missing-acceptance / acceptance-empty


### PR DESCRIPTION
## Summary

- `_FILE_ANCHOR_RE` in `packages/docs-mcp/src/docs_mcp/linters/linear_issue.py` omitted shell-script extensions, causing every `## Where` anchor pointing at a `.sh` / `.bash` / `.zsh` file to fail validation with `missing-file-anchor` regardless of path shape.
- One-line regex fix adds `sh|bash|zsh` to the extension alternation.
- Adds a parametric test (`test_shell_script_anchor_passes`) covering all three extensions across with-dir and bare-filename paths.

## Reproducer (pre-fix)

```
FAIL: ralph_upgrade_project.sh:758-770
FAIL: ./ralph_upgrade_project.sh:758-770
FAIL: lib/circuit_breaker.sh:1-100      # real dir, still fails — .sh not in list
FAIL: foo/bar.bash:10-20
PASS: .claude/rules/linear-standards.md:1-80    # .md is in the list
```

## Test plan

- [x] `pytest packages/docs-mcp/tests/unit/test_linear_issue_linter.py` — 27 passing (was 26, +1 new).

Refs TAP-1420 in TappsCodingAgents/ralph-claude-code (filed against ralph-claude-code as the calling project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)