### PR TITLE
chore(ralph): sync project to Ralph 2.21.4 templates

### DIFF
--- a/.claude/agents/ralph-architect.md
+++ b/.claude/agents/ralph-architect.md
@@ -20,7 +20,7 @@ disallowedTools:
   - Bash(git rm *)
   - Bash(git reset --hard *)
   - Bash(rm -rf *)
-model: claude-opus-4-7
+model: claude-opus-4-8
 permissionMode: bypassPermissions
 maxTurns: 50
 memory: project

--- a/.claude/agents/ralph-coordinator.md
+++ b/.claude/agents/ralph-coordinator.md
@@ -50,13 +50,46 @@ Run in one of three modes determined by your task input:
 **MODE=brief** (default — invoked at task start):
 
 1. Read the current task description (Linear issue body, fix_plan.md entry,
-   or PROMPT.md context) from your input.
+   or PROMPT.md context) from your input. In OAuth-via-MCP Linear mode the
+   harness cannot probe Linear shell-side, so `TASK_INPUT:` is empty every
+   loop. Read `RALPH_LINEAR_TEAM=` and `RALPH_LINEAR_PROJECT=` from your
+   input header — those are the authoritative values to pass to every
+   Linear MCP call below. Never invent a team name from the repo directory
+   or the project name.
+
+   **Empty `TASK_INPUT:` in Linear mode — mandatory fresh probe.** If
+   `TASK_SOURCE=linear` and `TASK_INPUT:` is empty (no Linear ID, no
+   summary), you MUST call `mcp__plugin_linear_linear__list_issues` with
+   the team/project from your input header for `state="started"`, then
+   `state="unstarted"`, then `state="backlog"` (limit=50,
+   projection=compact). Pick the highest-priority open issue (Urgent <
+   High < Normal < Low < None; ties broken by `updatedAt` descending) and
+   treat it as your TASK_INPUT — write the brief around that issue with
+   its real `task_id`. Only if all three states return zero issues for
+   the configured team/project may you conclude the backlog is empty
+   (see step 3's hard rule on EXIT_SIGNAL evidence).
 2. Call `mcp__tapps-brain__brain_recall` with focused queries to surface
-   prior learnings (see Keyword Strategy below).
+   prior learnings (see Keyword Strategy below). **Brain memory is NOT
+   sufficient evidence for backlog emptiness.** A `brain_recall` result
+   tagged `failure` that claims "backlog empty" is a hint to confirm via
+   a fresh `list_issues` probe — never a substitute for the probe.
 3. **Write `.ralph/brief.json` using the Write tool — this is REQUIRED, not
    optional.** Writing the file is the whole point of MODE=brief; returning
    a summary without writing the file is a hard failure that trips the
    harness's `coordinator: brief missing or invalid` regression detector.
+
+   **Hard rule on EXIT_SIGNAL acceptance criteria.** You may write
+   `acceptance_criteria` that mention `EXIT_SIGNAL: true` ONLY when the
+   brief's body cites a fresh `list_issues` probe from THIS coordinator
+   invocation that covered all three open states (`started`, `unstarted`,
+   `backlog`) and returned zero issues for the team/project from your
+   input header. A `no-task` brief that pre-emits EXIT_SIGNAL based on a
+   `brain_recall` result, a stale snapshot, or a prior session's
+   conclusion is a contract violation — the worker will trust it and
+   exit the campaign on a non-empty backlog (the AgentForge 2026-05-26
+   incident: TAP-2493 follow-up). When in doubt, write a
+   `task_id: "no-task"` brief WITHOUT EXIT_SIGNAL in `acceptance_criteria`
+   and let the worker re-probe.
 
    The Write tool call replaces any existing brief atomically at the Claude
    Code tool layer (equivalent to the tmp-path + rename pattern used by

--- a/.claude/agents/ralph-reviewer.md
+++ b/.claude/agents/ralph-reviewer.md
@@ -7,9 +7,9 @@ tools:
   - Read
   - Glob
   - Grep
-model: sonnet
+model: claude-opus-4-8
 maxTurns: 10
-effort: medium
+effort: high
 ---
 
 You are a code reviewer analyzing changes made by Ralph. Review for:

--- a/.claude/agents/ralph-tester.md
+++ b/.claude/agents/ralph-tester.md
@@ -9,7 +9,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: sonnet
+model: claude-opus-4-8
 maxTurns: 15
 isolation: worktree
 effort: low

--- a/.ralph/PROMPT.md
+++ b/.ralph/PROMPT.md
@@ -42,6 +42,19 @@ about — fill it in for your project.
 - Pipes (`|`) and `&&` between **read-only** commands (`git status`,
   `grep`, `find`) are fine and even encouraged for parallel observation.
 
+## Editing Guidelines
+- **Read before Edit.** Before your first Edit/Write to a file in a loop,
+  issue a `Read` on that file. The Edit tool rejects writes to a file it
+  hasn't seen this session (`File has not been read yet. Read it first`),
+  and a blind write can clobber state you didn't know was there.
+- **Guard shared/busy directories.** Before editing under a directory that
+  other in-flight tickets are known to touch, run `git status`. If unstaged
+  changes don't trace to your current ticket, emit `STATUS: BLOCKED` naming
+  the suspected conflicting ticket and pivot to a different task instead of
+  editing into a conflict. The busy-directory list is per-project and set
+  via `.ralphrc` (`RALPH_BUSY_DIRS`, space- or colon-separated; default
+  empty — no directories are treated as busy).
+
 ## Protected Files (DO NOT MODIFY)
 These files are Ralph's control surface. Never delete, move, rename, or
 overwrite them:

--- a/.ralph/hooks/on-stop.sh
+++ b/.ralph/hooks/on-stop.sh
@@ -1000,11 +1000,26 @@ if [[ -z "$_status_block" ]]; then
   # on tasks_done/files_modified at line 859 below. Without this guard,
   # productive timeouts trip no_status_block_3x after 3 long-running loops
   # and halt the campaign mid-flight.
-  if [[ "$files_modified" -ge 1 || "$tasks_done" -ge 1 ]]; then
+  #
+  # TAP-2636: a loop that completed a story by squash-merging a PR (or
+  # otherwise advancing main) modifies zero files in the working tree and
+  # may emit no RALPH_STATUS footer — but HEAD moved. Compare against the
+  # loop-start SHA recorded by execute_claude_code (.loop_start_sha) so a
+  # demonstrably productive merge loop also resets the counter instead of
+  # tipping toward a sticky halt.
+  _commit_landed=0
+  if [[ -s "$RALPH_DIR/.loop_start_sha" ]] && command -v git >/dev/null 2>&1; then
+    _loop_start_sha=$(tr -cd '0-9a-fA-F' < "$RALPH_DIR/.loop_start_sha" 2>/dev/null || echo "")
+    _head_now=$(git rev-parse HEAD 2>/dev/null || echo "")
+    if [[ -n "$_loop_start_sha" && -n "$_head_now" && "$_loop_start_sha" != "$_head_now" ]]; then
+      _commit_landed=1
+    fi
+  fi
+  if [[ "$files_modified" -ge 1 || "$tasks_done" -ge 1 || "$_commit_landed" -eq 1 ]]; then
     rm -f "$_nsb_count_file" 2>/dev/null || true
     _nsb_log_diag "productivity-reset"
     if [[ -f "$_ralph_log" ]]; then
-      echo "[$_ts] [INFO] on-stop: no RALPH_STATUS block but loop was productive (files=$files_modified tasks=$tasks_done) — counter reset (TAP-1899)" >> "$_ralph_log"
+      echo "[$_ts] [INFO] on-stop: no RALPH_STATUS block but loop was productive (files=$files_modified tasks=$tasks_done commit_landed=$_commit_landed) — counter reset (TAP-1899/TAP-2636)" >> "$_ralph_log"
     fi
   else
     _nsb_prev=0

--- a/.ralph/hooks/validate-command.sh
+++ b/.ralph/hooks/validate-command.sh
@@ -114,16 +114,23 @@ if [[ "$CMD0" == "git" ]]; then
             for arg in "${ARGV[@]:2}"; do
                 case "$arg" in
                     main|master) block "direct push to ${arg} forbidden (R0). Use a feature branch + gh pr merge --squash" ;;
-                    *:main|*:master|HEAD:main|HEAD:master) block "direct push to refs/heads/${arg##*:} forbidden (R0). Use a feature branch + gh pr merge --squash" ;;
+                    *:main|*:master|HEAD:main|HEAD:master|*:refs/heads/main|*:refs/heads/master) block "direct push to refs/heads/${arg##*:} forbidden (R0). Use a feature branch + gh pr merge --squash" ;;
                 esac
             done
         fi
     fi
 
-    # `git reset --hard`, `git clean -f*`, `git rm`
-    case "$REST" in
-        *" clean "*|*" rm "*|*" reset --hard"*|*" reset --hard "*)
-            block "destructive git subcommand" ;;
+    # `git reset --hard`, `git clean -f*`, `git rm`. Anchor to the subcommand
+    # position (ARGV[1]) — the prior substring scan over the whole command
+    # matched these words inside commit messages (e.g.
+    # `git commit -m "refactor: clean up"` was wrongly blocked).
+    case "${ARGV[1]:-}" in
+        clean|rm) block "destructive git subcommand (${ARGV[1]})" ;;
+        reset)
+            for arg in "${ARGV[@]:2}"; do
+                [[ "$arg" == "--hard" ]] && block "destructive git reset --hard"
+            done
+            ;;
     esac
 fi
 
@@ -220,6 +227,16 @@ _is_protected_path() {
     local p="$1"
     p="${p%\"}"; p="${p#\"}"; p="${p%\'}"; p="${p#\'}"
     case "$p" in
+        # Carve-out FIRST (TAP-2599): Ralph self-manages its transient
+        # task-selection caches under .ralph/. The ralph-workflow skill
+        # (step 0) tells the agent to `rm -f .ralph/.linear_next_issue`
+        # after honoring a locality hint, and the optimizer rewrites it
+        # every session. Blanket-protecting it forced a cancelled tool
+        # call every selection loop. These are ephemeral hints, never
+        # durable state — durable files (status.json, fix_plan.md,
+        # .circuit_breaker_state, .harness_halt_reason) stay protected by
+        # the blanket arm below.
+        "$RALPH_DIR"/.linear_next*|.ralph/.linear_next*|./.ralph/.linear_next*) return 1 ;;
         "$RALPH_DIR"|"$RALPH_DIR"/*) return 0 ;;
         .ralph|.ralph/*|./.ralph/*) return 0 ;;
         "$_proj_dir"/.ralphrc) return 0 ;;
@@ -262,25 +279,31 @@ esac
 # TAP-2344: anchor .ralph/ redirects to the project prefix so the global
 # `~/.ralph/` install isn't caught. .claude/ remains globally blocked
 # (see _is_protected_path above for the rationale).
-case "$NORM" in
-    *" > $RALPH_DIR/"*|*" >> $RALPH_DIR/"*) block "redirect into project .ralph/" ;;
-    *" > .ralph/"*|*" >> .ralph/"*|*" > ./.ralph/"*|*" >> ./.ralph/"*)
+#
+# Canonicalize every redirect operator (`>`, `>>`, `>|`, fd-numbered `1>`,
+# `&>`, and no-space forms like `x>.ralph/y`) to a single ` > ` token so the
+# space-anchored patterns below can't be bypassed. Without this, `echo x
+# >.ralph/status.json` (no space) and `1>`/`&>`/`>|` variants slipped past.
+RNORM=$(printf '%s' "$NORM" | sed -E 's/[0-9]*&?>{1,2}[|]?/ > /g' | tr -s ' ')
+case "$RNORM" in
+    *" > $RALPH_DIR/"*) block "redirect into project .ralph/" ;;
+    *" > .ralph/"*|*" > ./.ralph/"*)
         block "redirect into .ralph/" ;;
 esac
 # TAP-2345 (F4): allow redirects into .claude/rules/, .claude/skills/,
 # .claude/commands/ — those are routine agent surface area and the
 # Edit-side hook already allows them. Settings, agents/, hooks/ stay
 # blocked. The carve-out cases must precede the catch-all so they win.
-case "$NORM" in
-    *" > .claude/rules/"*|*" >> .claude/rules/"*|*" > ./.claude/rules/"*|*" >> ./.claude/rules/"*) ;;
-    *" > .claude/skills/"*|*" >> .claude/skills/"*|*" > ./.claude/skills/"*|*" >> ./.claude/skills/"*) ;;
-    *" > .claude/commands/"*|*" >> .claude/commands/"*|*" > ./.claude/commands/"*|*" >> ./.claude/commands/"*) ;;
-    *" > .claude/"*|*" >> .claude/"*|*" > ./.claude/"*|*" >> ./.claude/"*)
+case "$RNORM" in
+    *" > .claude/rules/"*|*" > ./.claude/rules/"*) ;;
+    *" > .claude/skills/"*|*" > ./.claude/skills/"*) ;;
+    *" > .claude/commands/"*|*" > ./.claude/commands/"*) ;;
+    *" > .claude/"*|*" > ./.claude/"*)
         block "redirect into .claude/" ;;
 esac
-case "$NORM" in
-    *" > $_proj_dir/.ralphrc"*|*" >> $_proj_dir/.ralphrc"*) block "redirect into project .ralphrc" ;;
-    *" > .ralphrc"*|*" >> .ralphrc"*) block "redirect into .ralphrc" ;;
+case "$RNORM" in
+    *" > $_proj_dir/.ralphrc"*) block "redirect into project .ralphrc" ;;
+    *" > .ralphrc"*) block "redirect into .ralphrc" ;;
 esac
 
 exit 0

--- a/.ralphrc
+++ b/.ralphrc
@@ -343,3 +343,17 @@ RALPH_PUSH_EVERY_LOOP=true
 # After each successful loop iteration that produced commits, run `git push`
 # =============================================================================
 # CONTEXT MANAGEMENT (Phase 14)
+# =============================================================================
+# EPIC-BOUNDARY DESLOP (ralph-workflow skill step 7.5)
+# =============================================================================
+# At each epic boundary, after QA is green, the ralph-workflow skill tells
+# Claude to run the `simplify` skill on the files changed in the epic
+# (removes dead code, unused imports, redundant comments, speculative error
+# handling — never adds). This is an agent-honored flag: it is exported to
+# the Claude CLI subprocess via `set -a`, and the skill checks it. When true,
+# the deslop pass is skipped.
+RALPH_NO_DESLOP=false
+# =============================================================================
+# At each epic boundary, after QA is green, the ralph-workflow skill tells
+# =============================================================================
+# Linear cache-locality optimizer (TAP-589 LINOPT epic)


### PR DESCRIPTION
## What

Sync the `.ralph/` tree to the current global Ralph templates (**ralph 2.21.4**) via `ralph-upgrade-project --yes`. Resolves the hook drift that `ralph-doctor` was flagging.

## Why

`ralph-doctor` reported two WARN lines before this change:

- `on-stop.sh differs from template`
- `validate-command.sh differs from template`

Global Ralph was already at 2.21.4, but the project's `.ralph/` tree had drifted from the refreshed templates.

## Changes (8 files, all CLI-generated — no hand edits)

- **hooks**: `on-stop.sh`, `validate-command.sh` re-synced from templates
- **agents**: `ralph-{architect,coordinator,reviewer,tester}.md` (task_source=linear)
- **.ralphrc**: appended `EPIC-BOUNDARY DESLOP` section (ralph-workflow skill step 7.5)
- **.ralph/PROMPT.md**: refreshed RALPH-managed section

## Verification

`ralph-doctor` after the upgrade: **all OK, 0 WARN/FAIL** — "all hooks match templates", TAP-1530/TAP-1531 guards intact, linear-mode templates aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)