### PR TITLE
feat(observability): TAP-3571 metrics, handoff hardening, and fleet audit

### DIFF
--- a/.claude/skills/tapps-continue-session/SKILL.md
+++ b/.claude/skills/tapps-continue-session/SKILL.md
@@ -20,21 +20,19 @@ Start work in a fresh context window by assembling structured state — not a us
 2. **Load handoff (priority order).**
    - Read `.tapps-mcp/session-handoff.md` if it exists — primary source.
    - Else best-effort CLI (no `tapps_memory` MCP — removed v3.12.0): `uv run tapps-mcp memory get --key session-handoff` (brain offline or auth missing → skip).
-   - Optional supplements (only if present, do not require):
-     - `docs/NEXT_SESSION_PROMPT.md` — short user-maintained prompt
-     - `docs/TAPPS_HANDOFF.md` — scan for `**Next:**` or the latest stage section
+   - Optional supplements (only if present): `docs/NEXT_SESSION_PROMPT.md`, `docs/TAPPS_HANDOFF.md` (**Next:** section).
+   - **P0 fallback:** If **Next (P0)** is empty but **Open** has bullets, promote the first Open item as provisional P0 and flag it in the continue block.
+   - **Memory context:** Run `uv run tapps-mcp memory search --query "<P0 text or Linear id>"` when brain shell auth is available; skip silently otherwise.
 
 3. **Linear context.**
    - If the user passed `TAP-####` (argument or in handoff **Linear P0**), call `mcp__plugin_linear_linear__get_issue(id=...)`.
    - For backlog/triage without a known id, invoke the `linear-read` skill instead of raw `list_issues` (do not call `list_issues` directly — cache gate).
 
 4. **Emit continue block (~15 lines max).** Present:
-   - **P0** — next action + Linear link if available
-   - **Done / Open / Blockers** — from handoff (compressed)
+   - **P0** — next action + Linear link if available (note if promoted from Open)
+   - **Done / Open / Blockers** — compressed from handoff
    - **Verify first** — commands from handoff
    - **Success criterion**
-   - **Stale warning** if handoff **Updated** is >7 days old
+   - **Stale warning** if handoff **Updated** is >7 days old or missing
 
-5. **Confirm and proceed.** Ask only if P0 is ambiguous; otherwise start on P0 using normal TAPPS workflow (`tapps_quick_check` after Python edits, etc.).
-
-Do **not** ask the user to re-paste prior context when handoff files exist.
+5. **Proceed on P0.** Ask only if P0 is ambiguous; otherwise start using normal TAPPS workflow (`tapps_quick_check` after Python edits). Do **not** ask the user to re-paste prior context when handoff files exist.

--- a/.claude/skills/tapps-handoff-session/SKILL.md
+++ b/.claude/skills/tapps-handoff-session/SKILL.md
@@ -22,6 +22,8 @@ End the session with a durable handoff the next chat can load via `/tapps-contin
    - **Verify** — commands to run first in the next session
    - **Success criterion** — one line
 
+**P0 gate.** Before writing the file: when **Open** has real items (not `none` / `- ...` placeholders), **Next (P0)** must name one concrete next action (prefer a Linear id). If P0 is missing, ask the user once — do not persist an incomplete handoff.
+
 2. **Persist (file is canonical).** Write or overwrite `.tapps-mcp/session-handoff.md` using this shape:
    - Set **Updated** to the real current UTC time: run `date -u +%Y-%m-%dT%H:%M:%SZ` and paste the output — never use a placeholder like `T00:00:00Z`.
    - Optionally add **Git:** `<short-sha>` when inside a git repo (`git rev-parse --short HEAD`).

--- a/.cursor/skills/tapps-continue-session/SKILL.md
+++ b/.cursor/skills/tapps-continue-session/SKILL.md
@@ -16,10 +16,22 @@ Start work in a fresh context by assembling structured state.
    - **Preferred:** Call `tapps_session_start()`. Note `compaction_rehydration` if present.
    - **CLI fallback** (MCP unavailable): Run `uv run tapps-mcp doctor --quick` and read `.tapps-mcp.yaml` for project context. Proceed without blocking.
 
-2. **Load handoff (priority):** Read `.tapps-mcp/session-handoff.md`; else CLI `uv run tapps-mcp memory get --key session-handoff` (no `tapps_memory` MCP). Optional: `docs/NEXT_SESSION_PROMPT.md`, `docs/TAPPS_HANDOFF.md` (**Next:** section).
+2. **Load handoff (priority order).**
+   - Read `.tapps-mcp/session-handoff.md` if it exists — primary source.
+   - Else best-effort CLI (no `tapps_memory` MCP — removed v3.12.0): `uv run tapps-mcp memory get --key session-handoff` (brain offline or auth missing → skip).
+   - Optional supplements (only if present): `docs/NEXT_SESSION_PROMPT.md`, `docs/TAPPS_HANDOFF.md` (**Next:** section).
+   - **P0 fallback:** If **Next (P0)** is empty but **Open** has bullets, promote the first Open item as provisional P0 and flag it in the continue block.
+   - **Memory context:** Run `uv run tapps-mcp memory search --query "<P0 text or Linear id>"` when brain shell auth is available; skip silently otherwise.
 
-3. **Linear:** `get_issue(id=...)` when user or handoff names `TAP-####`; else use `linear-read` for lists (not raw `list_issues`).
+3. **Linear context.**
+   - If the user passed `TAP-####` (argument or handoff **Linear P0**), call `get_issue(id=...)`.
+   - For backlog/triage without a known id, invoke the `linear-read` skill — do not call raw `list_issues` (cache gate).
 
-4. **Emit ~15-line continue block:** P0, Done/Open/Blockers (compressed), Verify first, Success criterion. Warn if handoff **Updated** >7 days old.
+4. **Emit continue block (~15 lines max).** Present:
+   - **P0** — next action + Linear link if available (note if promoted from Open)
+   - **Done / Open / Blockers** — compressed from handoff
+   - **Verify first** — commands from handoff
+   - **Success criterion**
+   - **Stale warning** if handoff **Updated** is >7 days old or missing
 
-5. Proceed on P0; do not ask for a re-paste when handoff exists.
+5. **Proceed on P0.** Ask only if P0 is ambiguous; otherwise start using normal TAPPS workflow (`tapps_quick_check` after Python edits). Do **not** ask the user to re-paste prior context when handoff files exist.

--- a/.cursor/skills/tapps-handoff-session/SKILL.md
+++ b/.cursor/skills/tapps-handoff-session/SKILL.md
@@ -13,6 +13,8 @@ End the session with a durable handoff the next chat loads via `tapps-continue-s
 
 1. **Draft handoff (5–10 bullets):** Done, Open, Next (P0), Blockers, Verify commands, Success criterion (one line).
 
+**P0 gate.** Before writing the file: when **Open** has real items (not `none` / `- ...` placeholders), **Next (P0)** must name one concrete next action (prefer a Linear id). If P0 is missing, ask the user once — do not persist an incomplete handoff.
+
 2. **Persist (file is canonical).** Write or overwrite `.tapps-mcp/session-handoff.md`:
    - Set **Updated** to the real current UTC time: run `date -u +%Y-%m-%dT%H:%M:%SZ` and paste the output — never use a placeholder like `T00:00:00Z`.
    - Optionally add **Git:** `<short-sha>` when inside a git repo (`git rev-parse --short HEAD`).
@@ -42,11 +44,11 @@ End the session with a durable handoff the next chat loads via `tapps-continue-s
 - ...
 ```
 
-3. **Persist (brain mirror, best-effort).** File from step 2 is canonical. `tapps_memory` is not an MCP tool (removed v3.12.0) — CLI only:
+3. **Persist (brain mirror, best-effort).** The markdown file from step 2 is always canonical. `tapps_memory` is not an MCP tool (removed v3.12.0, TAP-1994) — use CLI only:
 
    | Priority | When | How |
    |----------|------|-----|
-   | 1 (CLI) | Brain HTTP + shell auth (`TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN` or `TAPPS_BRAIN_AUTH_TOKEN`) | `uv run tapps-mcp memory save --key session-handoff --tier context --tags handoff,cross-session --value "<plain-text bullets>"` |
+   | 1 (CLI) | Brain HTTP reachable; shell has `TAPPS_MCP_MEMORY_BRAIN_HTTP_URL` + `TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN` (or `TAPPS_BRAIN_AUTH_TOKEN` via direnv) | `uv run tapps-mcp memory save --key session-handoff --tier context --tags handoff,cross-session --value "<plain-text bullets>"` |
    | 2 (skip) | Brain offline or auth missing | Skip silently — `.tapps-mcp/session-handoff.md` is enough |
 
 4. **Close lifecycle.** Best-effort session closure:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Metrics storage default** ([TAP-3572](https://linear.app/tappscodingagents/issue/TAP-3572)) — unset `TAPPS_METRICS_STORAGE` now defaults to `dual`; `dual` mode always writes local JSONL even when brain is healthy. New `tapps-mcp audit-fleet --period 1d` command aggregates usage across bootstrapped projects. Generated MCP configs pin `TAPPS_METRICS_STORAGE=dual` ([TAP-3576](https://linear.app/tappscodingagents/issue/TAP-3576)).
+- **Session handoff hardening** ([TAP-3573](https://linear.app/tappscodingagents/issue/TAP-3573), [TAP-3574](https://linear.app/tappscodingagents/issue/TAP-3574), [TAP-3575](https://linear.app/tappscodingagents/issue/TAP-3575), [TAP-3581](https://linear.app/tappscodingagents/issue/TAP-3581)) — `tapps doctor` lints `.tapps-mcp/session-handoff.md` (P0 required when Open has items). Handoff/continue skills enforce P0 gate, memory search, and Open→P0 fallback with aligned Cursor/Claude bodies.
+- **Pipeline compliance hints** ([TAP-3578](https://linear.app/tappscodingagents/issue/TAP-3578), [TAP-3577](https://linear.app/tappscodingagents/issue/TAP-3577), [TAP-3579](https://linear.app/tappscodingagents/issue/TAP-3579)) — SessionStart hooks and `tapps_session_start` surface prior-session `usage_gaps`. Doctor recommends `linear_enforce_cache_gate: block` when warn-mode violations exceed 20/24h, and `install_git_hooks: true` when high engagement meets <70% 7d gate pass rate. New CLI: `tapps-mcp usage-gaps-hint`.
+- **Dashboard observability** ([TAP-3582](https://linear.app/tappscodingagents/issue/TAP-3582), [TAP-3583](https://linear.app/tappscodingagents/issue/TAP-3583)) — `tapps_dashboard` adds `docs_metrics` (DocsMCP tool breakdown from JSONL/brain) and `session_funnel` (handoff freshness, session_start/checklist ratios). `tapps_stats` includes a `docs_tools` slice when docs calls are present. Funnel gaps surface in `recommendations`.
+
 ## [3.12.16] - 2026-06-09
 
 Patch: version stamp sync; republish global CLIs after 3.12.15 install drift.

--- a/docs/operations/CONSUMER-REPO-BRAIN-WIRING.md
+++ b/docs/operations/CONSUMER-REPO-BRAIN-WIRING.md
@@ -288,6 +288,25 @@ add a project-specific block to `CLAUDE.md` or `.cursor/rules/`, keep it short:
 
 ---
 
+## High-traffic projects: Linear cache-gate block mode (TAP-3577)
+
+For repos with heavy `list_issues` usage (e.g. backlog triage bots), keep
+`linear_enforce_cache_gate: block` in `.tapps-mcp.yaml` so raw
+`mcp__plugin_linear_linear__list_issues` calls fail unless a matching
+`tapps_linear_snapshot_get` sentinel exists (<300s). Route agents through the
+`linear-read` skill.
+
+```yaml
+# .tapps-mcp.yaml excerpt — high-traffic consumer
+linear_enforce_cache_gate: block
+```
+
+After changing the mode, run `tapps-mcp upgrade --force` to rebake hook scripts.
+`tapps-mcp doctor` reports 24h cache-gate violations and recommends `block`
+when warn-mode misses exceed 20/day.
+
+---
+
 ## Deliverable (agent report template)
 
 Post a short report:

--- a/packages/tapps-core/src/tapps_core/metrics/brain_telemetry.py
+++ b/packages/tapps-core/src/tapps_core/metrics/brain_telemetry.py
@@ -31,17 +31,15 @@ _QUALITY_METRIC_EVENT = "quality_metric"
 def metrics_storage_mode() -> Literal["local", "dual", "brain"]:
     """Return metrics persistence mode.
 
-    When ``TAPPS_METRICS_STORAGE`` is unset: ``brain`` if the bridge passes a
-    health probe, else ``dual`` (JSONL write-fallback). Explicit env values
-    always win.
+    When ``TAPPS_METRICS_STORAGE`` is unset, defaults to ``dual`` (JSONL plus
+    best-effort brain telemetry). Explicit env values always win; invalid
+    values fall back to ``dual``.
     """
     raw = os.environ.get(_STORAGE_ENV, "").strip().lower()
     if raw in _VALID_STORAGE:
         return raw  # type: ignore[return-value]
     if raw:
         return "dual"
-    if brain_metrics_bridge_available():
-        return "brain"
     return "dual"
 
 

--- a/packages/tapps-core/src/tapps_core/metrics/dashboard.py
+++ b/packages/tapps-core/src/tapps_core/metrics/dashboard.py
@@ -29,6 +29,29 @@ from tapps_core.metrics.visualizer import AnalyticsVisualizer
 
 logger = structlog.get_logger(__name__)
 
+_DOCS_TOOL_PREFIX = "docs_"
+_DOCS_MCP_MARKER = "docs-mcp__"
+_HANDOFF_RELATIVE = Path(".tapps-mcp") / "session-handoff.md"
+_HANDOFF_STALE_DAYS = 7
+_FUNNEL_MIN_SESSION_STARTS = 3
+_CHECKLIST_RATIO_THRESHOLD = 0.5
+_HANDOFF_RATIO_THRESHOLD = 0.3
+
+
+def is_docs_tool(tool_name: str) -> bool:
+    """Return True when *tool_name* identifies a DocsMCP invocation."""
+    if tool_name.startswith(_DOCS_TOOL_PREFIX):
+        return True
+    return _DOCS_MCP_MARKER in tool_name
+
+
+def normalize_docs_tool_name(tool_name: str) -> str:
+    """Normalize MCP-prefixed DocsMCP tool names to ``docs_*`` form."""
+    if _DOCS_MCP_MARKER in tool_name:
+        idx = tool_name.find(_DOCS_MCP_MARKER)
+        return tool_name[idx + len(_DOCS_MCP_MARKER) :]
+    return tool_name
+
 
 class DashboardGenerator:
     """Generates metrics dashboards in multiple formats."""
@@ -83,6 +106,8 @@ class DashboardGenerator:
         all_sections = sections or [
             "summary",
             "tool_metrics",
+            "docs_metrics",
+            "session_funnel",
             "scoring_trends",
             "expert_metrics",
             "cache_metrics",
@@ -100,6 +125,8 @@ class DashboardGenerator:
         builders: dict[str, Any] = {
             "summary": lambda: self._build_summary(since=since),
             "tool_metrics": lambda: self._build_tool_metrics(since=since),
+            "docs_metrics": lambda: self._build_docs_metrics(since=since),
+            "session_funnel": lambda: self._build_session_funnel(since=since),
             "scoring_trends": lambda: self._build_scoring_trends(since=since),
             "expert_metrics": self._build_expert_metrics,
             "cache_metrics": self._build_cache_metrics,
@@ -109,7 +136,7 @@ class DashboardGenerator:
             "memory_metrics": self._build_memory_metrics,
             "alerts": self._build_alerts,
             "business_metrics": self._build_business_metrics,
-            "recommendations": self._build_recommendations,
+            "recommendations": lambda: self._build_recommendations(since=since),
         }
 
         for section in all_sections:
@@ -134,6 +161,8 @@ class DashboardGenerator:
 
         self._render_md_summary(json_data, lines)
         self._render_md_tool_metrics(json_data, lines)
+        self._render_md_docs_metrics(json_data, lines)
+        self._render_md_session_funnel(json_data, lines)
         self._render_md_alerts(json_data, lines)
         self._render_md_provider_stats(json_data, lines)
         self._render_md_coverage_metrics(json_data, lines)
@@ -166,6 +195,47 @@ class DashboardGenerator:
             chart = self._visualizer.create_bar_chart(chart_data, title="## Tool Usage")
             lines.append(chart)
             lines.append("")
+
+    def _render_md_docs_metrics(self, json_data: dict[str, Any], lines: list[str]) -> None:
+        """Append DocsMCP tool usage section lines to *lines*."""
+        if "docs_metrics" not in json_data:
+            return
+        docs = json_data["docs_metrics"]
+        if not docs.get("available"):
+            return
+        lines.append("## DocsMCP Tool Usage")
+        lines.append(f"- Total docs tool calls: {docs.get('total_calls', 0)}")
+        for tool in docs.get("tools", []):
+            if not isinstance(tool, dict):
+                continue
+            lines.append(
+                f"- **{tool.get('tool_name', '')}**: "
+                f"calls={tool.get('call_count', 0)}, "
+                f"success={tool.get('success_rate', 0):.0%}"
+            )
+        lines.append("")
+
+    def _render_md_session_funnel(self, json_data: dict[str, Any], lines: list[str]) -> None:
+        """Append continue-session funnel section lines to *lines*."""
+        if "session_funnel" not in json_data:
+            return
+        funnel = json_data["session_funnel"]
+        lines.append("## Session Handoff Funnel")
+        lines.append(f"- Session starts: {funnel.get('session_start_calls', 0)}")
+        lines.append(f"- Session ends (handoff proxy): {funnel.get('session_end_calls', 0)}")
+        lines.append(f"- Checklist completions: {funnel.get('checklist_calls', 0)}")
+        ratio = funnel.get("checklist_per_session_start")
+        if ratio is not None:
+            lines.append(f"- Checklist / session_start ratio: {ratio:.0%}")
+        handoff = funnel.get("handoff_file", {})
+        if handoff.get("exists"):
+            lines.append(
+                f"- Handoff file updated: {handoff.get('updated_at', 'unknown')} "
+                f"({handoff.get('age_days', '?')}d ago)"
+            )
+        else:
+            lines.append("- Handoff file: missing")
+        lines.append("")
 
     def _render_md_alerts(self, json_data: dict[str, Any], lines: list[str]) -> None:
         """Append active alerts section lines to *lines*."""
@@ -339,7 +409,103 @@ class DashboardGenerator:
                 "avg_score": b.avg_score,
             }
             for b in breakdowns
+            if not is_docs_tool(b.tool_name)
         ]
+
+    def _build_docs_metrics(
+        self,
+        *,
+        since: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Per-tool DocsMCP breakdown from execution metrics (JSONL + brain merge)."""
+        metrics = self._execution.get_metrics(since=since)
+        docs_metrics = [m for m in metrics if is_docs_tool(m.tool_name)]
+        if not docs_metrics:
+            return {"available": False, "total_calls": 0, "tools": []}
+
+        by_tool: dict[str, list[Any]] = {}
+        for metric in docs_metrics:
+            name = normalize_docs_tool_name(metric.tool_name)
+            by_tool.setdefault(name, []).append(metric)
+
+        tools: list[dict[str, Any]] = []
+        for name, tool_rows in sorted(by_tool.items()):
+            summary = ToolCallMetricsCollector._compute_summary(tool_rows)
+            tools.append(
+                {
+                    "tool_name": name,
+                    "call_count": summary.total_calls,
+                    "success_rate": summary.success_rate,
+                    "avg_duration_ms": summary.avg_duration_ms,
+                    "p95_duration_ms": summary.p95_duration_ms,
+                }
+            )
+
+        return {
+            "available": True,
+            "total_calls": len(docs_metrics),
+            "tools": tools,
+        }
+
+    @staticmethod
+    def _handoff_file_status(project_root: Path) -> dict[str, Any]:
+        """Return handoff file freshness metadata for funnel reporting."""
+        handoff_path = project_root / _HANDOFF_RELATIVE
+        if not handoff_path.is_file():
+            return {"exists": False, "path": str(_HANDOFF_RELATIVE)}
+
+        from datetime import UTC, timedelta
+        from datetime import datetime as dt
+
+        mtime = dt.fromtimestamp(handoff_path.stat().st_mtime, tz=UTC)
+        age = dt.now(tz=UTC) - mtime
+        return {
+            "exists": True,
+            "path": str(_HANDOFF_RELATIVE),
+            "updated_at": mtime.isoformat(),
+            "age_days": round(age.total_seconds() / 86_400, 2),
+            "stale": age > timedelta(days=_HANDOFF_STALE_DAYS),
+        }
+
+    def _build_session_funnel(
+        self,
+        *,
+        since: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Continue-session funnel: session_start/end/checklist ratios + handoff freshness."""
+        metrics = self._execution.get_metrics(since=since)
+        session_starts = sum(1 for m in metrics if m.tool_name == "tapps_session_start")
+        session_ends = sum(1 for m in metrics if m.tool_name == "tapps_session_end")
+        checklists = sum(1 for m in metrics if m.tool_name == "tapps_checklist")
+
+        checklist_ratio = (
+            round(checklists / session_starts, 4) if session_starts > 0 else None
+        )
+        handoff_ratio = round(session_ends / session_starts, 4) if session_starts > 0 else None
+
+        project_root = self._metrics_dir.parent.parent
+        handoff_file = self._handoff_file_status(project_root)
+
+        gaps: list[str] = []
+        if session_starts >= _FUNNEL_MIN_SESSION_STARTS:
+            if checklist_ratio is not None and checklist_ratio < _CHECKLIST_RATIO_THRESHOLD:
+                gaps.append("low_checklist_completion")
+            if handoff_ratio is not None and handoff_ratio < _HANDOFF_RATIO_THRESHOLD:
+                gaps.append("low_handoff_writes")
+        if session_starts > 0 and not handoff_file.get("exists"):
+            gaps.append("missing_handoff_file")
+        if handoff_file.get("stale"):
+            gaps.append("stale_handoff_file")
+
+        return {
+            "session_start_calls": session_starts,
+            "session_end_calls": session_ends,
+            "checklist_calls": checklists,
+            "checklist_per_session_start": checklist_ratio,
+            "handoff_per_session_start": handoff_ratio,
+            "handoff_file": handoff_file,
+            "gaps_detected": gaps,
+        }
 
     def _build_scoring_trends(
         self,
@@ -685,9 +851,13 @@ class DashboardGenerator:
     def _build_business_metrics(self) -> dict[str, Any]:
         return {"note": "Business metrics removed (EPIC-94)"}
 
-    def _build_recommendations(self) -> list[str]:
+    def _build_recommendations(
+        self,
+        *,
+        since: datetime | None = None,
+    ) -> list[str]:
         recommendations: list[str] = []
-        exec_summary = self._execution.get_summary()
+        exec_summary = self._execution.get_summary(since=since)
 
         if exec_summary.total_calls == 0:
             recommendations.append("Start using TappsMCP tools to begin collecting metrics.")
@@ -710,6 +880,31 @@ class DashboardGenerator:
             recommendations.append(
                 "RAG cache hit rate is low. Consider pre-warming the cache with common libraries."
             )
+
+        funnel = self._build_session_funnel(since=since)
+        for gap in funnel.get("gaps_detected", []):
+            if gap == "low_checklist_completion":
+                ratio = funnel.get("checklist_per_session_start")
+                pct = f"{ratio:.0%}" if ratio is not None else "low"
+                recommendations.append(
+                    f"Checklist completion rate is {pct} vs session starts — "
+                    "run tapps_checklist before declaring work complete."
+                )
+            elif gap == "low_handoff_writes":
+                recommendations.append(
+                    "Few tapps_session_end calls vs session starts — "
+                    "invoke /tapps-handoff-session before ending chats."
+                )
+            elif gap == "missing_handoff_file":
+                recommendations.append(
+                    "No `.tapps-mcp/session-handoff.md` — "
+                    "use /tapps-handoff-session so /tapps-continue-session can resume work."
+                )
+            elif gap == "stale_handoff_file":
+                recommendations.append(
+                    f"Handoff file is older than {_HANDOFF_STALE_DAYS} days — "
+                    "refresh via /tapps-handoff-session."
+                )
 
         if not recommendations:
             recommendations.append("All metrics look healthy. Keep up the good work!")

--- a/packages/tapps-core/src/tapps_core/metrics/execution_metrics.py
+++ b/packages/tapps-core/src/tapps_core/metrics/execution_metrics.py
@@ -98,7 +98,6 @@ class ToolCallMetricsCollector:
     def record_call(self, metric: ToolCallMetric) -> None:
         """Record a tool call metric to buffer and disk."""
         from tapps_core.metrics.brain_telemetry import (
-            brain_metrics_bridge_available,
             emit_quality_metric_event,
             metrics_storage_mode,
         )
@@ -106,9 +105,7 @@ class ToolCallMetricsCollector:
         with self._write_lock:
             self._buffer.append(metric)
             mode = metrics_storage_mode()
-            if mode == "local" or (
-                mode == "dual" and not brain_metrics_bridge_available()
-            ):
+            if mode in ("local", "dual"):
                 self._append_to_file(metric)
         emit_quality_metric_event(metric)
 

--- a/packages/tapps-core/tests/unit/test_dashboard.py
+++ b/packages/tapps-core/tests/unit/test_dashboard.py
@@ -4,7 +4,17 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from tapps_core.metrics.dashboard import DashboardGenerator
+from tapps_core.metrics.dashboard import (
+    DashboardGenerator,
+    is_docs_tool,
+    normalize_docs_tool_name,
+)
+
+
+@pytest.fixture(autouse=True)
+def _local_metrics_storage(monkeypatch):
+    """Keep dashboard tests isolated from live brain telemetry."""
+    monkeypatch.setenv("TAPPS_METRICS_STORAGE", "local")
 
 
 @pytest.fixture
@@ -202,3 +212,116 @@ class TestDashboardGenerator:
         assert cov["files_scored"] >= 1
         assert cov["files_gated"] >= 1
         assert "tapps_score_file" in cov["core_tools_used"]
+
+
+class TestDocsMetrics:
+    def test_is_docs_tool(self) -> None:
+        assert is_docs_tool("docs_validate_linear_issue")
+        assert is_docs_tool("mcp__docs-mcp__docs_generate_story")
+        assert not is_docs_tool("tapps_session_start")
+
+    def test_normalize_docs_tool_name(self) -> None:
+        assert normalize_docs_tool_name("mcp__docs-mcp__docs_pdf") == "docs_pdf"
+        assert normalize_docs_tool_name("docs_check_drift") == "docs_check_drift"
+
+    def test_docs_metrics_aggregation(self, metrics_dir) -> None:
+        gen = DashboardGenerator(metrics_dir)
+        now = datetime.now(tz=UTC)
+        gen._execution.record(
+            "mcp__docs-mcp__docs_validate_linear_issue",
+            now,
+            now + timedelta(milliseconds=80),
+            status="success",
+        )
+        gen._execution.record(
+            "docs_generate_story",
+            now,
+            now + timedelta(milliseconds=120),
+            status="failed",
+            error_code="validation",
+        )
+        data = gen.generate_json_dashboard(sections=["docs_metrics"])
+        docs = data["docs_metrics"]
+        assert docs["available"] is True
+        assert docs["total_calls"] == 2
+        names = {t["tool_name"] for t in docs["tools"]}
+        assert names == {"docs_validate_linear_issue", "docs_generate_story"}
+        by_name = {t["tool_name"]: t for t in docs["tools"]}
+        assert by_name["docs_validate_linear_issue"]["success_rate"] == 1.0
+        assert by_name["docs_generate_story"]["success_rate"] == 0.0
+
+    def test_tool_metrics_excludes_docs_tools(self, metrics_dir) -> None:
+        gen = DashboardGenerator(metrics_dir)
+        now = datetime.now(tz=UTC)
+        gen._execution.record(
+            "docs_validate_linear_issue",
+            now,
+            now + timedelta(milliseconds=50),
+            status="success",
+        )
+        gen._execution.record(
+            "tapps_score_file",
+            now,
+            now + timedelta(milliseconds=50),
+            status="success",
+            score=90.0,
+        )
+        data = gen.generate_json_dashboard(sections=["tool_metrics"])
+        names = {t["tool_name"] for t in data["tool_metrics"]}
+        assert "docs_validate_linear_issue" not in names
+        assert "tapps_score_file" in names
+
+
+class TestSessionFunnel:
+    def test_session_funnel_ratios(self, metrics_dir) -> None:
+        gen = DashboardGenerator(metrics_dir)
+        now = datetime.now(tz=UTC)
+        for _ in range(4):
+            gen._execution.record(
+                "tapps_session_start",
+                now,
+                now + timedelta(milliseconds=10),
+                status="success",
+            )
+        gen._execution.record(
+            "tapps_session_end",
+            now,
+            now + timedelta(milliseconds=10),
+            status="success",
+        )
+        data = gen.generate_json_dashboard(sections=["session_funnel"])
+        funnel = data["session_funnel"]
+        assert funnel["session_start_calls"] == 4
+        assert funnel["session_end_calls"] == 1
+        assert funnel["checklist_calls"] == 0
+        assert funnel["handoff_per_session_start"] == 0.25
+        assert "low_handoff_writes" in funnel["gaps_detected"]
+
+    def test_handoff_file_freshness(self, metrics_dir) -> None:
+        project_root = metrics_dir.parent.parent
+        handoff_dir = project_root / ".tapps-mcp"
+        handoff_dir.mkdir(parents=True, exist_ok=True)
+        handoff_path = handoff_dir / "session-handoff.md"
+        handoff_path.write_text("# Handoff\n", encoding="utf-8")
+
+        gen = DashboardGenerator(metrics_dir)
+        data = gen.generate_json_dashboard(sections=["session_funnel"])
+        handoff = data["session_funnel"]["handoff_file"]
+        assert handoff["exists"] is True
+        assert handoff["stale"] is False
+        assert handoff["age_days"] >= 0
+
+    def test_funnel_recommendations(self, metrics_dir) -> None:
+        gen = DashboardGenerator(metrics_dir)
+        now = datetime.now(tz=UTC)
+        for _ in range(5):
+            gen._execution.record(
+                "tapps_session_start",
+                now,
+                now + timedelta(milliseconds=10),
+                status="success",
+            )
+        data = gen.generate_json_dashboard(sections=["recommendations"])
+        recs = data["recommendations"]
+        assert any("handoff" in r.lower() for r in recs)
+        assert any("checklist" in r.lower() for r in recs)

--- a/packages/tapps-core/tests/unit/test_execution_metrics.py
+++ b/packages/tapps-core/tests/unit/test_execution_metrics.py
@@ -12,6 +12,12 @@ from tapps_core.metrics.execution_metrics import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _local_metrics_storage(monkeypatch):
+    """Keep collector query tests isolated from live brain telemetry."""
+    monkeypatch.setenv("TAPPS_METRICS_STORAGE", "local")
+
+
 @pytest.fixture
 def metrics_dir(tmp_path):
     d = tmp_path / "metrics"
@@ -186,8 +192,9 @@ class TestToolCallMetricsCollector:
 class TestBrainTelemetryDualWrite:
     @pytest.mark.asyncio
     async def test_record_call_emits_quality_metric_when_loop_running(
-        self, collector: ToolCallMetricsCollector
+        self, collector: ToolCallMetricsCollector, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setenv("TAPPS_METRICS_STORAGE", "dual")
         mock_bridge = MagicMock()
         mock_bridge.record_kg_event = AsyncMock(return_value={"recorded": True})
         mock_bridge.save = AsyncMock(return_value={"success": True})
@@ -225,8 +232,9 @@ class TestBrainTelemetryDualWrite:
         now = datetime.now(tz=UTC)
         collector.record("tapps_score_file", now, now + timedelta(milliseconds=5), score=90.0)
         assert list(metrics_dir.glob("tool_calls_*.jsonl")) == []
-        summary = collector.get_summary()
-        assert summary.total_calls == 1
+        recent = collector.get_recent(limit=10)
+        assert len(recent) == 1
+        assert recent[0].tool_name == "tapps_score_file"
 
     @pytest.mark.asyncio
     async def test_load_tool_call_metrics_from_brain_query_events(self):
@@ -305,7 +313,7 @@ class TestBrainTelemetryDualWrite:
         assert len(metrics) == 1
         assert metrics[0].call_id == "brain-read"
 
-    def test_dual_mode_skips_jsonl_write_when_brain_healthy(self, metrics_dir, monkeypatch):
+    def test_dual_mode_writes_jsonl_when_brain_healthy(self, metrics_dir, monkeypatch):
         monkeypatch.setenv("TAPPS_METRICS_STORAGE", "dual")
         collector = ToolCallMetricsCollector(metrics_dir)
         now = datetime.now(tz=UTC)
@@ -314,9 +322,9 @@ class TestBrainTelemetryDualWrite:
             return_value=True,
         ):
             collector.record("tapps_score_file", now, now + timedelta(milliseconds=5), score=90.0)
-        assert list(metrics_dir.glob("tool_calls_*.jsonl")) == []
+        assert list(metrics_dir.glob("tool_calls_*.jsonl"))
 
-    def test_default_mode_brain_when_bridge_healthy(self, monkeypatch):
+    def test_default_mode_dual_when_unset(self, monkeypatch):
         monkeypatch.delenv("TAPPS_METRICS_STORAGE", raising=False)
         from tapps_core.metrics.brain_telemetry import metrics_storage_mode
 
@@ -324,7 +332,7 @@ class TestBrainTelemetryDualWrite:
             "tapps_core.metrics.brain_telemetry.brain_metrics_bridge_available",
             return_value=True,
         ):
-            assert metrics_storage_mode() == "brain"
+            assert metrics_storage_mode() == "dual"
 
     def test_default_mode_dual_when_bridge_unhealthy(self, monkeypatch):
         monkeypatch.delenv("TAPPS_METRICS_STORAGE", raising=False)
@@ -336,8 +344,24 @@ class TestBrainTelemetryDualWrite:
         ):
             assert metrics_storage_mode() == "dual"
 
-    def test_default_brain_skips_disk_write(self, metrics_dir, monkeypatch):
+    def test_default_dual_writes_disk(self, metrics_dir, monkeypatch):
         monkeypatch.delenv("TAPPS_METRICS_STORAGE", raising=False)
+        collector = ToolCallMetricsCollector(metrics_dir)
+        now = datetime.now(tz=UTC)
+        with patch(
+            "tapps_core.metrics.brain_telemetry.brain_metrics_bridge_available",
+            return_value=True,
+        ):
+            collector.record(
+                "tapps_score_file",
+                now,
+                now + timedelta(milliseconds=5),
+                score=90.0,
+            )
+        assert list(metrics_dir.glob("tool_calls_*.jsonl"))
+
+    def test_brain_mode_skips_disk_write(self, metrics_dir, monkeypatch):
+        monkeypatch.setenv("TAPPS_METRICS_STORAGE", "brain")
         collector = ToolCallMetricsCollector(metrics_dir)
         now = datetime.now(tz=UTC)
         with patch(

--- a/packages/tapps-mcp/docs/state-files.md
+++ b/packages/tapps-mcp/docs/state-files.md
@@ -38,6 +38,7 @@ unknown files are present and leaves them alone.
 | Path | Writer | Purpose |
 |---|---|---|
 | `.tapps-mcp/session-handoff.md` | `tapps-handoff-session` skill (or manual) | Cross-session continue block; read by `tapps-continue-session` on next chat. Brain mirror via `tapps-mcp memory save --key session-handoff`. |
+| `.tapps-mcp/metrics/tool_calls_*.jsonl` | TappsMCP tool handlers | Daily execution metrics (local leg of `dual` storage). Feeds `tapps_dashboard` / `tapps_stats` including `docs_metrics` and `session_funnel` sections. |
 | `.tapps-mcp/session-capture.json` | `tapps-memory-capture.sh` Stop hook (legacy) | Session summary written at session end; read at next session start. Superseded by `call_memory_index_session_start` (TAP-1999) but kept for backward compat. |
 | `.tapps-mcp/.linear-validate-sentinel` | `tapps-post-docs-validate.sh` | Confirms `docs_validate_linear_issue` ran before `save_issue` |
 | `.tapps-mcp/.linear-snapshot-sentinel-*` | `tapps-post-linear-snapshot-get.sh` | Per-key unlock for Linear list-issues cache gate |
@@ -45,3 +46,19 @@ unknown files are present and leaves them alone.
 | `.tapps-mcp/.cache-gate-violations.jsonl` | `tapps-pre-linear-list.sh` | Linear cache-gate violation log |
 | `.tapps-mcp/.push-test-log` | `.githooks/pre-push` | Tier-2 background test results |
 | `.tapps-mcp/.validation-marker` | `tapps_validate_changed` | Marks a successful validation run |
+
+## Session handoff funnel (dashboard)
+
+`tapps_dashboard` section `session_funnel` (and matching recommendations) reports:
+
+| Signal | Source | Meaning |
+|---|---|---|
+| `session_start_calls` | execution metrics JSONL (+ brain merge) | Sessions bootstrapped via `tapps_session_start` (proxy for continue-session volume). |
+| `session_end_calls` | execution metrics | Handoff writes proxy — `/tapps-handoff-session` calls `tapps_session_end`. |
+| `checklist_calls` | execution metrics | Pipeline completion proxy — `tapps_checklist` invocations. |
+| `checklist_per_session_start` | derived ratio | Drop-off when many sessions start but few run checklist. |
+| `handoff_file.updated_at` / `age_days` | `.tapps-mcp/session-handoff.md` mtime | Last persisted handoff; `stale` when older than 7 days. |
+
+When gaps are detected (`low_checklist_completion`, `low_handoff_writes`, `missing_handoff_file`, `stale_handoff_file`), the dashboard `recommendations` section suggests `/tapps-handoff-session` or `tapps_checklist` as appropriate.
+
+DocsMCP tool calls appear in the separate `docs_metrics` dashboard section (and `docs_tools` slice on `tapps_stats` when present), aggregated from the same JSONL/brain read path with `docs_*` tool names normalized from `mcp__docs-mcp__*` prefixes.

--- a/packages/tapps-mcp/src/tapps_mcp/cli.py
+++ b/packages/tapps-mcp/src/tapps_mcp/cli.py
@@ -337,6 +337,88 @@ def doctor(project_root: str, quick: bool) -> None:
         raise SystemExit(1)
 
 
+@main.command("usage-gaps-hint")
+@click.option(
+    "--project-root",
+    default=".",
+    help="Project root directory.",
+)
+def usage_gaps_hint_cmd(project_root: str) -> None:
+    """Print a one-line prior-session pipeline reminder for SessionStart hooks (TAP-3578)."""
+    from pathlib import Path
+
+    from tapps_mcp.tools.usage import format_session_start_gap_hint
+
+    hint = format_session_start_gap_hint(Path(project_root).resolve())
+    if hint:
+        click.echo(hint)
+
+
+@main.command("audit-fleet")
+@click.option(
+    "--period",
+    type=click.Choice(["1d", "7d", "30d"]),
+    default="1d",
+    show_default=True,
+    help="Trailing window for tool-call and pipeline metrics.",
+)
+@click.option(
+    "--roots",
+    default="",
+    help="Comma-separated project roots (default: TAPPS_FLEET_ROOTS or scan parent dir).",
+)
+@click.option(
+    "--scan-parent",
+    default=".",
+    help="When --roots is empty, scan immediate children of this directory.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "markdown"]),
+    default="json",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--no-brain",
+    is_flag=True,
+    default=False,
+    help="Skip brain telemetry merge (local JSONL only).",
+)
+def audit_fleet_cmd(
+    period: str,
+    roots: str,
+    scan_parent: str,
+    output_format: str,
+    no_brain: bool,
+) -> None:
+    """Audit TAPPS usage across bootstrapped projects (local JSONL + brain merge).
+
+    Discovers projects via ``--roots``, ``TAPPS_FLEET_ROOTS``, or by scanning
+    ``--scan-parent`` for ``.tapps-mcp.yaml`` markers.
+    """
+    import json
+    from pathlib import Path
+
+    from tapps_mcp.tools.fleet_audit import format_fleet_audit_markdown, run_fleet_audit
+
+    explicit: list[Path] | None = None
+    if roots.strip():
+        explicit = [Path(p.strip()) for p in roots.split(",") if p.strip()]
+
+    report = run_fleet_audit(
+        period=period,
+        roots=explicit,
+        scan_parent=Path(scan_parent),
+        include_brain=not no_brain,
+    )
+    if output_format == "markdown":
+        click.echo(format_fleet_audit_markdown(report))
+    else:
+        click.echo(json.dumps(report, indent=2))
+
+
 @main.command("check-agents-md-stamp")
 @click.option(
     "--project-root",

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -1251,10 +1251,16 @@ def _handoff_skill_content_ok(skill_name: str, content: str) -> bool:
     if skill_name == "tapps-handoff-session":
         if "tapps_session_end" not in lowered:
             return False
+        if "p0 gate" not in lowered:
+            return False
         # Brain mirror must route through CLI, not removed MCP tool.
         return "tapps-mcp memory save" in lowered
     if skill_name == "tapps-continue-session":
-        return "tapps_session_start" in lowered
+        return (
+            "tapps_session_start" in lowered
+            and "memory search" in lowered
+            and "p0 fallback" in lowered
+        )
     return False
 
 
@@ -1296,6 +1302,152 @@ def check_session_handoff_skills(project_root: Path) -> CheckResult:
         "session handoff skills",
         True,
         f"tapps-handoff-session + tapps-continue-session present on: {hosts}",
+    )
+
+
+def check_session_handoff_schema(project_root: Path) -> CheckResult:
+    """Lint ``.tapps-mcp/session-handoff.md`` for P0/Open consistency (TAP-3573)."""
+    from tapps_mcp.tools.handoff_schema import handoff_path, load_and_lint_handoff
+
+    path = handoff_path(project_root)
+    if not path.is_file():
+        return CheckResult(
+            "session handoff schema",
+            True,
+            "No session-handoff.md (optional until handoff)",
+        )
+
+    _doc, lint = load_and_lint_handoff(project_root)
+    if not lint.ok:
+        return CheckResult(
+            "session handoff schema",
+            False,
+            "; ".join(lint.errors),
+            "Fix `.tapps-mcp/session-handoff.md` — add Next (P0) when Open has items, "
+            "or invoke `/tapps-handoff-session` with a complete handoff.",
+        )
+
+    if lint.warnings:
+        rel = path.name
+        try:
+            rel = str(path.relative_to(project_root.resolve()))
+        except ValueError:
+            pass
+        return CheckResult(
+            "session handoff schema",
+            True,
+            f"Handoff present with warnings: {'; '.join(lint.warnings)}",
+            rel,
+        )
+
+    return CheckResult(
+        "session handoff schema",
+        True,
+        "session-handoff.md schema OK",
+    )
+
+
+_CACHE_GATE_BLOCK_HINT_THRESHOLD = 20
+
+
+def check_cache_gate_block_hint(project_root: Path) -> CheckResult:
+    """Recommend ``linear_enforce_cache_gate: block`` on high-traffic projects (TAP-3577)."""
+    from tapps_core.config.settings import load_settings
+
+    try:
+        settings = load_settings(project_root=project_root)
+        resolved_mode = settings.linear_enforce_cache_gate_resolved()
+    except Exception:
+        resolved_mode = _detect_cache_gate_mode(project_root)
+
+    if resolved_mode == "block":
+        return CheckResult(
+            "Linear cache-gate promotion",
+            True,
+            "linear_enforce_cache_gate is block",
+        )
+
+    viol_24h = _count_cache_gate_violations_24h(project_root)
+    if resolved_mode == "warn" and viol_24h >= _CACHE_GATE_BLOCK_HINT_THRESHOLD:
+        return CheckResult(
+            "Linear cache-gate promotion",
+            True,
+            f"{viol_24h} cache-gate misses in 24h while mode=warn",
+            "Set linear_enforce_cache_gate: block in .tapps-mcp.yaml and run "
+            "tapps-mcp upgrade --force. Route multi-issue reads through the linear-read skill.",
+        )
+
+    if resolved_mode == "off" and viol_24h > 0:
+        return CheckResult(
+            "Linear cache-gate promotion",
+            True,
+            f"{viol_24h} raw list_issues gate misses logged while mode=off",
+            "Enable linear_enforce_cache_gate: warn (or block for high-traffic repos) "
+            "in .tapps-mcp.yaml, then tapps-mcp upgrade --force.",
+        )
+
+    return CheckResult(
+        "Linear cache-gate promotion",
+        True,
+        f"mode={resolved_mode}, {viol_24h} gate_miss violations in 24h",
+    )
+
+
+def check_install_git_hooks_hint(project_root: Path) -> CheckResult:
+    """Recommend ``install_git_hooks: true`` when high engagement + low gate pass (TAP-3579)."""
+    from tapps_core.config.settings import load_settings
+    from tapps_mcp.tools.loop_metrics import compute_gate_pass_rate_7d
+
+    try:
+        settings = load_settings(project_root=project_root)
+        if settings.install_git_hooks:
+            return CheckResult(
+                "Git pre-commit hook",
+                True,
+                "install_git_hooks is enabled",
+            )
+    except Exception:
+        settings = None
+
+    hook_path = project_root / ".githooks" / "pre-commit"
+    if hook_path.is_file():
+        return CheckResult(
+            "Git pre-commit hook",
+            True,
+            ".githooks/pre-commit present",
+        )
+
+    engagement = _read_engagement_level(project_root) or "medium"
+    if engagement != "high":
+        return CheckResult(
+            "Git pre-commit hook",
+            True,
+            f"optional at llm_engagement_level={engagement}",
+        )
+
+    gate_pass = compute_gate_pass_rate_7d(project_root)
+    if gate_pass is None:
+        return CheckResult(
+            "Git pre-commit hook",
+            True,
+            "insufficient 7d gate metrics for recommendation",
+        )
+
+    if gate_pass < 0.70:
+        pct = round(gate_pass * 100)
+        return CheckResult(
+            "Git pre-commit hook",
+            True,
+            f"7d gate pass rate {pct}% (<70%) at high engagement",
+            "Set install_git_hooks: true in .tapps-mcp.yaml and run tapps-mcp upgrade "
+            "to enforce validate-changed on git commit.",
+        )
+
+    pct = round(gate_pass * 100)
+    return CheckResult(
+        "Git pre-commit hook",
+        True,
+        f"7d gate pass rate {pct}% — install_git_hooks not required",
     )
 
 
@@ -3222,6 +3374,9 @@ def _collect_checks(root: Path, *, quick: bool = False) -> list[CheckResult]:
     checks.append(check_finish_task_skill(root))
     checks.append(check_tapps_memory_skill(root))
     checks.append(check_session_handoff_skills(root))
+    checks.append(check_session_handoff_schema(root))
+    checks.append(check_cache_gate_block_hint(root))
+    checks.append(check_install_git_hooks_hint(root))
     checks.append(check_continuous_learning_v2_skill(root))
     checks.append(check_pretooluse_matchers(root))
     checks.append(check_agents_md(root))

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
@@ -469,6 +469,8 @@ def _build_server_entry(
         # tools on tapps-brain v3.20.0+). Operator-overridable knob — export
         # TAPPS_BRAIN_PROFILE=operator for a maintenance session.
         "TAPPS_BRAIN_PROFILE": BRAIN_PROFILE_SERVER,
+        # TAP-3572: dual-write keeps local JSONL for fleet audit even when brain is up.
+        "TAPPS_METRICS_STORAGE": "dual",
     }
     project_id = _derive_brain_project_id(project_root)
     if project_id:

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_hook_templates.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_hook_templates.py
@@ -63,6 +63,17 @@ fi
 echo "REQUIRED: Call tapps_session_start() NOW as your first action."
 echo "This initializes project context for all TappsMCP quality tools."
 echo "Tools called without session_start will have degraded accuracy."
+# TAP-3578: Prior-session pipeline gap reminder from disk telemetry.
+PROJECT="${TAPPS_PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-.}}"
+USAGE_HINT=""
+if command -v tapps-mcp >/dev/null 2>&1; then
+  USAGE_HINT=$(tapps-mcp usage-gaps-hint --project-root "$PROJECT" 2>/dev/null || true)
+elif command -v uv >/dev/null 2>&1 && [ -f "$PROJECT/pyproject.toml" ]; then
+  USAGE_HINT=$(cd "$PROJECT" && uv run tapps-mcp usage-gaps-hint 2>/dev/null || true)
+fi
+if [ -n "$USAGE_HINT" ]; then
+  echo "TappsMCP prior-session reminder: $USAGE_HINT"
+fi
 exit 0
 """,
     "tapps-session-compact.sh": """\
@@ -73,6 +84,13 @@ INPUT=$(cat)
 echo "[TappsMCP] Context was compacted — re-injecting TappsMCP awareness."
 echo "Remember: use tapps_quick_check after editing Python files."
 echo "Run tapps_validate_changed before declaring work complete."
+PROJECT="${TAPPS_PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-.}}"
+if command -v tapps-mcp >/dev/null 2>&1; then
+  USAGE_HINT=$(tapps-mcp usage-gaps-hint --project-root "$PROJECT" 2>/dev/null || true)
+  if [ -n "$USAGE_HINT" ]; then
+    echo "TappsMCP prior-session reminder: $USAGE_HINT"
+  fi
+fi
 exit 0
 """,
     "tapps-post-edit.sh": """\
@@ -703,6 +721,11 @@ $null = $input | Out-Null
 Write-Output "REQUIRED: Call tapps_session_start() NOW as your first action."
 Write-Output "This initializes project context for all TappsMCP quality tools."
 Write-Output "Tools called without session_start will have degraded accuracy."
+$proj = if ($env:TAPPS_PROJECT_ROOT) { $env:TAPPS_PROJECT_ROOT } elseif ($env:CLAUDE_PROJECT_DIR) { $env:CLAUDE_PROJECT_DIR } else { "." }
+if (Get-Command tapps-mcp -ErrorAction SilentlyContinue) {
+  $hint = & tapps-mcp usage-gaps-hint --project-root $proj 2>$null
+  if ($hint) { Write-Output "TappsMCP prior-session reminder: $hint" }
+}
 exit 0
 """,
     "tapps-session-compact.ps1": """\
@@ -712,6 +735,11 @@ $null = $input | Out-Null
 Write-Output "[TappsMCP] Context was compacted - re-injecting TappsMCP awareness."
 Write-Output "Remember: use tapps_quick_check after editing Python files."
 Write-Output "Run tapps_validate_changed before declaring work complete."
+$proj = if ($env:TAPPS_PROJECT_ROOT) { $env:TAPPS_PROJECT_ROOT } elseif ($env:CLAUDE_PROJECT_DIR) { $env:CLAUDE_PROJECT_DIR } else { "." }
+if (Get-Command tapps-mcp -ErrorAction SilentlyContinue) {
+  $hint = & tapps-mcp usage-gaps-hint --project-root $proj 2>$null
+  if ($hint) { Write-Output "TappsMCP prior-session reminder: $hint" }
+}
 exit 0
 """,
     "tapps-post-edit.ps1": """\

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
@@ -15,6 +15,65 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 # ---------------------------------------------------------------------------
+# Shared session-transfer bodies (TAP-3574/3575/3581)
+# ---------------------------------------------------------------------------
+
+_HANDOFF_MARKDOWN_SHAPE = """\
+```markdown
+# Session handoff
+**Updated:** <ISO-8601 UTC from date -u>
+**Git:** <short-sha or omit>
+**Linear P0:** <TAP-#### or none>
+
+## Done
+- ...
+
+## Open
+- ...
+
+## Next (P0)
+- ...
+
+## Blockers
+- ...
+
+## Verify
+- ...
+
+## Success criterion
+- ...
+```"""
+
+_HANDOFF_P0_GATE = """\
+**P0 gate.** Before writing the file: when **Open** has real items (not `none` / `- ...` placeholders), **Next (P0)** must name one concrete next action (prefer a Linear id). If P0 is missing, ask the user once — do not persist an incomplete handoff."""
+
+_HANDOFF_BRAIN_MIRROR = """\
+3. **Persist (brain mirror, best-effort).** The markdown file from step 2 is always canonical. `tapps_memory` is not an MCP tool (removed v3.12.0, TAP-1994) — use CLI only:
+
+   | Priority | When | How |
+   |----------|------|-----|
+   | 1 (CLI) | Brain HTTP reachable; shell has `TAPPS_MCP_MEMORY_BRAIN_HTTP_URL` + `TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN` (or `TAPPS_BRAIN_AUTH_TOKEN` via direnv) | `uv run tapps-mcp memory save --key session-handoff --tier context --tags handoff,cross-session --value "<plain-text bullets>"` |
+   | 2 (skip) | Brain offline or auth missing | Skip silently — `.tapps-mcp/session-handoff.md` is enough |"""
+
+_CONTINUE_LOAD_AND_CONTEXT = """\
+2. **Load handoff (priority order).**
+   - Read `.tapps-mcp/session-handoff.md` if it exists — primary source.
+   - Else best-effort CLI (no `tapps_memory` MCP — removed v3.12.0): `uv run tapps-mcp memory get --key session-handoff` (brain offline or auth missing → skip).
+   - Optional supplements (only if present): `docs/NEXT_SESSION_PROMPT.md`, `docs/TAPPS_HANDOFF.md` (**Next:** section).
+   - **P0 fallback:** If **Next (P0)** is empty but **Open** has bullets, promote the first Open item as provisional P0 and flag it in the continue block.
+   - **Memory context:** Run `uv run tapps-mcp memory search --query "<P0 text or Linear id>"` when brain shell auth is available; skip silently otherwise."""
+
+_CONTINUE_EMIT_AND_PROCEED = """\
+4. **Emit continue block (~15 lines max).** Present:
+   - **P0** — next action + Linear link if available (note if promoted from Open)
+   - **Done / Open / Blockers** — compressed from handoff
+   - **Verify first** — commands from handoff
+   - **Success criterion**
+   - **Stale warning** if handoff **Updated** is >7 days old or missing
+
+5. **Proceed on P0.** Ask only if P0 is ambiguous; otherwise start using normal TAPPS workflow (`tapps_quick_check` after Python edits). Do **not** ask the user to re-paste prior context when handoff files exist."""
+
+# ---------------------------------------------------------------------------
 # Skills templates (Story 12.8)
 # ---------------------------------------------------------------------------
 
@@ -129,42 +188,16 @@ End the session with a durable handoff the next chat can load via `/tapps-contin
    - **Verify** — commands to run first in the next session
    - **Success criterion** — one line
 
+""" + _HANDOFF_P0_GATE + """
+
 2. **Persist (file is canonical).** Write or overwrite `.tapps-mcp/session-handoff.md` using this shape:
    - Set **Updated** to the real current UTC time: run `date -u +%Y-%m-%dT%H:%M:%SZ` and paste the output — never use a placeholder like `T00:00:00Z`.
    - Optionally add **Git:** `<short-sha>` when inside a git repo (`git rev-parse --short HEAD`).
    - Claude Code (Bash-only): `mkdir -p .tapps-mcp && cat > .tapps-mcp/session-handoff.md <<'EOF'` … `EOF`.
 
-```markdown
-# Session handoff
-**Updated:** <ISO-8601 UTC from date -u>
-**Git:** <short-sha or omit>
-**Linear P0:** <TAP-#### or none>
+""" + _HANDOFF_MARKDOWN_SHAPE + """
 
-## Done
-- ...
-
-## Open
-- ...
-
-## Next (P0)
-- ...
-
-## Blockers
-- ...
-
-## Verify
-- ...
-
-## Success criterion
-- ...
-```
-
-3. **Persist (brain mirror, best-effort).** The markdown file from step 2 is always canonical. `tapps_memory` is not an MCP tool (removed v3.12.0, TAP-1994) — use CLI only:
-
-   | Priority | When | How |
-   |----------|------|-----|
-   | 1 (CLI) | Brain HTTP reachable; shell has `TAPPS_MCP_MEMORY_BRAIN_HTTP_URL` + `TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN` (or `TAPPS_BRAIN_AUTH_TOKEN` via direnv) | `uv run tapps-mcp memory save --key session-handoff --tier context --tags handoff,cross-session --value "<plain-text bullets>"` |
-   | 2 (skip) | Brain offline or auth missing | Skip silently — `.tapps-mcp/session-handoff.md` is enough |
+""" + _HANDOFF_BRAIN_MIRROR + """
 
 4. **Close lifecycle.** Best-effort session closure:
    - **Preferred:** `mcp__tapps-mcp__tapps_session_end()`
@@ -193,27 +226,13 @@ Start work in a fresh context window by assembling structured state — not a us
    - **Preferred:** Call `mcp__tapps-mcp__tapps_session_start()`. If `data.compaction_rehydration` is present, summarize it in one sentence.
    - **CLI fallback** (MCP unavailable): Run `uv run tapps-mcp doctor --quick` and read `.tapps-mcp.yaml` for project context (quality preset, brain URL, engagement). Proceed without blocking.
 
-2. **Load handoff (priority order).**
-   - Read `.tapps-mcp/session-handoff.md` if it exists — primary source.
-   - Else best-effort CLI (no `tapps_memory` MCP — removed v3.12.0): `uv run tapps-mcp memory get --key session-handoff` (brain offline or auth missing → skip).
-   - Optional supplements (only if present, do not require):
-     - `docs/NEXT_SESSION_PROMPT.md` — short user-maintained prompt
-     - `docs/TAPPS_HANDOFF.md` — scan for `**Next:**` or the latest stage section
+""" + _CONTINUE_LOAD_AND_CONTEXT + """
 
 3. **Linear context.**
    - If the user passed `TAP-####` (argument or in handoff **Linear P0**), call `mcp__plugin_linear_linear__get_issue(id=...)`.
    - For backlog/triage without a known id, invoke the `linear-read` skill instead of raw `list_issues` (do not call `list_issues` directly — cache gate).
 
-4. **Emit continue block (~15 lines max).** Present:
-   - **P0** — next action + Linear link if available
-   - **Done / Open / Blockers** — from handoff (compressed)
-   - **Verify first** — commands from handoff
-   - **Success criterion**
-   - **Stale warning** if handoff **Updated** is >7 days old
-
-5. **Confirm and proceed.** Ask only if P0 is ambiguous; otherwise start on P0 using normal TAPPS workflow (`tapps_quick_check` after Python edits, etc.).
-
-Do **not** ask the user to re-paste prior context when handoff files exist.
+""" + _CONTINUE_EMIT_AND_PROCEED + """
 """,
     "tapps-report": """\
 ---
@@ -1203,41 +1222,15 @@ End the session with a durable handoff the next chat loads via `tapps-continue-s
 
 1. **Draft handoff (5–10 bullets):** Done, Open, Next (P0), Blockers, Verify commands, Success criterion (one line).
 
+""" + _HANDOFF_P0_GATE + """
+
 2. **Persist (file is canonical).** Write or overwrite `.tapps-mcp/session-handoff.md`:
    - Set **Updated** to the real current UTC time: run `date -u +%Y-%m-%dT%H:%M:%SZ` and paste the output — never use a placeholder like `T00:00:00Z`.
    - Optionally add **Git:** `<short-sha>` when inside a git repo (`git rev-parse --short HEAD`).
 
-```markdown
-# Session handoff
-**Updated:** <ISO-8601 UTC from date -u>
-**Git:** <short-sha or omit>
-**Linear P0:** <TAP-#### or none>
+""" + _HANDOFF_MARKDOWN_SHAPE + """
 
-## Done
-- ...
-
-## Open
-- ...
-
-## Next (P0)
-- ...
-
-## Blockers
-- ...
-
-## Verify
-- ...
-
-## Success criterion
-- ...
-```
-
-3. **Persist (brain mirror, best-effort).** File from step 2 is canonical. `tapps_memory` is not an MCP tool (removed v3.12.0) — CLI only:
-
-   | Priority | When | How |
-   |----------|------|-----|
-   | 1 (CLI) | Brain HTTP + shell auth (`TAPPS_MCP_MEMORY_BRAIN_AUTH_TOKEN` or `TAPPS_BRAIN_AUTH_TOKEN`) | `uv run tapps-mcp memory save --key session-handoff --tier context --tags handoff,cross-session --value "<plain-text bullets>"` |
-   | 2 (skip) | Brain offline or auth missing | Skip silently — `.tapps-mcp/session-handoff.md` is enough |
+""" + _HANDOFF_BRAIN_MIRROR + """
 
 4. **Close lifecycle.** Best-effort session closure:
    - **Preferred:** `tapps_session_end()`
@@ -1265,13 +1258,13 @@ Start work in a fresh context by assembling structured state.
    - **Preferred:** Call `tapps_session_start()`. Note `compaction_rehydration` if present.
    - **CLI fallback** (MCP unavailable): Run `uv run tapps-mcp doctor --quick` and read `.tapps-mcp.yaml` for project context. Proceed without blocking.
 
-2. **Load handoff (priority):** Read `.tapps-mcp/session-handoff.md`; else CLI `uv run tapps-mcp memory get --key session-handoff` (no `tapps_memory` MCP). Optional: `docs/NEXT_SESSION_PROMPT.md`, `docs/TAPPS_HANDOFF.md` (**Next:** section).
+""" + _CONTINUE_LOAD_AND_CONTEXT + """
 
-3. **Linear:** `get_issue(id=...)` when user or handoff names `TAP-####`; else use `linear-read` for lists (not raw `list_issues`).
+3. **Linear context.**
+   - If the user passed `TAP-####` (argument or handoff **Linear P0**), call `get_issue(id=...)`.
+   - For backlog/triage without a known id, invoke the `linear-read` skill — do not call raw `list_issues` (cache gate).
 
-4. **Emit ~15-line continue block:** P0, Done/Open/Blockers (compressed), Verify first, Success criterion. Warn if handoff **Updated** >7 days old.
-
-5. Proceed on P0; do not ask for a re-paste when handoff exists.
+""" + _CONTINUE_EMIT_AND_PROCEED + """
 """,
     "tapps-report": """\
 ---

--- a/packages/tapps-mcp/src/tapps_mcp/server_metrics_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_metrics_tools.py
@@ -57,6 +57,12 @@ def _sanitize_param(value: str, max_len: int = 100) -> str:
 _PERIOD_DAYS: dict[str, int] = {"1d": 1, "7d": 7, "30d": 30}
 
 
+def _is_docs_stats_tool(tool_name: str) -> bool:
+    from tapps_core.metrics.dashboard import is_docs_tool
+
+    return is_docs_tool(tool_name)
+
+
 def _session_stats(
     hub: MetricsHub,
     tool_name: str | None,
@@ -143,9 +149,10 @@ async def tapps_dashboard(
             ``"30d"``, or ``"90d"``.
         sections: Sections to include. Default ``None`` returns all
             sections. Options: ``"summary"``, ``"tool_metrics"``,
-            ``"scoring_trends"``, ``"expert_metrics"``,
-            ``"cache_metrics"``, ``"quality_distribution"``,
-            ``"alerts"``, ``"business_metrics"``, ``"recommendations"``.
+            ``"docs_metrics"``, ``"session_funnel"``, ``"scoring_trends"``,
+            ``"expert_metrics"``, ``"cache_metrics"``,
+            ``"quality_distribution"``, ``"alerts"``,
+            ``"business_metrics"``, ``"recommendations"``.
     """
     from tapps_mcp.server import _get_metrics_hub, _record_call, _record_execution, _with_nudges
 
@@ -246,23 +253,29 @@ def tapps_stats(
 
     recommendations = _generate_stats_recommendations(summary, tool_breakdowns)
 
+    payload: dict[str, Any] = {
+        "period": period,
+        "total_calls": summary.total_calls,
+        "success_rate": summary.success_rate,
+        "avg_duration_ms": summary.avg_duration_ms,
+        "p95_duration_ms": summary.p95_duration_ms,
+        "gate_pass_rate": summary.gate_pass_rate,
+        "avg_score": summary.avg_score,
+        "tools": tool_breakdowns,
+        "recommendations": recommendations,
+    }
+    docs_tools = [t for t in tool_breakdowns if _is_docs_stats_tool(t.get("tool_name", ""))]
+    if docs_tools:
+        payload["docs_tools"] = docs_tools
+        payload["docs_tool_calls"] = sum(int(t.get("call_count", 0)) for t in docs_tools)
+
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_stats", start)
 
     resp = success_response(
         "tapps_stats",
         elapsed_ms,
-        {
-            "period": period,
-            "total_calls": summary.total_calls,
-            "success_rate": summary.success_rate,
-            "avg_duration_ms": summary.avg_duration_ms,
-            "p95_duration_ms": summary.p95_duration_ms,
-            "gate_pass_rate": summary.gate_pass_rate,
-            "avg_score": summary.avg_score,
-            "tools": tool_breakdowns,
-            "recommendations": recommendations,
-        },
+        payload,
     )
     return _with_nudges("tapps_stats", resp)
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -685,6 +685,22 @@ async def tapps_session_start(
     except Exception:
         _logger.debug("compaction_rehydration_session_start_failed", exc_info=True)
 
+    # TAP-3578: surface prior-session usage gaps from disk telemetry.
+    try:
+        from tapps_mcp.tools.usage import compute_gaps, format_session_start_gap_hint
+
+        gap_hint = format_session_start_gap_hint(settings.project_root)
+        usage = compute_gaps(settings.project_root, called_tools=set())
+        data["usage_gaps"] = {
+            "gaps": usage.get("gaps", []),
+            "recommendations": usage.get("recommendations", []),
+            "session_start_hint": gap_hint,
+            "rolling_gate_skip_rate": usage.get("rolling_stats", {}).get("gate_skip_rate", 0.0),
+            "rolling_loops": usage.get("rolling_stats", {}).get("loops", 0),
+        }
+    except Exception:
+        _logger.debug("usage_gaps_session_start_failed", exc_info=True)
+
     # TAP-1082: Hard-fail on tapps-brain auth probe 401/403 unless explicitly
     # tolerated. Audit (38 sessions, worst case 18 retries) shows agents do
     # not act on degraded:true buried inside memory_status — they retry, or

--- a/packages/tapps-mcp/src/tapps_mcp/tools/fleet_audit.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/fleet_audit.py
@@ -1,0 +1,285 @@
+"""Fleet-level TAPPS usage audit across bootstrapped project roots (TAP-3572).
+
+Merges local execution-metrics JSONL with optional brain telemetry and
+loop-metrics pipeline compliance signals for operator-server visibility.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from tapps_core.metrics.brain_telemetry import (
+    brain_metrics_bridge_available,
+    sync_load_tool_call_metrics_from_brain,
+)
+from tapps_core.metrics.execution_metrics import ToolCallMetric, ToolCallMetricsCollector
+from tapps_mcp.tools.loop_metrics import compute_rolling_stats
+
+_PERIOD_DAYS: dict[str, int] = {"1d": 1, "7d": 7, "30d": 30}
+_BOOTSTRAP_MARKER = ".tapps-mcp.yaml"
+_HANDOFF_PATH = Path(".tapps-mcp") / "session-handoff.md"
+
+
+def parse_period(period: str) -> int:
+    """Return window length in days for a period token."""
+    key = period.strip().lower()
+    if key not in _PERIOD_DAYS:
+        msg = f"Invalid period {period!r}; expected one of {sorted(_PERIOD_DAYS)}"
+        raise ValueError(msg)
+    return _PERIOD_DAYS[key]
+
+
+def period_cutoff(period: str) -> datetime:
+    """UTC cutoff datetime for the trailing window."""
+    days = parse_period(period)
+    return datetime.now(tz=UTC) - timedelta(days=days)
+
+
+def discover_project_roots(
+    *,
+    explicit_roots: list[Path] | None = None,
+    scan_parent: Path | None = None,
+) -> list[Path]:
+    """Resolve bootstrapped project roots for a fleet audit."""
+    if explicit_roots:
+        return [_normalize_root(r) for r in explicit_roots if _is_bootstrapped(_normalize_root(r))]
+
+    env_roots = os.environ.get("TAPPS_FLEET_ROOTS", "").strip()
+    if env_roots:
+        candidates = [Path(p.strip()) for p in env_roots.split(",") if p.strip()]
+        return [_normalize_root(r) for r in candidates if _is_bootstrapped(_normalize_root(r))]
+
+    parent = (scan_parent or Path.cwd()).resolve()
+    if _is_bootstrapped(parent):
+        return [parent]
+
+    discovered: list[Path] = []
+    if not parent.is_dir():
+        return discovered
+    for child in sorted(parent.iterdir()):
+        if child.is_dir() and _is_bootstrapped(child):
+            discovered.append(child.resolve())
+    return discovered
+
+
+def _normalize_root(root: Path) -> Path:
+    return root.expanduser().resolve()
+
+
+def _is_bootstrapped(root: Path) -> bool:
+    return (root / _BOOTSTRAP_MARKER).is_file()
+
+
+def load_jsonl_metrics(
+    metrics_dir: Path,
+    *,
+    since: datetime,
+    until: datetime | None = None,
+) -> list[ToolCallMetric]:
+    """Load tool-call metrics from daily JSONL files (no brain dependency)."""
+    if not metrics_dir.is_dir():
+        return []
+
+    metrics: list[ToolCallMetric] = []
+    for path in sorted(metrics_dir.glob("tool_calls_*.jsonl")):
+        try:
+            file_date = datetime.fromisoformat(path.stem.replace("tool_calls_", "")).replace(
+                tzinfo=UTC
+            )
+        except ValueError:
+            continue
+        if file_date.date() < since.date():
+            continue
+        if until is not None and file_date.date() > until.date():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                if not isinstance(data, dict):
+                    continue
+                metric = ToolCallMetric.from_dict(data)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if _metric_in_window(metric, since, until):
+                metrics.append(metric)
+    return metrics
+
+
+def merge_metrics(
+    local: list[ToolCallMetric],
+    brain: list[ToolCallMetric],
+) -> list[ToolCallMetric]:
+    """Merge local and brain metrics, deduplicating by ``call_id``."""
+    merged: dict[str, ToolCallMetric] = {m.call_id: m for m in local}
+    for metric in brain:
+        merged.setdefault(metric.call_id, metric)
+    return list(merged.values())
+
+
+def _metric_in_window(
+    metric: ToolCallMetric,
+    since: datetime,
+    until: datetime | None,
+) -> bool:
+    try:
+        ts = datetime.fromisoformat(metric.started_at)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+    except (ValueError, TypeError):
+        return True
+    if ts < since:
+        return False
+    return not (until is not None and ts > until)
+
+
+def _pipeline_compliance(project_root: Path, *, window_days: int) -> dict[str, Any]:
+    stats = compute_rolling_stats(project_root, window_days=window_days)
+    rows_total = stats.get("loops", 0)
+    return {
+        "loop_samples": rows_total,
+        "gate_skip_rate": stats.get("gate_skip_rate", 0.0),
+        "lookup_docs_to_edit_ratio": stats.get("lookup_docs_to_edit_ratio", 0.0),
+        "mcp_call_ratio": stats.get("mcp_call_ratio", 0.0),
+    }
+
+
+def _session_start_lookup_ratio(metrics: list[ToolCallMetric]) -> float | None:
+    session_starts = sum(1 for m in metrics if m.tool_name == "tapps_session_start")
+    lookups = sum(1 for m in metrics if m.tool_name == "tapps_lookup_docs")
+    if session_starts == 0:
+        return None
+    return round(lookups / session_starts, 4)
+
+
+def audit_project_root(
+    project_root: Path,
+    *,
+    since: datetime,
+    until: datetime | None = None,
+    include_brain: bool = True,
+    window_days: int = 1,
+) -> dict[str, Any]:
+    """Audit a single bootstrapped project root."""
+    root = _normalize_root(project_root)
+    metrics_dir = root / ".tapps-mcp" / "metrics"
+    local = load_jsonl_metrics(metrics_dir, since=since, until=until)
+
+    brain_count = 0
+    if include_brain and brain_metrics_bridge_available():
+        brain = sync_load_tool_call_metrics_from_brain(since=since, until=until, limit=5000)
+        brain_count = len(brain)
+        metrics = merge_metrics(local, brain)
+    else:
+        metrics = local
+
+    collector = ToolCallMetricsCollector(metrics_dir)
+    summary = collector._compute_summary(metrics)
+
+    handoff_path = root / _HANDOFF_PATH
+    handoff_mtime: str | None = None
+    if handoff_path.is_file():
+        handoff_mtime = datetime.fromtimestamp(handoff_path.stat().st_mtime, tz=UTC).isoformat()
+
+    return {
+        "project_root": str(root),
+        "bootstrapped": True,
+        "metrics": {
+            "total_calls": summary.total_calls,
+            "local_jsonl_rows": len(local),
+            "brain_rows_merged": brain_count,
+            "success_rate": summary.success_rate,
+            "gate_pass_rate": summary.gate_pass_rate,
+            "avg_score": summary.avg_score,
+            "session_start_lookup_ratio": _session_start_lookup_ratio(metrics),
+        },
+        "pipeline": _pipeline_compliance(root, window_days=window_days),
+        "handoff": {
+            "path": str(_HANDOFF_PATH),
+            "exists": handoff_path.is_file(),
+            "updated_at": handoff_mtime,
+        },
+    }
+
+
+def run_fleet_audit(
+    *,
+    period: str = "1d",
+    roots: list[Path] | None = None,
+    scan_parent: Path | None = None,
+    include_brain: bool = True,
+) -> dict[str, Any]:
+    """Run fleet audit and return structured results."""
+    window_days = parse_period(period)
+    since = period_cutoff(period)
+    project_roots = discover_project_roots(explicit_roots=roots, scan_parent=scan_parent)
+
+    projects: list[dict[str, Any]] = []
+    for root in project_roots:
+        projects.append(
+            audit_project_root(
+                root,
+                since=since,
+                include_brain=include_brain,
+                window_days=window_days,
+            )
+        )
+
+    totals = sum(p["metrics"]["total_calls"] for p in projects)
+    return {
+        "period": period,
+        "since": since.isoformat(),
+        "generated_at": datetime.now(tz=UTC).isoformat(),
+        "project_count": len(projects),
+        "total_tool_calls": totals,
+        "projects": projects,
+    }
+
+
+def format_fleet_audit_markdown(report: dict[str, Any]) -> str:
+    """Render fleet audit report as Markdown."""
+    lines = [
+        "# TAPPS fleet audit",
+        "",
+        f"- **Period:** {report.get('period', '?')}",
+        f"- **Since:** {report.get('since', '?')}",
+        f"- **Projects:** {report.get('project_count', 0)}",
+        f"- **Total tool calls:** {report.get('total_tool_calls', 0)}",
+        "",
+        "| Project | Calls | Gate pass | Lookup/session | Handoff |",
+        "|---------|------:|----------:|---------------:|---------|",
+    ]
+    for project in report.get("projects", []):
+        metrics = project.get("metrics", {})
+        name = Path(project.get("project_root", "?")).name
+        gate = metrics.get("gate_pass_rate")
+        gate_str = f"{gate:.0%}" if gate is not None else "—"
+        ratio = metrics.get("session_start_lookup_ratio")
+        ratio_str = f"{ratio:.0%}" if ratio is not None else "—"
+        handoff = "yes" if project.get("handoff", {}).get("exists") else "no"
+        lines.append(
+            f"| {name} | {metrics.get('total_calls', 0)} | {gate_str} | {ratio_str} | {handoff} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "audit_project_root",
+    "discover_project_roots",
+    "format_fleet_audit_markdown",
+    "load_jsonl_metrics",
+    "merge_metrics",
+    "parse_period",
+    "period_cutoff",
+    "run_fleet_audit",
+]

--- a/packages/tapps-mcp/src/tapps_mcp/tools/handoff_schema.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/handoff_schema.py
@@ -1,0 +1,202 @@
+"""Parse and lint ``.tapps-mcp/session-handoff.md`` (TAP-3573)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+_HANDOFF_RELATIVE = Path(".tapps-mcp") / "session-handoff.md"
+_UPDATED_RE = re.compile(r"^\*\*Updated:\*\*\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+_LINEAR_P0_RE = re.compile(r"^\*\*Linear P0:\*\*\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+_SECTION_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+_PLACEHOLDER_UPDATED = frozenset({"<iso-8601 utc from date -u>", "t00:00:00z"})
+_IGNORE_BULLETS = frozenset({"none", "n/a", "...", "—", "-", "tbd"})
+
+
+@dataclass
+class HandoffDocument:
+    """Structured view of a session handoff markdown file."""
+
+    updated: datetime | None = None
+    linear_p0: str | None = None
+    done: list[str] = field(default_factory=list)
+    open_items: list[str] = field(default_factory=list)
+    next_p0: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    verify: list[str] = field(default_factory=list)
+    success_criterion: list[str] = field(default_factory=list)
+    raw_text: str = ""
+
+
+@dataclass
+class HandoffLintResult:
+    """Lint outcome for a handoff document."""
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def handoff_path(project_root: Path) -> Path:
+    return project_root / _HANDOFF_RELATIVE
+
+
+def _normalize_header(name: str) -> str:
+    return name.strip().lower()
+
+
+def _section_key(header: str) -> str | None:
+    norm = _normalize_header(header)
+    if norm == "done":
+        return "done"
+    if norm == "open":
+        return "open"
+    if norm in {"next (p0)", "next", "p0"}:
+        return "next_p0"
+    if norm == "blockers":
+        return "blockers"
+    if norm == "verify":
+        return "verify"
+    if norm in {"success criterion", "success criteria"}:
+        return "success_criterion"
+    return None
+
+
+def _is_real_bullet(line: str) -> bool:
+    stripped = line.strip().lstrip("-* ").strip()
+    if not stripped:
+        return False
+    lowered = stripped.lower()
+    if lowered in _IGNORE_BULLETS:
+        return False
+    if stripped.startswith("<") and stripped.endswith(">"):
+        return False
+    if stripped.endswith("..."):
+        return False
+    return True
+
+
+def _extract_bullets(block: str) -> list[str]:
+    items: list[str] = []
+    for line in block.splitlines():
+        line = line.strip()
+        if not line.startswith(("-", "*")):
+            continue
+        bullet = line.lstrip("-* ").strip()
+        if _is_real_bullet(bullet):
+            items.append(bullet)
+    return items
+
+
+def _parse_updated(raw: str) -> datetime | None:
+    value = raw.strip()
+    if not value:
+        return None
+    lowered = value.lower()
+    if lowered in _PLACEHOLDER_UPDATED or value.startswith("<"):
+        return None
+    try:
+        ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts
+
+
+def _parse_linear_p0(raw: str) -> str | None:
+    value = raw.strip()
+    if not value or value.lower() in {"none", "n/a", "..."}:
+        return None
+    if value.startswith("<") and value.endswith(">"):
+        return None
+    return value
+
+
+def parse_handoff_markdown(text: str) -> HandoffDocument:
+    """Parse handoff markdown into structured sections."""
+    doc = HandoffDocument(raw_text=text)
+    updated_match = _UPDATED_RE.search(text)
+    if updated_match:
+        doc.updated = _parse_updated(updated_match.group(1))
+    linear_match = _LINEAR_P0_RE.search(text)
+    if linear_match:
+        doc.linear_p0 = _parse_linear_p0(linear_match.group(1))
+
+    sections = _SECTION_RE.split(text)
+    # split returns [preamble, h1, body1, h2, body2, ...]
+    idx = 1
+    while idx + 1 < len(sections):
+        header = sections[idx]
+        body = sections[idx + 1]
+        key = _section_key(header)
+        if key == "done":
+            doc.done = _extract_bullets(body)
+        elif key == "open":
+            doc.open_items = _extract_bullets(body)
+        elif key == "next_p0":
+            doc.next_p0 = _extract_bullets(body)
+        elif key == "blockers":
+            doc.blockers = _extract_bullets(body)
+        elif key == "verify":
+            doc.verify = _extract_bullets(body)
+        elif key == "success_criterion":
+            doc.success_criterion = _extract_bullets(body)
+        idx += 2
+    return doc
+
+
+def lint_handoff(
+    doc: HandoffDocument,
+    *,
+    stale_days: int = 7,
+    now: datetime | None = None,
+) -> HandoffLintResult:
+    """Validate handoff schema; errors fail doctor, warnings are advisory."""
+    result = HandoffLintResult()
+    clock = now or datetime.now(tz=UTC)
+
+    if doc.open_items and not doc.next_p0:
+        result.errors.append(
+            "Open items exist but Next (P0) is missing — continue-session cannot pick up work"
+        )
+
+    if doc.updated is None:
+        result.warnings.append(
+            "Updated timestamp missing or placeholder — run date -u +%Y-%m-%dT%H:%M:%SZ"
+        )
+    else:
+        age = clock - doc.updated
+        if age > timedelta(days=stale_days):
+            result.warnings.append(f"Handoff Updated is older than {stale_days} days")
+
+    success_text = " ".join(doc.success_criterion).lower()
+    if doc.open_items and "met" in success_text:
+        result.warnings.append("Success criterion says MET but Open items remain")
+
+    return result
+
+
+def load_and_lint_handoff(project_root: Path) -> tuple[HandoffDocument | None, HandoffLintResult]:
+    """Load handoff file if present and lint it."""
+    path = handoff_path(project_root)
+    if not path.is_file():
+        return None, HandoffLintResult()
+    text = path.read_text(encoding="utf-8")
+    doc = parse_handoff_markdown(text)
+    return doc, lint_handoff(doc)
+
+
+__all__ = [
+    "HandoffDocument",
+    "HandoffLintResult",
+    "handoff_path",
+    "lint_handoff",
+    "load_and_lint_handoff",
+    "parse_handoff_markdown",
+]

--- a/packages/tapps-mcp/src/tapps_mcp/tools/loop_metrics.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/loop_metrics.py
@@ -109,7 +109,27 @@ def should_auto_promote_cache_gate(
     return True, {**stats, "reason": "ready_to_promote"}
 
 
+def compute_gate_pass_rate_7d(project_root: Path) -> float | None:
+    """Return 7-day quality gate pass rate from execution metrics JSONL.
+
+    Uses tool-call rows where ``gate_passed`` is set. Returns ``None`` when
+    no gated calls were recorded in the window.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from tapps_core.metrics.execution_metrics import ToolCallMetricsCollector
+
+    metrics_dir = project_root / ".tapps-mcp" / "metrics"
+    if not metrics_dir.is_dir():
+        return None
+    since = datetime.now(tz=UTC) - timedelta(days=7)
+    collector = ToolCallMetricsCollector(metrics_dir)
+    summary = collector.get_summary(since=since)
+    return summary.gate_pass_rate
+
+
 __all__ = [
+    "compute_gate_pass_rate_7d",
     "compute_rolling_stats",
     "read_loop_metrics",
     "should_auto_promote_cache_gate",

--- a/packages/tapps-mcp/src/tapps_mcp/tools/usage.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/usage.py
@@ -175,6 +175,42 @@ def compute_gaps(
     }
 
 
+def format_session_start_gap_hint(project_root: Path) -> str | None:
+    """One-line prior-session pipeline reminder for SessionStart hooks (TAP-3578).
+
+    Uses disk-only telemetry (loop-metrics + completion-gate violations) so hooks
+    and CLI invocations work without an active MCP ``CallTracker`` session.
+    """
+    violations = read_recent_violations(project_root, limit=20)
+    violation_tags: list[str] = []
+    for row in violations:
+        for reason in row.get("reasons", []):
+            if isinstance(reason, str):
+                violation_tags.append(reason.split(":", 1)[0])
+
+    report = compute_gaps(project_root, called_tools=set())
+    gaps = list(report.get("gaps", []))
+    recs = [r for r in report.get("recommendations", []) if "No gaps detected" not in r]
+
+    if "CHECKLIST_MISSING" in violation_tags and "checklist_skipped" not in gaps:
+        gaps.insert(0, "checklist_skipped")
+    if any(t.startswith("QUALITY_GATE_SKIP") for t in violation_tags):
+        if "edits_without_validation" not in gaps:
+            gaps.insert(0, "edits_without_validation")
+
+    if not gaps:
+        return None
+
+    if "CHECKLIST_MISSING" in violation_tags:
+        return (
+            "Last session ended without tapps_checklist after edits — run "
+            "tapps_validate_changed + tapps_checklist before declaring done."
+        )
+    if recs:
+        return f"{', '.join(gaps[:3])}: {recs[0]}"
+    return ", ".join(gaps[:3])
+
+
 def render_markdown(report: dict[str, Any]) -> str:
     """Render a compact markdown summary of a gap report."""
     lines: list[str] = ["## tapps_usage gap report"]
@@ -203,6 +239,7 @@ def render_markdown(report: dict[str, Any]) -> str:
 
 __all__ = [
     "compute_gaps",
+    "format_session_start_gap_hint",
     "read_recent_violations",
     "render_markdown",
 ]

--- a/packages/tapps-mcp/tests/unit/test_doctor.py
+++ b/packages/tapps-mcp/tests/unit/test_doctor.py
@@ -1578,9 +1578,9 @@ class TestCheckSessionHandoffSkills:
         skill_dir.mkdir(parents=True, exist_ok=True)
         body = f"---\nname: {name}\n---\n"
         if name == "tapps-handoff-session":
-            body += "\nsession-handoff.md\ntapps_session_end\ntapps-mcp memory save\n" * 5
+            body += "\nsession-handoff.md\ntapps_session_end\ntapps-mcp memory save\np0 gate\n" * 5
         elif name == "tapps-continue-session":
-            body += "\nsession-handoff.md\ntapps_session_start\n" * 5
+            body += "\nsession-handoff.md\ntapps_session_start\nmemory search\np0 fallback\n" * 5
         (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
 
     def test_both_skills_on_claude_passes(self, tmp_path):
@@ -1645,6 +1645,106 @@ class TestCheckSessionHandoffSkills:
         self._write_skill(base, "tapps-continue-session")
         result = check_session_handoff_skills(tmp_path)
         assert result.ok is True
+
+
+class TestCheckSessionHandoffSchema:
+    def test_missing_handoff_passes(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_session_handoff_schema
+
+        result = check_session_handoff_schema(tmp_path)
+        assert result.ok is True
+        assert "optional" in result.message.lower()
+
+    def test_open_without_p0_fails(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_session_handoff_schema
+
+        path = tmp_path / ".tapps-mcp" / "session-handoff.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "# Session handoff\n**Updated:** 2026-06-11T12:00:00Z\n\n"
+            "## Open\n- unfinished\n\n## Next (P0)\n- none\n",
+            encoding="utf-8",
+        )
+        result = check_session_handoff_schema(tmp_path)
+        assert result.ok is False
+        assert "p0" in result.message.lower()
+
+    def test_valid_handoff_passes(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_session_handoff_schema
+
+        path = tmp_path / ".tapps-mcp" / "session-handoff.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "# Session handoff\n**Updated:** 2026-06-11T12:00:00Z\n\n"
+            "## Open\n- none\n\n## Next (P0)\n- ship wave 2\n",
+            encoding="utf-8",
+        )
+        result = check_session_handoff_schema(tmp_path)
+        assert result.ok is True
+
+
+class TestCheckCacheGateBlockHint:
+    def test_block_mode_ok(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_cache_gate_block_hint
+
+        (tmp_path / ".tapps-mcp.yaml").write_text(
+            "linear_enforce_cache_gate: block\n",
+            encoding="utf-8",
+        )
+        result = check_cache_gate_block_hint(tmp_path)
+        assert result.ok is True
+        assert "block" in result.message
+
+    def test_warn_high_violations_recommends_block(self, tmp_path):
+        import time
+
+        from tapps_mcp.distribution.doctor import check_cache_gate_block_hint
+
+        hooks = tmp_path / ".claude" / "hooks"
+        hooks.mkdir(parents=True)
+        (hooks / "tapps-pre-linear-list.sh").write_text('MODE="warn"\n', encoding="utf-8")
+        log = tmp_path / ".tapps-mcp" / ".cache-gate-violations.jsonl"
+        log.parent.mkdir(parents=True)
+        now = time.time()
+        lines = [
+            json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)), "category": "gate_miss"})
+            for _ in range(25)
+        ]
+        log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        result = check_cache_gate_block_hint(tmp_path)
+        assert result.ok is True
+        assert "block" in (result.detail or "").lower()
+
+
+class TestCheckInstallGitHooksHint:
+    def test_high_engagement_low_pass_rate_hints(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_install_git_hooks_hint
+
+        (tmp_path / ".tapps-mcp.yaml").write_text(
+            "llm_engagement_level: high\ninstall_git_hooks: false\n",
+            encoding="utf-8",
+        )
+        metrics_dir = tmp_path / ".tapps-mcp" / "metrics"
+        metrics_dir.mkdir(parents=True)
+        metric = {
+            "call_id": "a",
+            "tool_name": "tapps_quality_gate",
+            "status": "success",
+            "duration_ms": 1.0,
+            "started_at": "2026-06-11T00:00:00+00:00",
+            "completed_at": "2026-06-11T00:00:01+00:00",
+            "gate_passed": False,
+        }
+        from datetime import date
+
+        day = date.today().isoformat()
+        (metrics_dir / f"tool_calls_{day}.jsonl").write_text(
+            json.dumps(metric) + "\n",
+            encoding="utf-8",
+        )
+        result = check_install_git_hooks_hint(tmp_path)
+        assert result.ok is True
+        assert "install_git_hooks" in (result.detail or "")
 
 
 class TestCheckContinuousLearningV2Skill:

--- a/packages/tapps-mcp/tests/unit/test_fleet_audit.py
+++ b/packages/tapps-mcp/tests/unit/test_fleet_audit.py
@@ -1,0 +1,138 @@
+"""Tests for fleet audit CLI helpers (TAP-3572)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from tapps_core.metrics.execution_metrics import ToolCallMetric
+
+from tapps_mcp.tools.fleet_audit import (
+    audit_project_root,
+    discover_project_roots,
+    format_fleet_audit_markdown,
+    load_jsonl_metrics,
+    merge_metrics,
+    parse_period,
+    run_fleet_audit,
+)
+
+
+def _write_metric(metrics_dir: Path, metric: ToolCallMetric) -> None:
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    day = metric.started_at[:10]
+    path = metrics_dir / f"tool_calls_{day}.jsonl"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(metric.to_dict()) + "\n")
+
+
+def _sample_metric(*, call_id: str = "c1", tool: str = "tapps_session_start") -> ToolCallMetric:
+    now = datetime.now(tz=UTC).isoformat()
+    return ToolCallMetric(
+        call_id=call_id,
+        tool_name=tool,
+        status="success",
+        duration_ms=1.0,
+        started_at=now,
+        completed_at=now,
+        gate_passed=True,
+        score=90.0,
+    )
+
+
+class TestFleetAuditHelpers:
+    def test_parse_period(self) -> None:
+        assert parse_period("1d") == 1
+        assert parse_period("7d") == 7
+
+    def test_discover_explicit_roots(self, tmp_path: Path) -> None:
+        bootstrapped = tmp_path / "proj-a"
+        bootstrapped.mkdir()
+        (bootstrapped / ".tapps-mcp.yaml").write_text("quality_preset: standard\n")
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        found = discover_project_roots(explicit_roots=[bootstrapped, bare])
+        assert found == [bootstrapped.resolve()]
+
+    def test_discover_scan_parent(self, tmp_path: Path) -> None:
+        child = tmp_path / "child"
+        child.mkdir()
+        (child / ".tapps-mcp.yaml").write_text("quality_preset: standard\n")
+
+        found = discover_project_roots(scan_parent=tmp_path)
+        assert found == [child.resolve()]
+
+    def test_load_jsonl_metrics_filters_by_window(self, tmp_path: Path) -> None:
+        metrics_dir = tmp_path / "metrics"
+        recent = _sample_metric(call_id="recent")
+        _write_metric(metrics_dir, recent)
+
+        old_ts = (datetime.now(tz=UTC) - timedelta(days=10)).isoformat()
+        old = ToolCallMetric(
+            call_id="old",
+            tool_name="tapps_score_file",
+            status="success",
+            duration_ms=1.0,
+            started_at=old_ts,
+            completed_at=old_ts,
+        )
+        _write_metric(metrics_dir, old)
+
+        since = datetime.now(tz=UTC) - timedelta(days=1)
+        loaded = load_jsonl_metrics(metrics_dir, since=since)
+        assert len(loaded) == 1
+        assert loaded[0].call_id == "recent"
+
+    def test_merge_metrics_deduplicates(self) -> None:
+        local = [_sample_metric(call_id="shared")]
+        brain = [_sample_metric(call_id="shared"), _sample_metric(call_id="brain-only")]
+        merged = merge_metrics(local, brain)
+        assert len(merged) == 2
+        assert {m.call_id for m in merged} == {"shared", "brain-only"}
+
+
+class TestFleetAuditProject:
+    def test_audit_project_root_jsonl_only(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("TAPPS_METRICS_STORAGE", "local")
+        project = tmp_path / "demo"
+        project.mkdir()
+        (project / ".tapps-mcp.yaml").write_text("quality_preset: standard\n")
+        metrics_dir = project / ".tapps-mcp" / "metrics"
+        _write_metric(metrics_dir, _sample_metric(call_id="a"))
+        _write_metric(
+            metrics_dir,
+            _sample_metric(call_id="b", tool="tapps_lookup_docs"),
+        )
+
+        report = audit_project_root(
+            project,
+            since=datetime.now(tz=UTC) - timedelta(days=1),
+            include_brain=False,
+        )
+        assert report["metrics"]["total_calls"] == 2
+        assert report["metrics"]["local_jsonl_rows"] == 2
+        assert report["metrics"]["session_start_lookup_ratio"] == 1.0
+        assert report["handoff"]["exists"] is False
+
+    def test_run_fleet_audit_shape(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo"
+        project.mkdir()
+        (project / ".tapps-mcp.yaml").write_text("quality_preset: standard\n")
+        metrics_dir = project / ".tapps-mcp" / "metrics"
+        _write_metric(metrics_dir, _sample_metric())
+
+        report = run_fleet_audit(period="1d", roots=[project], include_brain=False)
+        assert report["project_count"] == 1
+        assert report["total_tool_calls"] == 1
+        assert report["projects"][0]["project_root"] == str(project.resolve())
+
+    def test_format_markdown_includes_project(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo"
+        project.mkdir()
+        (project / ".tapps-mcp.yaml").write_text("quality_preset: standard\n")
+        report = run_fleet_audit(period="1d", roots=[project], include_brain=False)
+        md = format_fleet_audit_markdown(report)
+        assert "demo" in md
+        assert "Total tool calls" in md

--- a/packages/tapps-mcp/tests/unit/test_handoff_schema.py
+++ b/packages/tapps-mcp/tests/unit/test_handoff_schema.py
@@ -1,0 +1,116 @@
+"""Tests for session handoff schema parsing and lint (TAP-3573)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tapps_mcp.tools.handoff_schema import (
+    lint_handoff,
+    load_and_lint_handoff,
+    parse_handoff_markdown,
+)
+
+_VALID_HANDOFF = """\
+# Session handoff
+**Updated:** 2026-06-11T12:00:00Z
+**Linear P0:** TAP-3571
+
+## Done
+- Shipped metrics fix
+
+## Open
+- none
+
+## Next (P0)
+- Continue Wave 2 handoff hardening
+
+## Blockers
+- none
+
+## Verify
+- uv run pytest
+
+## Success criterion
+- Doctor passes handoff lint
+"""
+
+_MISSING_P0 = """\
+# Session handoff
+**Updated:** 2026-06-11T12:00:00Z
+
+## Done
+- Partial work
+
+## Open
+- Finish doctor linter
+
+## Next (P0)
+- none
+
+## Success criterion
+- MET
+"""
+
+_STALE_HANDOFF = """\
+# Session handoff
+**Updated:** 2026-01-01T00:00:00Z
+
+## Open
+- stale task
+
+## Next (P0)
+- refresh handoff
+"""
+
+
+class TestHandoffSchemaParse:
+    def test_parse_valid_handoff(self) -> None:
+        doc = parse_handoff_markdown(_VALID_HANDOFF)
+        assert doc.linear_p0 == "TAP-3571"
+        assert doc.done == ["Shipped metrics fix"]
+        assert doc.next_p0 == ["Continue Wave 2 handoff hardening"]
+
+    def test_lint_passes_valid(self) -> None:
+        doc = parse_handoff_markdown(_VALID_HANDOFF)
+        result = lint_handoff(doc, now=datetime(2026, 6, 11, tzinfo=UTC))
+        assert result.ok
+        assert not result.warnings
+
+    def test_lint_fails_open_without_p0(self) -> None:
+        doc = parse_handoff_markdown(_MISSING_P0)
+        result = lint_handoff(doc, now=datetime(2026, 6, 11, tzinfo=UTC))
+        assert not result.ok
+        assert any("Next (P0)" in err for err in result.errors)
+
+    def test_lint_warns_met_with_open(self) -> None:
+        text = _MISSING_P0.replace("## Next (P0)\n- none\n", "## Next (P0)\n- do the thing\n")
+        doc = parse_handoff_markdown(text)
+        result = lint_handoff(doc, now=datetime(2026, 6, 11, tzinfo=UTC))
+        assert result.ok
+        assert any("MET" in w for w in result.warnings)
+
+    def test_lint_warns_stale_updated(self) -> None:
+        doc = parse_handoff_markdown(_STALE_HANDOFF)
+        result = lint_handoff(
+            doc,
+            now=datetime(2026, 6, 11, tzinfo=UTC),
+            stale_days=7,
+        )
+        assert result.ok
+        assert any("older than" in w for w in result.warnings)
+
+
+class TestHandoffSchemaDoctorIntegration:
+    def test_load_and_lint_missing_file(self, tmp_path: Path) -> None:
+        doc, lint = load_and_lint_handoff(tmp_path)
+        assert doc is None
+        assert lint.ok
+
+    def test_load_and_lint_bad_handoff_on_disk(self, tmp_path: Path) -> None:
+        handoff = tmp_path / ".tapps-mcp" / "session-handoff.md"
+        handoff.parent.mkdir(parents=True)
+        handoff.write_text(_MISSING_P0, encoding="utf-8")
+        doc, lint = load_and_lint_handoff(tmp_path)
+        assert doc is not None
+        assert not lint.ok

--- a/packages/tapps-mcp/tests/unit/test_loop_metrics.py
+++ b/packages/tapps-mcp/tests/unit/test_loop_metrics.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from tapps_mcp.tools.loop_metrics import (
+    compute_gate_pass_rate_7d,
     compute_rolling_stats,
     read_loop_metrics,
     should_auto_promote_cache_gate,
@@ -97,3 +98,42 @@ class TestShouldAutoPromoteCacheGate:
         )
         assert promote is False
         assert telemetry["reason"] == "insufficient_loops"
+
+
+class TestComputeGatePassRate7d:
+    def test_returns_none_without_metrics(self, tmp_path: Path) -> None:
+        assert compute_gate_pass_rate_7d(tmp_path) is None
+
+    def test_computes_from_jsonl(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("TAPPS_METRICS_STORAGE", "local")
+        from datetime import date
+
+        metrics_dir = tmp_path / ".tapps-mcp" / "metrics"
+        metrics_dir.mkdir(parents=True)
+        day = date.today().isoformat()
+        rows = [
+            {
+                "call_id": "1",
+                "tool_name": "tapps_quality_gate",
+                "status": "success",
+                "duration_ms": 1.0,
+                "started_at": "2026-06-11T00:00:00+00:00",
+                "completed_at": "2026-06-11T00:00:01+00:00",
+                "gate_passed": True,
+            },
+            {
+                "call_id": "2",
+                "tool_name": "tapps_quality_gate",
+                "status": "success",
+                "duration_ms": 1.0,
+                "started_at": "2026-06-11T00:00:02+00:00",
+                "completed_at": "2026-06-11T00:00:03+00:00",
+                "gate_passed": False,
+            },
+        ]
+        (metrics_dir / f"tool_calls_{day}.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n",
+            encoding="utf-8",
+        )
+        rate = compute_gate_pass_rate_7d(tmp_path)
+        assert rate == 0.5

--- a/packages/tapps-mcp/tests/unit/test_platform_skills.py
+++ b/packages/tapps-mcp/tests/unit/test_platform_skills.py
@@ -480,6 +480,32 @@ class TestSessionHandoffSkills:
         assert "tapps_session_start" in CURSOR_SKILLS["tapps-continue-session"]
         assert "session-handoff.md" in CLAUDE_SKILLS["tapps-continue-session"]
 
+    def test_handoff_requires_p0_gate(self) -> None:
+        for skills in (CLAUDE_SKILLS, CURSOR_SKILLS):
+            assert "P0 gate" in skills["tapps-handoff-session"]
+
+    def test_continue_has_memory_search_and_p0_fallback(self) -> None:
+        for skills in (CLAUDE_SKILLS, CURSOR_SKILLS):
+            content = skills["tapps-continue-session"]
+            assert "memory search" in content
+            assert "P0 fallback" in content
+
+    def test_continue_session_body_parity(self) -> None:
+        """Cursor and Claude continue-session share the same core steps (TAP-3581)."""
+        markers = (
+            "Load handoff (priority order)",
+            "P0 fallback",
+            "memory search",
+            "Emit continue block",
+            "Proceed on P0",
+            "linear-read",
+        )
+        claude_body = CLAUDE_SKILLS["tapps-continue-session"].split("---", 2)[-1]
+        cursor_body = CURSOR_SKILLS["tapps-continue-session"].split("---", 2)[-1]
+        for marker in markers:
+            assert marker in claude_body
+            assert marker in cursor_body
+
     def test_generated_handoff_and_continue_skills(self, tmp_path: Path) -> None:
         generate_skills(tmp_path, "cursor")
         assert (tmp_path / ".cursor" / "skills" / "tapps-handoff-session" / "SKILL.md").exists()

--- a/packages/tapps-mcp/tests/unit/test_session_start_memoization.py
+++ b/packages/tapps-mcp/tests/unit/test_session_start_memoization.py
@@ -129,6 +129,7 @@ class TestSessionStartHookSentinel:
         assert 'if [ -f "$SENTINEL" ]' in script
         # Still emits the REQUIRED prompt on first fire for a session.
         assert "REQUIRED: Call tapps_session_start()" in script
+        assert "usage-gaps-hint" in script
 
     def test_hook_emits_prompt_on_first_fire_and_silences_on_resume(
         self, tmp_path: object

--- a/packages/tapps-mcp/tests/unit/test_setup_generator.py
+++ b/packages/tapps-mcp/tests/unit/test_setup_generator.py
@@ -1064,6 +1064,14 @@ class TestEnvInConfig:
         data = json.loads((project / ".cursor" / "mcp.json").read_text(encoding="utf-8"))
         assert data["mcpServers"]["tapps-mcp"]["env"]["TAPPS_BRAIN_PROFILE"] == "full"
 
+    def test_tapps_mcp_entry_pins_dual_metrics_storage(self, tmp_path):
+        """TAP-3572: generated MCP config pins TAPPS_METRICS_STORAGE=dual."""
+        project = tmp_path / "demo"
+        project.mkdir()
+        _generate_config("cursor", project)
+        data = json.loads((project / ".cursor" / "mcp.json").read_text(encoding="utf-8"))
+        assert data["mcpServers"]["tapps-mcp"]["env"]["TAPPS_METRICS_STORAGE"] == "dual"
+
     def test_docs_mcp_entry_pins_agent_brain_profile(self, tmp_path):
         """TAP-1935: the docs-mcp entry pins TAPPS_BRAIN_PROFILE=agent_brain."""
         project = tmp_path / "demo"
@@ -1098,6 +1106,7 @@ class TestEnvInConfig:
         _generate_config("cursor", project, force=True, upgrade_mode=True)
         env = json.loads(cfg.read_text(encoding="utf-8"))["mcpServers"]["tapps-mcp"]["env"]
         assert env["TAPPS_BRAIN_PROFILE"] == "full"
+        assert env["TAPPS_METRICS_STORAGE"] == "dual"
         assert env["MY_CUSTOM_KEY"] == "keep-me"  # human-added key preserved
 
     def test_brain_env_token_is_substitution_not_literal(self, tmp_path):

--- a/packages/tapps-mcp/tests/unit/test_usage_gaps_hint.py
+++ b/packages/tapps-mcp/tests/unit/test_usage_gaps_hint.py
@@ -1,0 +1,56 @@
+"""Tests for usage gap SessionStart hints (TAP-3578)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from tapps_mcp.tools.usage import format_session_start_gap_hint
+
+
+class TestFormatSessionStartGapHint:
+    def test_returns_none_when_clean(self, tmp_path: Path) -> None:
+        assert format_session_start_gap_hint(tmp_path) is None
+
+    def test_surfaces_checklist_missing_from_violations(self, tmp_path: Path) -> None:
+        metrics_dir = tmp_path / ".tapps-mcp"
+        metrics_dir.mkdir(parents=True)
+        violations = metrics_dir / ".completion-gate-violations.jsonl"
+        violations.write_text(
+            json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "reasons": ["CHECKLIST_MISSING"],
+                    "files_edited": ["src/a.py"],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        hint = format_session_start_gap_hint(tmp_path)
+        assert hint is not None
+        assert "tapps_checklist" in hint
+
+    def test_surfaces_loop_metric_gaps(self, tmp_path: Path) -> None:
+        metrics_dir = tmp_path / ".tapps-mcp"
+        metrics_dir.mkdir(parents=True)
+        loop_metrics = metrics_dir / "loop-metrics.jsonl"
+        loop_metrics.write_text(
+            json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "files_edited": ["src/a.py"],
+                    "mcp_calls": 1,
+                    "gate_skipped_files": ["src/a.py"],
+                    "lookup_docs_called": False,
+                    "checklist_called": False,
+                    "tools_used": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        hint = format_session_start_gap_hint(tmp_path)
+        assert hint is not None
+        assert "validation" in hint.lower() or "checklist" in hint.lower()


### PR DESCRIPTION
## Summary

Implements [TAP-3571](https://linear.app/tappscodingagents/issue/TAP-3571) (server audit: TAPPS observability and continue-session hardening) across four waves:

- **Metrics default (TAP-3572/3576):** Unset `TAPPS_METRICS_STORAGE` defaults to `dual`; `dual` always writes local JSONL. New `tapps-mcp audit-fleet --period 1d|7d|30d` merges JSONL + brain telemetry across bootstrapped projects. Generated MCP configs pin `TAPPS_METRICS_STORAGE=dual`.
- **Handoff hardening (TAP-3573–3575):** Shared `handoff_schema.py`, doctor lint for `.tapps-mcp/session-handoff.md`, aligned handoff/continue skills with P0 gate + memory search + Open→P0 fallback.
- **Pipeline compliance (TAP-3578–3579):** SessionStart hooks + `tapps_session_start` surface `usage_gaps`; doctor recommends cache-gate block and git hooks when thresholds are met.
- **Dashboard (TAP-3582/3583):** `docs_metrics` and `session_funnel` dashboard sections; `tapps_stats` adds `docs_tools` slice when present.

## Test plan

- [x] `uv run pytest packages/tapps-core/tests/unit/test_dashboard.py -q`
- [x] `uv run pytest packages/tapps-core/tests/unit/test_execution_metrics.py -q`
- [x] `uv run pytest packages/tapps-mcp/tests/unit/test_fleet_audit.py packages/tapps-mcp/tests/unit/test_handoff_schema.py packages/tapps-mcp/tests/unit/test_usage_gaps_hint.py -q`
- [ ] CI tapps-quality workflow
- [ ] Manual: `uv run tapps-mcp audit-fleet --period 1d --format markdown`
- [ ] Manual: `tapps_dashboard(sections=["docs_metrics","session_funnel"])`

## Ops follow-up (TAP-3580, not in this PR)

Run `tapps-mcp upgrade --host auto --force` on consumer repos (NLTWeb, HeyGen, ReportLab) and set `linear_enforce_cache_gate: block` on high-traffic projects per CONSUMER-REPO-BRAIN-WIRING.md.

## Notes

Left unstaged (unrelated local changes): `.github/workflows/codeql-analysis.yml`, `.tapps-mcp.yaml`, ReportLab epic artifacts under `docs/epics/stories/`.

Made with [Cursor](https://cursor.com)