### PR TITLE
feat: TAP-2000/1960 checklist brain events, CLI memory, metrics dual-write

### DIFF
--- a/.claude/hooks/tapps-user-prompt-submit.sh
+++ b/.claude/hooks/tapps-user-prompt-submit.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # tapps-mcp-hook-version: 3.12.11
-# TappsMCP UserPromptSubmit hook (TAP-975)
+# TappsMCP UserPromptSubmit hook (TAP-975 / TAP-2000)
 # Re-surfaces pipeline state per user turn so long sessions don't drift.
-# Reads two sidecars:
+# Reads one sidecar:
 #   .tapps-mcp/.session-start-marker   — Unix epoch of last tapps_session_start
-#   .tapps-mcp/.checklist-state.json   — last tapps_checklist outcome
-# Stays SILENT when session_start was within 30 min AND no open checklist.
+# Checklist outcomes live in brain (checklist_outcome events via TAP-2000);
+# call tapps_checklist or /tapps-finish-task — bash hooks cannot query brain.
+# Stays SILENT when session_start was within 30 min.
 INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 SS_MARKER="$PROJECT_DIR/.tapps-mcp/.session-start-marker"
-CL_STATE="$PROJECT_DIR/.tapps-mcp/.checklist-state.json"
 NOW=$(date +%s)
 NEED_SS=0
 if [ ! -f "$SS_MARKER" ]; then
@@ -25,33 +25,11 @@ else
     NEED_SS=1
   fi
 fi
-OPEN_CHECKLIST=""
-if [ -f "$CL_STATE" ]; then
-  PYBIN=$(command -v python3 2>/dev/null || command -v python 2>/dev/null)
-  OPEN_CHECKLIST=$("$PYBIN" -c "
-import json
-try:
-    d=json.load(open('$CL_STATE'))
-    if d.get('complete') is False:
-        m=d.get('missing_required',[])
-        if m:
-            print('open: ' + ', '.join(m[:3]))
-        else:
-            print('open')
-except Exception:
-    pass
-" 2>/dev/null)
-fi
-if [ "$NEED_SS" -eq 0 ] && [ -z "$OPEN_CHECKLIST" ]; then
+if [ "$NEED_SS" -eq 0 ]; then
   exit 0
 fi
 {
   echo "[TappsMCP] Pipeline-state reminder:"
-  if [ "$NEED_SS" -eq 1 ]; then
-    echo "  - tapps_session_start was not called within the last 30 min — call it before edits to refresh project context."
-  fi
-  if [ -n "$OPEN_CHECKLIST" ]; then
-    echo "  - tapps_checklist last reported incomplete ($OPEN_CHECKLIST) — run /tapps-finish-task or address the missing tools."
-  fi
+  echo "  - tapps_session_start was not called within the last 30 min — call it before edits to refresh project context."
 } >&2
 exit 0

--- a/docs/MEMORY_REFERENCE.md
+++ b/docs/MEMORY_REFERENCE.md
@@ -193,6 +193,16 @@ so the feedback flywheel receives explicit signals.
 
 See [AGENTS.md](../AGENTS.md#brain-health-diagnostics-brain_bridge_health) for the agent-facing summary of the same block.
 
+## CLI memory commands (TAP-1960)
+
+Operator workflows for import/export/reseed live on the CLI — not the MCP tool surface:
+
+| Command | Description |
+|---------|-------------|
+| `uv run tapps-mcp memory import-file --file <path> [--overwrite]` | Import memories from JSON |
+| `uv run tapps-mcp memory export-file --file <path> [--format json\|markdown] [--tier …] [--scope …] [--min-confidence 0.8]` | Export with tier/scope/format filters |
+| `uv run tapps-mcp memory reseed --confirm` | Re-seed auto-seeded entries from the detected project profile |
+
 ## Cross-session chat transfer
 
 For moving work between fresh chats (not just compaction recovery):

--- a/packages/tapps-core/src/tapps_core/metrics/brain_telemetry.py
+++ b/packages/tapps-core/src/tapps_core/metrics/brain_telemetry.py
@@ -1,0 +1,73 @@
+"""Best-effort brain KG events for metrics collectors (TAP-1997 phase-1).
+
+Dual-write: local JSON/JSONL metrics remain the read path until brain event
+payload reads land (see ``docs/handoff/BRAIN-wave2-capabilities.md``). This
+module adds fire-and-forget ``quality_metric`` events without blocking callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from tapps_core.metrics.execution_metrics import ToolCallMetric
+
+logger = structlog.get_logger(__name__)
+
+
+def emit_quality_metric_event(metric: ToolCallMetric) -> None:
+    """Emit a ``quality_metric`` brain event for a recorded tool call (best-effort)."""
+
+    async def _emit() -> None:
+        try:
+            from tapps_core.brain_bridge import create_brain_bridge
+            from tapps_core.config.settings import load_settings
+
+            bridge = create_brain_bridge(load_settings())
+            if bridge is None or not hasattr(bridge, "record_kg_event"):
+                return
+
+            entities: list[dict[str, str]] = [
+                {"type": "tool", "id": metric.tool_name},
+            ]
+            edges: list[dict[str, str]] = []
+            if metric.file_path and metric.score is not None:
+                file_id = metric.file_path
+                score_id = f"{metric.score:.1f}"
+                entities.append({"type": "file", "id": file_id})
+                edges.append(
+                    {"src": file_id, "predicate": "scored", "dst": score_id},
+                )
+
+            payload_data: dict[str, Any] = {
+                "call_id": metric.call_id,
+                "status": metric.status,
+                "duration_ms": metric.duration_ms,
+                "gate_passed": metric.gate_passed,
+                "score": metric.score,
+                "degraded": metric.degraded,
+                "session_id": metric.session_id,
+            }
+            if metric.error_code:
+                payload_data["error_code"] = metric.error_code
+
+            await bridge.record_kg_event(  # type: ignore[union-attr]
+                event_type="quality_metric",
+                entities=entities,
+                edges=edges,
+                payload_data=payload_data,
+            )
+        except Exception:
+            logger.debug("quality_metric_brain_emit_failed", exc_info=True)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    try:
+        loop.create_task(_emit())  # noqa: RUF006
+    except Exception:
+        pass

--- a/packages/tapps-core/src/tapps_core/metrics/execution_metrics.py
+++ b/packages/tapps-core/src/tapps_core/metrics/execution_metrics.py
@@ -97,6 +97,9 @@ class ToolCallMetricsCollector:
         with self._write_lock:
             self._buffer.append(metric)
             self._append_to_file(metric)
+        from tapps_core.metrics.brain_telemetry import emit_quality_metric_event
+
+        emit_quality_metric_event(metric)
 
     def record(
         self,

--- a/packages/tapps-core/tests/unit/test_execution_metrics.py
+++ b/packages/tapps-core/tests/unit/test_execution_metrics.py
@@ -1,6 +1,8 @@
 """Tests for execution metrics collector."""
 
+import asyncio
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -177,3 +179,32 @@ class TestToolCallMetricsCollector:
 
         summary = collector.get_summary()
         assert summary.p95_duration_ms > 0
+
+
+class TestBrainTelemetryDualWrite:
+    @pytest.mark.asyncio
+    async def test_record_call_emits_quality_metric_when_loop_running(
+        self, collector: ToolCallMetricsCollector
+    ) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.record_kg_event = AsyncMock(return_value={"recorded": True})
+        metric = ToolCallMetric(
+            call_id="abc",
+            tool_name="tapps_score_file",
+            status="success",
+            duration_ms=12.0,
+            started_at="2025-01-01T00:00:00+00:00",
+            completed_at="2025-01-01T00:00:00.012+00:00",
+            file_path="/tmp/x.py",
+            score=88.0,
+        )
+        with patch(
+            "tapps_core.brain_bridge.create_brain_bridge",
+            return_value=mock_bridge,
+        ):
+            collector.record_call(metric)
+            await asyncio.sleep(0)
+        mock_bridge.record_kg_event.assert_awaited_once()
+        kwargs = mock_bridge.record_kg_event.await_args.kwargs
+        assert kwargs["event_type"] == "quality_metric"
+        assert kwargs["payload_data"]["score"] == 88.0

--- a/packages/tapps-mcp/src/tapps_mcp/cli.py
+++ b/packages/tapps-mcp/src/tapps_mcp/cli.py
@@ -891,6 +891,7 @@ def memory_import(file_path: str, overwrite: bool) -> None:
 
     from tapps_brain.io import import_memories
     from tapps_brain.store import MemoryStore
+
     from tapps_core.security.path_validator import PathValidator
 
     root = _get_project_root()
@@ -913,22 +914,95 @@ def memory_import(file_path: str, overwrite: bool) -> None:
     "file_path",
     required=True,
     type=click.Path(),
-    help="Output JSON file path.",
+    help="Output file path (.json or .md).",
 )
-def memory_export(file_path: str) -> None:
-    """Export memories to a JSON file."""
+@click.option(
+    "--format",
+    "export_format",
+    type=click.Choice(["json", "markdown"]),
+    default="json",
+    show_default=True,
+    help="Export format.",
+)
+@click.option(
+    "--tier",
+    type=click.Choice(["architectural", "pattern", "procedural", "context"]),
+    default=None,
+    help="Filter by memory tier.",
+)
+@click.option(
+    "--scope",
+    type=click.Choice(["project", "branch", "session", "shared"]),
+    default=None,
+    help="Filter by memory scope.",
+)
+@click.option(
+    "--min-confidence",
+    type=float,
+    default=-1.0,
+    help="Minimum confidence threshold (0.0-1.0). Default: no filter.",
+)
+def memory_export(
+    file_path: str,
+    export_format: str,
+    tier: str | None,
+    scope: str | None,
+    min_confidence: float,
+) -> None:
+    """Export memories to a JSON or Markdown file."""
     from pathlib import Path
 
     from tapps_brain.io import export_memories
     from tapps_brain.store import MemoryStore
+
     from tapps_core.security.path_validator import PathValidator
 
     root = _get_project_root()
     store = MemoryStore(root, store_dir=".tapps-mcp")
     validator = PathValidator(root)
     try:
-        result = export_memories(store, Path(file_path), validator)
+        result = export_memories(
+            store,
+            Path(file_path),
+            validator,
+            tier=tier,
+            scope=scope,
+            min_confidence=min_confidence if min_confidence >= 0 else None,
+            export_format=export_format,
+        )
         click.echo(f"Exported {result['exported_count']} memories to {result['file_path']}")
+    finally:
+        store.close()
+
+
+@memory.command("reseed")
+@click.option(
+    "--confirm",
+    is_flag=True,
+    required=True,
+    help="Confirm re-seeding from the detected project profile.",
+)
+def memory_reseed(confirm: bool) -> None:
+    """Re-seed memories from the project profile (auto-seeded entries only)."""
+    if not confirm:
+        raise SystemExit("Pass --confirm to re-seed memories.")
+    from tapps_brain.seeding import reseed_from_profile
+    from tapps_brain.store import MemoryStore
+
+    from tapps_core.config.settings import load_settings
+    from tapps_mcp.project.profiler import detect_project_profile
+
+    root = _get_project_root()
+    store = MemoryStore(root, store_dir=".tapps-mcp")
+    try:
+        settings = load_settings(root)
+        profile = detect_project_profile(settings.project_root)
+        profile.project_type = profile.project_type or ""
+        result = reseed_from_profile(store, profile)  # type: ignore[arg-type]
+        click.echo(
+            f"Re-seeded {result.get('seeded_count', result.get('count', 0))} "
+            f"memories from project profile."
+        )
     finally:
         store.close()
 

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_hook_templates.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_hook_templates.py
@@ -339,16 +339,16 @@ exit 0
 """,
     "tapps-user-prompt-submit.sh": """\
 #!/usr/bin/env bash
-# TappsMCP UserPromptSubmit hook (TAP-975)
+# TappsMCP UserPromptSubmit hook (TAP-975 / TAP-2000)
 # Re-surfaces pipeline state per user turn so long sessions don't drift.
-# Reads two sidecars:
+# Reads one sidecar:
 #   .tapps-mcp/.session-start-marker   — Unix epoch of last tapps_session_start
-#   .tapps-mcp/.checklist-state.json   — last tapps_checklist outcome
-# Stays SILENT when session_start was within 30 min AND no open checklist.
+# Checklist outcomes live in brain (checklist_outcome events via TAP-2000);
+# call tapps_checklist or /tapps-finish-task — bash hooks cannot query brain.
+# Stays SILENT when session_start was within 30 min.
 INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 SS_MARKER="$PROJECT_DIR/.tapps-mcp/.session-start-marker"
-CL_STATE="$PROJECT_DIR/.tapps-mcp/.checklist-state.json"
 NOW=$(date +%s)
 NEED_SS=0
 if [ ! -f "$SS_MARKER" ]; then
@@ -364,34 +364,12 @@ else
     NEED_SS=1
   fi
 fi
-OPEN_CHECKLIST=""
-if [ -f "$CL_STATE" ]; then
-  PYBIN=$(command -v python3 2>/dev/null || command -v python 2>/dev/null)
-  OPEN_CHECKLIST=$("$PYBIN" -c "
-import json
-try:
-    d=json.load(open('$CL_STATE'))
-    if d.get('complete') is False:
-        m=d.get('missing_required',[])
-        if m:
-            print('open: ' + ', '.join(m[:3]))
-        else:
-            print('open')
-except Exception:
-    pass
-" 2>/dev/null)
-fi
-if [ "$NEED_SS" -eq 0 ] && [ -z "$OPEN_CHECKLIST" ]; then
+if [ "$NEED_SS" -eq 0 ]; then
   exit 0
 fi
 {
   echo "[TappsMCP] Pipeline-state reminder:"
-  if [ "$NEED_SS" -eq 1 ]; then
-    echo "  - tapps_session_start was not called within the last 30 min — call it before edits to refresh project context."
-  fi
-  if [ -n "$OPEN_CHECKLIST" ]; then
-    echo "  - tapps_checklist last reported incomplete ($OPEN_CHECKLIST) — run /tapps-finish-task or address the missing tools."
-  fi
+  echo "  - tapps_session_start was not called within the last 30 min — call it before edits to refresh project context."
 } >&2
 exit 0
 """,
@@ -803,17 +781,17 @@ Write-Host "Reminder: Before declaring complete, run /tapps-finish-task (or tapp
 exit 0
 """,
     "tapps-user-prompt-submit.ps1": """\
-# TappsMCP UserPromptSubmit hook (TAP-975)
+# TappsMCP UserPromptSubmit hook (TAP-975 / TAP-2000)
 # Re-surfaces pipeline state per user turn so long sessions don't drift.
-# Reads two sidecars:
+# Reads one sidecar:
 #   .tapps-mcp/.session-start-marker   — Unix epoch of last tapps_session_start
-#   .tapps-mcp/.checklist-state.json   — last tapps_checklist outcome
-# Stays SILENT when session_start was within 30 min AND no open checklist.
+# Checklist outcomes live in brain (checklist_outcome events via TAP-2000);
+# call tapps_checklist or /tapps-finish-task — hooks cannot query brain.
+# Stays SILENT when session_start was within 30 min.
 $null = $input | Out-Null
 $projDir = $env:CLAUDE_PROJECT_DIR
 if (-not $projDir) { $projDir = "." }
 $ssMarker = Join-Path $projDir '.tapps-mcp/.session-start-marker'
-$clState = Join-Path $projDir '.tapps-mcp/.checklist-state.json'
 $now = [int64]([DateTimeOffset]::Now.ToUnixTimeSeconds())
 $needSs = $false
 if (-not (Test-Path $ssMarker)) {
@@ -828,31 +806,11 @@ if (-not (Test-Path $ssMarker)) {
         if ($age -gt 1800) { $needSs = $true }
     }
 }
-$openChecklist = ''
-if (Test-Path $clState) {
-    try {
-        $d = Get-Content -Path $clState -Raw -ErrorAction Stop | ConvertFrom-Json
-        if ($d.complete -eq $false) {
-            $missing = @($d.missing_required)
-            if ($missing.Count -gt 0) {
-                $first = ($missing | Select-Object -First 3) -join ', '
-                $openChecklist = "open: $first"
-            } else {
-                $openChecklist = 'open'
-            }
-        }
-    } catch {}
-}
-if (-not $needSs -and -not $openChecklist) {
+if (-not $needSs) {
     exit 0
 }
 [Console]::Error.WriteLine('[TappsMCP] Pipeline-state reminder:')
-if ($needSs) {
-    [Console]::Error.WriteLine('  - tapps_session_start was not called within the last 30 min - call it before edits to refresh project context.')
-}
-if ($openChecklist) {
-    [Console]::Error.WriteLine("  - tapps_checklist last reported incomplete ($openChecklist) - run /tapps-finish-task or address the missing tools.")
-}
+[Console]::Error.WriteLine('  - tapps_session_start was not called within the last 30 min - call it before edits to refresh project context.')
 exit 0
 """,
     "tapps-task-completed.ps1": """\

--- a/packages/tapps-mcp/src/tapps_mcp/server.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server.py
@@ -1558,6 +1558,19 @@ async def tapps_checklist(
         if ev is not None:
             resp_data["epic_validation"] = ev.model_dump()
 
+        # TAP-2000: best-effort prior outcome from brain + emit checklist_outcome event.
+        try:
+            from tapps_mcp.server_helpers import (
+                fetch_prior_checklist_outcome,
+                write_checklist_state_marker,
+            )
+
+            prior = await fetch_prior_checklist_outcome(settings.project_root)
+            if prior is not None:
+                resp_data["prior_checklist_outcome"] = prior
+        except Exception:
+            logger.debug("prior_checklist_outcome_failed", exc_info=True)
+
         resp = success_response("tapps_checklist", elapsed_ms, resp_data)
 
         # Attach structured output (markdown/json only - compact is already minimal)
@@ -1581,14 +1594,12 @@ async def tapps_checklist(
             except Exception:
                 logger.debug("structured_output_failed: tapps_checklist", exc_info=True)
 
-        # TAP-975: persist checklist outcome so the UserPromptSubmit hook can
-        # surface "open checklist" reminders across topic shifts.
+        # TAP-2000: emit checklist_outcome brain event (advisory; hook reads dropped).
         try:
-            from tapps_mcp.config import load_settings as _load_settings
             from tapps_mcp.server_helpers import write_checklist_state_marker
 
             write_checklist_state_marker(
-                _load_settings().project_root,
+                settings.project_root,
                 complete=result.complete,
                 missing_required=list(result.missing_required),
             )

--- a/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import os
 import threading
@@ -628,34 +629,86 @@ def write_session_start_marker(project_root: Path | str) -> None:
         pass
 
 
+def _checklist_entity_id(project_root: Path) -> str:
+    """Stable brain entity id for checklist outcomes (TAP-2000)."""
+    try:
+        from tapps_core.config.settings import load_settings
+
+        settings = load_settings(project_root)
+        brain_id = getattr(settings.memory, "brain_project_id", "") or ""
+        if brain_id:
+            return f"checklist:{brain_id}"
+    except Exception:
+        pass
+    return f"checklist:{project_root.resolve()}"
+
+
 def write_checklist_state_marker(
     project_root: Path | str,
     *,
     complete: bool,
     missing_required: list[str] | None = None,
 ) -> None:
-    """TAP-975: Record the most recent ``tapps_checklist`` outcome on disk.
+    """TAP-2000: Record the most recent ``tapps_checklist`` outcome in brain.
 
-    Read by the ``tapps-user-prompt-submit`` hook to surface "open checklist"
-    reminders when the last run flagged missing required tools. Failures are
-    swallowed — same advisory contract as :func:`write_session_start_marker`.
+    Emits a ``checklist_outcome`` KG event via ``brain_record_event``. The
+    legacy ``.checklist-state.json`` sidecar is no longer written — hook
+    checklist reminders were dropped because bash hooks cannot call brain
+    (see ``docs/handoff/BRAIN-wave2-capabilities.md``). Failures are swallowed
+    — same advisory contract as :func:`write_session_start_marker`.
     """
-    try:
-        import json as _json
+    root = project_root if isinstance(project_root, Path) else Path(project_root)
+    payload_data = {
+        "ts": int(time.time()),
+        "complete": bool(complete),
+        "missing_required": list(missing_required or []),
+    }
+    entity_id = _checklist_entity_id(root)
 
-        root = project_root if isinstance(project_root, Path) else Path(project_root)
-        sidecar_dir = root / ".tapps-mcp"
-        sidecar_dir.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "ts": int(time.time()),
-            "complete": bool(complete),
-            "missing_required": list(missing_required or []),
-        }
-        (sidecar_dir / ".checklist-state.json").write_text(
-            _json.dumps(payload, separators=(",", ":")), encoding="utf-8"
-        )
+    async def _emit() -> None:
+        try:
+            bridge = _get_brain_bridge()
+            if bridge is None or not hasattr(bridge, "record_kg_event"):
+                return
+            await bridge.record_kg_event(  # type: ignore[union-attr]
+                event_type="checklist_outcome",
+                entities=[{"type": "project", "id": entity_id}],
+                payload_data=payload_data,
+            )
+        except Exception:
+            pass
+
+    try:
+        asyncio.create_task(_emit())  # noqa: RUF006
     except Exception:
         pass
+
+
+async def fetch_prior_checklist_outcome(project_root: Path | str) -> dict[str, Any] | None:
+    """Best-effort read of the latest checklist outcome from brain (TAP-2000).
+
+    Returns ``None`` when brain is unavailable or the event payload cannot be
+    read back (brain_get_neighbors returns graph structure only today).
+    """
+    root = project_root if isinstance(project_root, Path) else Path(project_root)
+    entity_id = _checklist_entity_id(root)
+    try:
+        bridge = _get_brain_bridge()
+        if bridge is None or not hasattr(bridge, "get_neighbors"):
+            return None
+        result = await bridge.get_neighbors(entity_ids=[entity_id], hops=1)  # type: ignore[union-attr]
+        if not isinstance(result, dict):
+            return None
+        neighbors = result.get("neighbors") or result.get("edges") or []
+        if not neighbors:
+            return None
+        return {
+            "entity_id": entity_id,
+            "neighbor_count": len(neighbors),
+            "source": "brain_get_neighbors",
+        }
+    except Exception:
+        return None
 
 
 def _reset_session_state() -> None:

--- a/packages/tapps-mcp/tests/unit/test_cli_memory.py
+++ b/packages/tapps-mcp/tests/unit/test_cli_memory.py
@@ -273,9 +273,6 @@ class TestMemoryImportExport:
                 "error_count": 0,
             }
             result = runner.invoke(main, ["memory", "import-file", "--file", str(import_file)])
-        # import_memories is imported locally in the CLI function, so we need
-        # to patch at the right level. Since it's a local import, we patch the
-        # function that the CLI calls.
         assert result.exit_code == 0 or "Imported" in result.output or result.exit_code == 0
 
     def test_export_success(self, runner: CliRunner, tmp_path: Path) -> None:
@@ -292,3 +289,75 @@ class TestMemoryImportExport:
             }
             result = runner.invoke(main, ["memory", "export-file", "--file", str(export_file)])
         assert result.exit_code == 0 or "Exported" in result.output or result.exit_code == 0
+
+    def test_export_with_tier_and_format(self, runner: CliRunner, tmp_path: Path) -> None:
+        export_file = tmp_path / "export.md"
+        mock_store = _mock_store()
+        with (
+            patch(_ROOT_PATCH, return_value=tmp_path),
+            patch(_STORE_PATCH, return_value=mock_store),
+            patch("tapps_brain.io.export_memories") as mock_export,
+        ):
+            mock_export.return_value = {
+                "exported_count": 2,
+                "file_path": str(export_file),
+            }
+            result = runner.invoke(
+                main,
+                [
+                    "memory",
+                    "export-file",
+                    "--file",
+                    str(export_file),
+                    "--format",
+                    "markdown",
+                    "--tier",
+                    "architectural",
+                    "--scope",
+                    "project",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_export.assert_called_once()
+        _, kwargs = mock_export.call_args
+        assert kwargs["export_format"] == "markdown"
+        assert kwargs["tier"] == "architectural"
+        assert kwargs["scope"] == "project"
+
+    def test_export_bad_format_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        result = runner.invoke(
+            main,
+            [
+                "memory",
+                "export-file",
+                "--file",
+                str(tmp_path / "out.json"),
+                "--format",
+                "yaml",
+            ],
+        )
+        assert result.exit_code != 0
+
+
+class TestMemoryReseed:
+    def test_reseed_requires_confirm(self, runner: CliRunner) -> None:
+        result = runner.invoke(main, ["memory", "reseed"])
+        assert result.exit_code != 0
+
+    def test_reseed_success(self, runner: CliRunner, tmp_path: Path) -> None:
+        mock_store = _mock_store()
+        mock_profile = MagicMock()
+        mock_profile.project_type = "python"
+        with (
+            patch(_ROOT_PATCH, return_value=tmp_path),
+            patch(_STORE_PATCH, return_value=mock_store),
+            patch("tapps_mcp.project.profiler.detect_project_profile", return_value=mock_profile),
+            patch("tapps_brain.seeding.reseed_from_profile") as mock_reseed,
+            patch("tapps_core.config.settings.load_settings") as mock_settings,
+        ):
+            mock_settings.return_value.project_root = tmp_path
+            mock_reseed.return_value = {"seeded_count": 4}
+            result = runner.invoke(main, ["memory", "reseed", "--confirm"])
+        assert result.exit_code == 0
+        assert "Re-seeded" in result.output
+        mock_reseed.assert_called_once()

--- a/packages/tapps-mcp/tests/unit/test_server_helpers.py
+++ b/packages/tapps-mcp/tests/unit/test_server_helpers.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tapps_mcp.server_helpers import error_response, serialize_issues, success_response
 
@@ -111,4 +113,39 @@ class TestGetBrainBridgeProfile:
             f"Expected default_profile='full', got {call_kwargs}"
         )
         # Cleanup singleton so other tests start clean.
+        _reset_brain_bridge_cache()
+
+
+class TestChecklistStateMarker:
+    """TAP-2000: checklist outcomes emit brain events, not local JSON."""
+
+    def test_emits_checklist_outcome_event(self, tmp_path: Path) -> None:
+        from tapps_mcp.server_helpers import _reset_brain_bridge_cache, write_checklist_state_marker
+
+        mock_bridge = MagicMock()
+        mock_bridge.record_kg_event = AsyncMock(return_value={"recorded": True})
+        captured: list[Any] = []
+
+        with (
+            patch("tapps_mcp.server_helpers._reset_brain_bridge_cache"),
+            patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=mock_bridge),
+            patch(
+                "tapps_mcp.server_helpers.asyncio.create_task",
+                side_effect=lambda coro: captured.append(coro),
+            ),
+        ):
+            write_checklist_state_marker(
+                tmp_path,
+                complete=False,
+                missing_required=["tapps_validate_changed"],
+            )
+            import asyncio
+
+            asyncio.run(captured[0])
+
+        kwargs = mock_bridge.record_kg_event.await_args.kwargs
+        assert kwargs["event_type"] == "checklist_outcome"
+        assert kwargs["payload_data"]["complete"] is False
+        assert kwargs["payload_data"]["missing_required"] == ["tapps_validate_changed"]
+        assert "ts" in kwargs["payload_data"]
         _reset_brain_bridge_cache()

--- a/packages/tapps-mcp/tests/unit/test_user_prompt_submit_hook.py
+++ b/packages/tapps-mcp/tests/unit/test_user_prompt_submit_hook.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -55,31 +57,45 @@ class TestSidecarWriters:
         # Writer must not raise.
         write_session_start_marker("/dev/null/cannot-mkdir-here")
 
-    def test_checklist_state_marker_writes_json(self, tmp_path: Path) -> None:
-        write_checklist_state_marker(
-            tmp_path,
-            complete=False,
-            missing_required=["tapps_score_file", "tapps_quality_gate"],
-        )
-        path = tmp_path / ".tapps-mcp" / ".checklist-state.json"
-        assert path.exists()
-        data = json.loads(path.read_text(encoding="utf-8"))
-        assert data["complete"] is False
-        assert data["missing_required"] == [
-            "tapps_score_file",
-            "tapps_quality_gate",
-        ]
-        assert isinstance(data["ts"], int)
+    def test_checklist_state_marker_emits_brain_event(self, tmp_path: Path) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.record_kg_event = AsyncMock(return_value={"recorded": True})
+        captured: list[Any] = []
 
-    def test_checklist_state_marker_complete(self, tmp_path: Path) -> None:
-        write_checklist_state_marker(tmp_path, complete=True)
-        data = json.loads(
-            (tmp_path / ".tapps-mcp" / ".checklist-state.json").read_text(
-                encoding="utf-8"
+        with (
+            patch("tapps_mcp.server_helpers._reset_brain_bridge_cache"),
+            patch("tapps_mcp.server_helpers._get_brain_bridge", return_value=mock_bridge),
+            patch(
+                "tapps_mcp.server_helpers.asyncio.create_task",
+                side_effect=lambda coro: captured.append(coro),
+            ),
+        ):
+            write_checklist_state_marker(
+                tmp_path,
+                complete=False,
+                missing_required=["tapps_quality_gate"],
             )
-        )
-        assert data["complete"] is True
-        assert data["missing_required"] == []
+            assert len(captured) == 1
+            import asyncio
+
+            asyncio.run(captured[0])
+
+        mock_bridge.record_kg_event.assert_awaited_once()
+        call_kwargs = mock_bridge.record_kg_event.await_args.kwargs
+        assert call_kwargs["event_type"] == "checklist_outcome"
+        assert call_kwargs["payload_data"]["complete"] is False
+        assert call_kwargs["payload_data"]["missing_required"] == ["tapps_quality_gate"]
+        assert (tmp_path / ".tapps-mcp" / ".checklist-state.json").exists() is False
+
+    def test_checklist_state_marker_swallows_errors(self, tmp_path: Path) -> None:
+        with (
+            patch("tapps_mcp.server_helpers.asyncio.create_task"),
+            patch(
+                "tapps_mcp.server_helpers._get_brain_bridge",
+                side_effect=RuntimeError("brain down"),
+            ),
+        ):
+            write_checklist_state_marker(tmp_path, complete=True)
 
 
 class TestScriptContent:
@@ -91,15 +107,15 @@ class TestScriptContent:
     def test_ps_script_exists(self) -> None:
         assert "tapps-user-prompt-submit.ps1" in CLAUDE_HOOK_SCRIPTS_PS
 
-    def test_bash_references_both_sidecars(self) -> None:
+    def test_bash_references_session_sidecar(self) -> None:
         body = CLAUDE_HOOK_SCRIPTS["tapps-user-prompt-submit.sh"]
         assert ".session-start-marker" in body
-        assert ".checklist-state.json" in body
+        assert ".checklist-state.json" not in body
 
-    def test_ps_references_both_sidecars(self) -> None:
+    def test_ps_references_session_sidecar(self) -> None:
         body = CLAUDE_HOOK_SCRIPTS_PS["tapps-user-prompt-submit.ps1"]
         assert ".session-start-marker" in body
-        assert ".checklist-state.json" in body
+        assert ".checklist-state.json" not in body
 
     def test_bash_uses_1800s_window(self) -> None:
         # The AC's "30 minute" freshness check.
@@ -108,13 +124,9 @@ class TestScriptContent:
     def test_ps_uses_1800s_window(self) -> None:
         assert "1800" in CLAUDE_HOOK_SCRIPTS_PS["tapps-user-prompt-submit.ps1"]
 
-    def test_bash_mentions_finish_task(self) -> None:
+    def test_bash_mentions_brain_checklist_note(self) -> None:
         body = CLAUDE_HOOK_SCRIPTS["tapps-user-prompt-submit.sh"]
-        assert "/tapps-finish-task" in body
-
-    def test_ps_mentions_finish_task(self) -> None:
-        body = CLAUDE_HOOK_SCRIPTS_PS["tapps-user-prompt-submit.ps1"]
-        assert "/tapps-finish-task" in body
+        assert "checklist_outcome" in body or "tapps_checklist" in body
 
     def test_bash_exits_zero(self) -> None:
         # UserPromptSubmit advisory only — exit 2 would block the prompt.
@@ -249,27 +261,17 @@ class TestBehavior:
         assert rc == 0
         assert "tapps_session_start" in stderr
 
-    def test_open_checklist_warns_even_when_session_fresh(
+    def test_open_checklist_sidecar_no_longer_triggers_hook(
         self, tmp_path: Path
     ) -> None:
+        """TAP-2000: checklist reminders moved to brain; hook stays silent."""
         write_session_start_marker(tmp_path)
-        write_checklist_state_marker(
-            tmp_path,
-            complete=False,
-            missing_required=["tapps_quality_gate"],
-        )
-        script = self._setup(tmp_path)
-        rc, _, stderr = self._run(
-            script, stdin="{}", env={"CLAUDE_PROJECT_DIR": str(tmp_path)}
-        )
-        assert rc == 0
-        assert "tapps_checklist" in stderr
-        assert "tapps_quality_gate" in stderr
-        assert "/tapps-finish-task" in stderr
-
-    def test_complete_checklist_does_not_warn(self, tmp_path: Path) -> None:
-        write_session_start_marker(tmp_path)
-        write_checklist_state_marker(tmp_path, complete=True)
+        with patch("tapps_mcp.server_helpers.asyncio.create_task"):
+            write_checklist_state_marker(
+                tmp_path,
+                complete=False,
+                missing_required=["tapps_quality_gate"],
+            )
         script = self._setup(tmp_path)
         rc, _, stderr = self._run(
             script, stdin="{}", env={"CLAUDE_PROJECT_DIR": str(tmp_path)}


### PR DESCRIPTION
## Summary

- **TAP-2000**: `write_checklist_state_marker` emits `checklist_outcome` brain KG events; drops `.checklist-state.json` and simplifies UserPromptSubmit hook to session-start only.
- **TAP-1960**: Adds `tapps-mcp memory reseed --confirm` and extends `export-file` with `--format`, `--tier`, `--scope`, `--min-confidence`; documents CLI paths in `docs/MEMORY_REFERENCE.md`.
- **TAP-1997 (phase 1)**: Dual-write `quality_metric` brain events from `ToolCallMetricsCollector` via new `brain_telemetry` module while keeping local JSON/JSONL metrics for dashboard reads.

Audit work (read-only, no code in audited files): completed TAP-2044–2047 sessions; filed TAP-3126 (P1), TAP-3127–3130 (digests). Closed TAP-1914, TAP-2000, TAP-1960 in Linear.

## Test plan

- [x] `uv run pytest packages/tapps-core/tests/unit/test_execution_metrics.py -q`
- [x] `uv run pytest packages/tapps-mcp/tests/unit/test_cli_memory.py packages/tapps-mcp/tests/unit/test_server_helpers.py packages/tapps-mcp/tests/unit/test_user_prompt_submit_hook.py -q`
- [ ] `uv run tapps-mcp memory reseed --confirm` against a bootstrapped project
- [ ] `uv run tapps-mcp memory export-file --file /tmp/out.md --format markdown --tier architectural`


Made with [Cursor](https://cursor.com)