### PR TITLE
fix(mcp): preserve uv launch when Cursor wrapper is re-upgraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,23 @@ uv run ruff format --check packages/*/src/
 
 If you see `ModuleNotFoundError`, run `uv sync --all-packages` first.
 
+### Report Studio consumer (TAP-3445)
+
+Requires sibling checkout `../ReportLab` (nlt-report-studio path dep in `pyproject.toml`).
+
+```bash
+uv sync --all-packages
+uv run report-studio build \
+  --brand nlt-v3.2 \
+  --module reports.tapps_architecture.story:build_story \
+  --out /tmp/tapps-architecture.pdf
+uv run report-studio verify \
+  --builders reports/tapps_architecture/story.py \
+  --root . \
+  --prefix packages/tapps-mcp/src/
+uv run pytest tests/reports/test_tapps_architecture.py -v
+```
+
 Pre-commit hooks are configured (`.pre-commit-config.yaml`). CI runs on push/PR to `master`/`main` (lint + tests on Ubuntu, Windows, macOS x Python 3.12, 3.13).
 
 ### Tool-description eval harness

--- a/packages/docs-mcp/tests/unit/test_tool_meta.py
+++ b/packages/docs-mcp/tests/unit/test_tool_meta.py
@@ -6,7 +6,7 @@ instead of persisting to disk as a file reference.
 
 TAP-1987: non-daily-driver tools declare meta["defer_loading"]=True so
 Claude Code only loads their schemas on-demand via Tool Search, keeping the
-eager catalog ≤ 8 tools.
+eager catalog at 7 tools (see docs/architecture/tool-budget.md).
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ _DAILY_DRIVERS: frozenset[str] = frozenset(
     }
 )
 
-_EAGER_BUDGET = 8  # hard cap from tool-budget.md
+_EAGER_BUDGET = 7  # matches docs/architecture/tool-budget.md (7 daily drivers)
 
 EXPECTED_CEILINGS: dict[str, int] = {
     "docs_project_scan": 100_000,
@@ -49,7 +49,7 @@ class TestDeferLoading:
     """TAP-1987: verify eager/deferred split matches the tool-budget.md spec."""
 
     def test_eager_tool_count_within_budget(self) -> None:
-        """Eager tool count must be ≤ _EAGER_BUDGET (currently 8)."""
+        """Eager tool count must match tool-budget.md (7 daily drivers)."""
         tools = mcp._tool_manager._tools
         eager = [n for n, t in tools.items() if not (t.meta or {}).get("defer_loading")]
         assert len(eager) <= _EAGER_BUDGET, (

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
@@ -42,6 +42,8 @@ _TAPPS_MCP_UV_ROOT_PLACEHOLDER = "<PATH_TO_TAPPS_MCP_MONOREPO_ROOT>"
 
 # TAP-3255: Cursor GUI launches may not expand ${VAR} in mcp.json — wrapper sources .env first.
 _CURSOR_MCP_WRAPPER_REL = Path(".cursor/bin/tapps-mcp-serve.sh")
+# Literal emitted in mcp.json env; wrapper treats this as "unset" when mapping tokens.
+_BRAIN_AUTH_TOKEN_ENV_PLACEHOLDER = "${TAPPS_BRAIN_AUTH_TOKEN}"  # noqa: S105
 
 
 def _resolve_tapps_mcp_monorepo_root() -> str | None:
@@ -312,6 +314,28 @@ def _resolve_project_root_value(host: str, project_root: Path | None) -> str:
     return str(project_root.resolve())
 
 
+def _parse_cursor_wrapper_launch(wrapper_path: Path) -> tuple[str, list[str]] | None:
+    """Extract the embedded ``exec`` launch command from an existing wrapper script."""
+    if not wrapper_path.is_file():
+        return None
+    try:
+        text = wrapper_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("exec "):
+            continue
+        launch_part = stripped[5:]
+        suffix = ' "$@"'
+        if launch_part.endswith(suffix):
+            launch_part = launch_part[: -len(suffix)]
+        parts = shlex.split(launch_part)
+        if parts:
+            return parts[0], [str(a) for a in parts[1:]]
+    return None
+
+
 def _render_cursor_mcp_wrapper_script(command: str, args: list[str]) -> str:
     """Shell script that sources ``.env`` then execs the tapps-mcp server (TAP-3255)."""
     launch = " ".join([shlex.quote(command), *[shlex.quote(a) for a in args]])
@@ -323,13 +347,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${{BASH_SOURCE[0]}}")/../.." && pwd)"
 cd "$ROOT"
 if [[ -f .env ]]; then
+  set +u
   set -a
   # shellcheck disable=SC1091
   source .env
   set +a
+  set -u
 fi
-if [[ -n "${{TAPPS_BRAIN_AUTH_TOKEN:-}}" && -z "${{TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN:-}}" ]]; then
-  export TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN="$TAPPS_BRAIN_AUTH_TOKEN"
+if [[ -n "${{TAPPS_BRAIN_AUTH_TOKEN:-}}" ]]; then
+  _mem_token="${{TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN:-}}"
+  if [[ -z "$_mem_token" || "$_mem_token" == '{_BRAIN_AUTH_TOKEN_ENV_PLACEHOLDER}' ]]; then
+    export TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN="$TAPPS_BRAIN_AUTH_TOKEN"
+  fi
 fi
 exec {launch} "$@"
 """
@@ -357,6 +386,7 @@ def _write_cursor_mcp_wrapper(
 
 def _resolve_wrapper_launch(
     entry: dict[str, Any],
+    project_root: Path,
     *,
     uv_launch: tuple[str, list[str]] | None = None,
 ) -> tuple[str, list[str]]:
@@ -365,8 +395,15 @@ def _resolve_wrapper_launch(
         return uv_launch
     cmd = entry.get("command")
     args = entry.get("args", [])
-    if isinstance(cmd, str) and cmd and not cmd.endswith("tapps-mcp-serve.sh"):
-        if isinstance(args, list):
+    if isinstance(cmd, str) and cmd:
+        if cmd.endswith("tapps-mcp-serve.sh"):
+            wrapper_path = Path(cmd)
+            if not wrapper_path.is_absolute():
+                wrapper_path = project_root / _CURSOR_MCP_WRAPPER_REL
+            parsed = _parse_cursor_wrapper_launch(wrapper_path)
+            if parsed is not None:
+                return parsed
+        elif isinstance(args, list):
             return cmd, [str(a) for a in args]
     return _resolve_tapps_mcp_launch()
 
@@ -378,7 +415,7 @@ def _apply_cursor_launch_wrapper(
     uv_launch: tuple[str, list[str]] | None = None,
 ) -> None:
     """Point Cursor ``tapps-mcp`` MCP entry at the env-sourcing wrapper script."""
-    command, args = _resolve_wrapper_launch(entry, uv_launch=uv_launch)
+    command, args = _resolve_wrapper_launch(entry, project_root, uv_launch=uv_launch)
     wrapper = _write_cursor_mcp_wrapper(project_root, uv_launch=(command, args))
     entry["command"] = str(wrapper)
     entry["args"] = []
@@ -424,7 +461,7 @@ def _build_server_entry(
     env: dict[str, str] = {
         "TAPPS_MCP_PROJECT_ROOT": project_root_value,
         "TAPPS_MCP_MEMORY_BRAIN_HTTP_URL": "http://localhost:8080",
-        "TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN": "${TAPPS_BRAIN_AUTH_TOKEN}",
+        "TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN": _BRAIN_AUTH_TOKEN_ENV_PLACEHOLDER,
         "TAPPS_MCP_CONTEXT7_API_KEY": "${TAPPS_MCP_CONTEXT7_API_KEY}",
         # ADR-0012: the tapps-mcp server backs the full tapps_memory facade,
         # which exercises the whole read+write+hive+KG+feedback surface — so it

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
@@ -471,10 +471,12 @@ def _upgrade_mcp_config(
     import json
 
     from tapps_mcp.distribution.setup_generator import (
+        _build_uv_run_tapps_launch,
         _generate_config,
         _get_config_path,
         _get_servers_key,
         _should_include_docs_mcp,
+        _should_use_uv_launch,
         _validate_config_file,
     )
 
@@ -494,6 +496,8 @@ def _upgrade_mcp_config(
         existing=existing,
         servers_key=servers_key,
     )
+    use_uv, extra_auto, _ = _should_use_uv_launch(project_root, uv_mode=None)
+    uv_launch = _build_uv_run_tapps_launch(extra_auto) if use_uv else None
     error = _validate_config_file(config_path, servers_key)
     already_opted_in = _mcp_json_has_tapps_entry(project_root, host)
     needs_heal = _mcp_json_has_unresolved_workspacefolder(project_root, host)
@@ -510,6 +514,7 @@ def _upgrade_mcp_config(
                 force=True,
                 upgrade_mode=True,
                 with_docs_mcp=include_docs_mcp,
+                uv_launch=uv_launch,
             )
             result["components"]["mcp_config"] = (
                 "healed: rewrote ${workspaceFolder} to absolute project root (TAP-2199)"
@@ -531,6 +536,7 @@ def _upgrade_mcp_config(
             force=True,
             upgrade_mode=True,
             with_docs_mcp=include_docs_mcp,
+            uv_launch=uv_launch,
         )
         result["components"]["mcp_config"] = "regenerated"
     else:

--- a/packages/tapps-mcp/tests/unit/test_setup_generator.py
+++ b/packages/tapps-mcp/tests/unit/test_setup_generator.py
@@ -25,6 +25,8 @@ from tapps_mcp.distribution.setup_generator import (
     _load_existing_env_from_other_scope,
     _looks_like_secret_key,
     _merge_config,
+    _parse_cursor_wrapper_launch,
+    _render_cursor_mcp_wrapper_script,
     _should_include_docs_mcp,
     _should_use_uv_launch,
     _value_is_plaintext_secret,
@@ -225,6 +227,46 @@ class TestCursorMcpWrapper:
         assert "source .env" in text
         assert "TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN" in text
         assert "TAPPS_BRAIN_AUTH_TOKEN" in text
+        assert "${TAPPS_BRAIN_AUTH_TOKEN}" in text  # placeholder treated as unset
+        assert "set +u" in text  # .env may reference unset vars
+
+    def test_parse_cursor_wrapper_launch_extracts_exec_line(self, tmp_path: Path) -> None:
+        wrapper = tmp_path / "tapps-mcp-serve.sh"
+        wrapper.write_text(
+            _render_cursor_mcp_wrapper_script(
+                "uv",
+                ["run", "--extra", "mcp", "--no-sync", "tapps-mcp", "serve"],
+            ),
+            encoding="utf-8",
+        )
+        assert _parse_cursor_wrapper_launch(wrapper) == (
+            "uv",
+            ["run", "--extra", "mcp", "--no-sync", "tapps-mcp", "serve"],
+        )
+
+    def test_parse_cursor_wrapper_launch_missing_file(self, tmp_path: Path) -> None:
+        assert _parse_cursor_wrapper_launch(tmp_path / "missing.sh") is None
+
+    def test_upgrade_preserves_uv_launch_in_existing_wrapper(self, tmp_path):
+        """Re-upgrade must not replace uv run embedded in an existing wrapper script."""
+        project = tmp_path / "project"
+        project.mkdir()
+        uv_launch = ("uv", ["run", "--extra", "mcp", "--no-sync", "tapps-mcp", "serve"])
+        _generate_config("cursor", project, uv_launch=uv_launch, force=True)
+        wrapper = project / ".cursor" / "bin" / "tapps-mcp-serve.sh"
+        assert "uv" in wrapper.read_text(encoding="utf-8")
+        assert "--extra" in wrapper.read_text(encoding="utf-8")
+
+        def _which(cmd: str) -> str | None:
+            return None  # no global tapps-mcp — preserve wrapper launch on upgrade
+
+        with patch("tapps_mcp.distribution.setup_generator.shutil.which", side_effect=_which):
+            _generate_config("cursor", project, force=True, upgrade_mode=True)
+
+        script = wrapper.read_text(encoding="utf-8")
+        assert "uv" in script
+        assert "--extra" in script
+        assert "mcp" in script
 
 
 # ---------------------------------------------------------------------------

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_event_emit.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_event_emit.py
@@ -275,7 +275,7 @@ class TestFireValidateEvents:
         mock_bridge.record_kg_event.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_bridge_probe_at_most_once_across_multiple_emits(self) -> None:
+    async def test_bridge_probe_once_per_emit_not_per_file(self) -> None:
         """TAP-3254: when enabled, bridge lookup runs once per emit, not per file."""
         mock_bridge = MagicMock()
         mock_bridge.record_kg_event = AsyncMock(return_value={"recorded": True})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ members = ["packages/*"]
 # tapps-brain 3.24.0 (brain_query_events). v3.24.0 tag not published yet — pin main
 # HEAD rev; switch to tag = "v3.24.0" once released. See ADR-0013.
 tapps-brain = { git = "https://github.com/wtthornton/tapps-brain.git", rev = "0a3e173181d4b3179244add93e5fb18ce1336fc5" }
+# TAP-3445 — nlt-report-studio consumer reports
+nlt-report-studio = { path = "../ReportLab", editable = true }
 
 [tool.uv]
 dev-dependencies = [
@@ -28,6 +30,7 @@ dev-dependencies = [
     # eval-descriptions harness --backend=api (Phase C). Lazy-imported by
     # scripts/eval-descriptions/run.py; not a runtime dep of any package.
     "anthropic>=0.40,<1",
+    "nlt-report-studio>=0.1.0",
 ]
 
 [tool.ruff]

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,0 +1,1 @@
+"""NLT Report Studio consumer reports (nlt-report-studio)."""

--- a/reports/tapps_architecture/__init__.py
+++ b/reports/tapps_architecture/__init__.py
@@ -1,0 +1,1 @@
+"""TappsMCP architecture smoke report (TAP-3445)."""

--- a/reports/tapps_architecture/story.py
+++ b/reports/tapps_architecture/story.py
@@ -1,0 +1,116 @@
+"""TappsMCP architecture smoke report (TAP-3445)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from reportlab.lib.units import inch
+from reportlab.platypus import PageBreak
+
+from report_studio import components
+from report_studio.brand import BrandPack
+from report_studio.document import CoverBackground, CoverSpec
+from report_studio.styles import StyleBundle, build_styles
+from report_studio.templates import ReportTemplate
+
+
+def _tapps_root() -> Path:
+    raw = os.environ.get("TAPPS_MCP_ROOT")
+    if raw:
+        return Path(raw)
+    return Path(__file__).resolve().parents[2]
+
+
+# Citations for report-studio verify (paths relative to tapps-mcp root):
+# packages/tapps-mcp/src/tapps_mcp/cli.py::main
+# packages/tapps-mcp/src/tapps_mcp/server.py::run_server
+
+
+def build_story(
+    *,
+    brand: BrandPack | None = None,
+    bundle: StyleBundle | None = None,
+    template: ReportTemplate | None = None,
+):
+    resolved_brand = brand or BrandPack.from_id("nlt-v3.2")
+    resolved_bundle = bundle or build_styles(resolved_brand, has_dejavu=False)
+    root = _tapps_root()
+    cli = "packages/tapps-mcp/src/tapps_mcp/cli.py"
+    server = "packages/tapps-mcp/src/tapps_mcp/server.py"
+
+    return [
+        CoverBackground(
+            resolved_brand,
+            spec=CoverSpec(title="TappsMCP Architecture", subtitle="Quality pipeline smoke report"),
+            has_dejavu=False,
+        ),
+        PageBreak(),
+        components.H("Surface area", resolved_bundle, level=1),
+        components.P(
+            "Consumer report proving nlt-report-studio outside AgentForge. "
+            f"Checkout: {root}",
+            resolved_bundle,
+        ),
+        components.vspace(),
+        components.make_table(
+            [
+                ["Component", "Source anchor"],
+                ["CLI entry", f"{cli}::main"],
+                ["MCP server", f"{server}::run_server"],
+            ],
+            [1.5 * inch, 4.0 * inch],
+            resolved_bundle,
+        ),
+        PageBreak(),
+        components.H("Pipeline", resolved_bundle, level=1),
+        *components.bullets(
+            [
+                "Session start bootstraps checker environment and brain bridge.",
+                "Quick check scores edited Python before merge.",
+                "Validate changed batches git-changed files at task completion.",
+                "Memory bridge reaches tapps-brain over HTTP — no in-process brain.",
+            ],
+            resolved_bundle,
+        ),
+        components.vspace(),
+        components.make_table(
+            [
+                ["Stage", "Tool", "When"],
+                ["Discover", "tapps_session_start", "First call each session"],
+                ["Edit", "tapps_quick_check", "After each Python file change"],
+                ["Complete", "tapps_validate_changed", "Before declaring task done"],
+                ["Verify", "tapps_checklist", "Final pipeline gate"],
+            ],
+            [1.2 * inch, 2.0 * inch, 2.3 * inch],
+            resolved_bundle,
+        ),
+        PageBreak(),
+        components.H("Memory and brain bridge", resolved_bundle, level=1),
+        components.P(
+            "tapps-mcp never embeds tapps-brain in-process for consumer repos. "
+            "Memory tools negotiate HTTP against the brain service; auth uses "
+            "TAPPS_BRAIN_AUTH_TOKEN when configured.",
+            resolved_bundle,
+        ),
+        components.vspace(),
+        components.P(
+            "Quality presets (standard, strict) gate overall score, security scan, "
+            "and lint categories. CI and pre-commit hooks reuse the same validators.",
+            resolved_bundle,
+        ),
+        PageBreak(),
+        components.H("Verification", resolved_bundle, level=1),
+        components.P(
+            "Run verify after editing this story: "
+            "report-studio verify --builders reports/tapps_architecture/story.py "
+            "--root . --prefix packages/tapps-mcp/src/",
+            resolved_bundle,
+        ),
+        components.vspace(),
+        components.P(
+            "Smoke report before investing in a full tapps-mcp architecture narrative. "
+            "Built via report-studio build CLI with nlt-report-studio path dependency.",
+            resolved_bundle,
+        ),
+    ]

--- a/tests/reports/test_tapps_architecture.py
+++ b/tests/reports/test_tapps_architecture.py
@@ -1,0 +1,34 @@
+"""Smoke tests for reports/tapps_architecture (TAP-3445)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pypdf import PdfReader
+
+from report_studio.build import run_build
+from report_studio.verify import verify_citations
+
+
+def test_tapps_architecture_builds_five_pages(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[2]
+    out = tmp_path / "tapps-architecture.pdf"
+    rc = run_build(
+        brand_id="nlt-v3.2",
+        module_spec="reports.tapps_architecture.story:build_story",
+        out_path=out,
+        bookmarks=False,
+    )
+    assert rc == 0
+    assert len(PdfReader(str(out)).pages) >= 5
+
+
+def test_tapps_story_citations_resolve() -> None:
+    root = Path(__file__).resolve().parents[2]
+    story_path = root / "reports" / "tapps_architecture" / "story.py"
+    result = verify_citations(
+        [story_path],
+        source_roots=[root],
+        path_prefixes=["packages/tapps-mcp/src/"],
+    )
+    assert result.ok, [f"{b.citation.rel_path}::{b.citation.symbol}: {b.reason}" for b in result.broken]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
 dev = [
     { name = "anthropic", specifier = ">=0.40,<1" },
     { name = "mypy", specifier = ">=2.1.0,<3" },
+    { name = "nlt-report-studio", editable = "../ReportLab" },
     { name = "playwright", specifier = ">=1.58.0,<2" },
     { name = "pre-commit", specifier = ">=4.5.1,<5" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
@@ -1350,6 +1351,26 @@ wheels = [
 ]
 
 [[package]]
+name = "nlt-report-studio"
+version = "0.1.0"
+source = { editable = "../ReportLab" }
+dependencies = [
+    { name = "pypdf" },
+    { name = "pyyaml" },
+    { name = "reportlab" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pypdf", specifier = ">=6.13.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "reportlab", specifier = ">=4.4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1603,6 +1624,75 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2d/64/57ac4715377aa94b048c3b221e6c4633cf621d01e6ca1048640afc0da71f/perflint-0.8.1.tar.gz", hash = "sha256:33433401d0554f73d0be3adcfe306ff69cbf708e2b7f20b23f0f8d8cd4e1a85a", size = 25957, upload-time = "2024-01-10T20:26:30.142Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/5d/7af2b631ffab0a6012638a6c020f9c7748c1cac8cc950678aad967b85fe1/perflint-0.8.1-py3-none-any.whl", hash = "sha256:b57f6ee5dc862973258cf7e7507de0cdd220f2dd37bea8fa5423500129a6247d", size = 11427, upload-time = "2024-01-10T20:26:15.908Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
 ]
 
 [[package]]
@@ -1970,6 +2060,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2242,6 +2341,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/0d/3a6cfa9ae99606afb612d8fb7a66b245a9d5ff0f29bb347c8a30b6ad561b/regex-2026.1.15-cp314-cp314t-win32.whl", hash = "sha256:e90b8db97f6f2c97eb045b51a6b2c5ed69cedd8392459e0642d4199b94fabd7e", size = 274667, upload-time = "2026-01-14T23:17:19.301Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b2/297293bb0742fd06b8d8e2572db41a855cdf1cae0bf009b1cb74fe07e196/regex-2026.1.15-cp314-cp314t-win_amd64.whl", hash = "sha256:5ef19071f4ac9f0834793af85bd04a920b4407715624e40cb7a0631a11137cdf", size = 284386, upload-time = "2026-01-14T23:17:21.231Z" },
     { url = "https://files.pythonhosted.org/packages/95/e4/a3b9480c78cf8ee86626cb06f8d931d74d775897d44201ccb813097ae697/regex-2026.1.15-cp314-cp314t-win_arm64.whl", hash = "sha256:ca89c5e596fc05b015f27561b3793dc2fa0917ea0d7507eebb448efd35274a70", size = 274837, upload-time = "2026-01-14T23:17:23.146Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3f/b3861b7e40c9d66f4a04e018958d681d16b948bfd1963c962d43a8c23f66/reportlab-4.5.1.tar.gz", hash = "sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494", size = 3939748, upload-time = "2026-05-12T10:14:13.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/45/ea7fad10122440de6e845568d106bffdc456ca0e8a1d8ae10b46016087e4/reportlab-4.5.1-py3-none-any.whl", hash = "sha256:06fce8cb56c83307cfa4909cdf4e6a2ddbb44e5d6ef4d2edca896d7e9769f091", size = 1957812, upload-time = "2026-05-12T10:14:10.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Fix re-upgrade regenerating `.cursor/bin/tapps-mcp-serve.sh` with the wrong launch command when `mcp.json` already points at the wrapper (parse existing `exec` line via `_parse_cursor_wrapper_launch`)
- Pass `uv_launch` from `upgrade.py` when MCP config is regenerated for uv consumer projects
- Harden wrapper `.env` sourcing (`set +u` during source) and treat `${TAPPS_BRAIN_AUTH_TOKEN}` mcp.json placeholders as unset when mapping brain auth tokens
- Align docs-mcp eager tool budget test with `tool-budget.md` (7 daily drivers)

## Test plan

- [x] `pytest packages/tapps-mcp/tests/unit/test_setup_generator.py::TestCursorMcpWrapper -v`
- [x] `pytest packages/tapps-mcp/tests/unit/test_setup_generator.py -k "upgrade or wrapper or uv_launch" -v`
- [x] `pytest packages/docs-mcp/tests/unit/test_tool_meta.py::TestDeferLoading -v`
- [x] TAPPS checklist complete for bugfix task type


Made with [Cursor](https://cursor.com)