### PR TITLE
feat(document): document-output quality pipeline (EPIC-104–107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Document-output quality pipeline (EPIC-104–107, TAP-3591–3607)** — Blocking `validate_changed.judges` (`pytest`, `grep`, `exists`, `shell`) with `when_changed` globs fold into `all_gates_passed`; judge rows appear in `summary_rows` and CLI output. `tapps_init` / `tapps_upgrade` auto-merge discovered judge presets and optional `memory.profile: document-builder` for document consumers. New checklist `task_type=document`. `report_authoring` quality preset zeros `test_coverage` weight under `reports/**`. Pluggable `yaml_manifest` config validation via `manifest_validation` in `.tapps-mcp.yaml`. `search_first` injects `document-quality` lookup_docs topic; impact analysis nudges rebuild for layout paths.
+
 ## [3.12.21] - 2026-06-11
 
 Patch: metrics default dual, session handoff hardening, pipeline compliance hints, dashboard observability (TAP-3572–3583).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -47,7 +47,9 @@ extra_recommended:
     - tapps_validate_config
 ```
 
-When you change YAML infra or brand files, call `tapps_validate_config(file_path='...', config_type='yaml')` explicitly. Domain-specific quality (PDF layout, hyperlinks) belongs in project tools (e.g. report-studio verify) via `validate_changed.judges` in `.tapps-mcp.yaml`, not generic YAML lint in tapps-mcp core.
+When you change YAML brand/template manifests, call `tapps_validate_config(file_path='...', config_type='yaml_manifest')` after enabling `manifest_validation` in `.tapps-mcp.yaml`. Domain-specific quality (PDF layout, hyperlinks) belongs in consumer audit CLIs wired through `validate_changed.judges` (pytest/grep/shell) in `.tapps-mcp.yaml`, not generic code gates alone.
+
+Use checklist `task_type=document` (or `.tapps-mcp/checklist-policy.yaml` extras) so agents run `tapps_validate_changed` with judges plus `tapps_validate_config` for manifest YAML.
 
 ### Verifying MCP server health
 

--- a/docs/epics/EPIC-104.md
+++ b/docs/epics/EPIC-104.md
@@ -1,0 +1,125 @@
+# Epic 104: Document-output gate orchestration (judges pipeline)
+
+<!-- docsmcp:start:metadata -->
+**Status:** Proposed
+**Priority:** High
+**Estimated LOE:** M
+
+<!-- docsmcp:end:metadata -->
+
+---
+
+<!-- docsmcp:start:purpose-intent -->
+## Purpose & Intent
+
+We are doing this so that TappsMCP can gate shipped document OUTPUT quality (PDFs, HTML builds, audit CLIs) — not only Python source quality — using deterministic judges that agents and CI actually fail on.
+
+<!-- docsmcp:end:purpose-intent -->
+
+<!-- docsmcp:start:goal -->
+## Goal
+
+Harden validate_changed judges so blocking failures fold into the primary pass/fail signal, surface visibly in summary output, and support generic shell/command gates with optional when_changed path filters.
+
+<!-- docsmcp:end:goal -->
+
+<!-- docsmcp:start:motivation -->
+## Motivation
+
+ReportLab production use proved code gates miss thin PDF pages, missing link annotations, and dropped --audit flags in prebuild scripts. Judges exist (pytest/grep/exists) but judges_passed is separate from all_gates_passed, blocking defaults to False, and CLI ignores judge failures. Shell judges are needed for consumer audit CLIs.
+
+<!-- docsmcp:end:motivation -->
+
+<!-- docsmcp:start:acceptance-criteria -->
+## Acceptance Criteria
+
+- [ ] - [ ] Blocking judge failure sets all_gates_passed and overall_passed to false
+- [ ] judge_results appear in summary_rows and CLI validate-changed output
+- [ ] shell/command judge runs subprocess with timeout and cwd=project_root
+- [ ] when_changed globs skip judges when git diff does not touch matching paths
+- [ ] Unit tests cover blocking integration
+- [ ] shell exit codes
+- [ ] and when_changed filtering
+
+<!-- docsmcp:end:acceptance-criteria -->
+
+<!-- docsmcp:start:stories -->
+## Stories
+
+### 104.1 -- judge.py: wire blocking judges into all_gates_passed
+
+**Points:** 3
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement judge.py: wire blocking judges into all_gates_passed
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** judge.py: wire blocking judges into all_gates_passed is implemented, tests pass, and documentation is updated.
+
+---
+
+### 104.2 -- validate_changed_output.py: judge rows in summary_rows and CLI
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement validate_changed_output.py: judge rows in summary_rows and cli
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** validate_changed_output.py: judge rows in summary_rows and CLI is implemented, tests pass, and documentation is updated.
+
+---
+
+### 104.3 -- judge.py: add shell command judge type
+
+**Points:** 3
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement judge.py: add shell command judge type
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** judge.py: add shell command judge type is implemented, tests pass, and documentation is updated.
+
+---
+
+### 104.4 -- judge.py: add when_changed glob filter for judges
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement judge.py: add when_changed glob filter for judges
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** judge.py: add when_changed glob filter for judges is implemented, tests pass, and documentation is updated.
+
+---
+
+<!-- docsmcp:end:stories -->
+
+<!-- docsmcp:start:technical-notes -->
+## Technical Notes
+
+- Document architecture decisions for **Document-output gate orchestration (judges pipeline)**...
+
+<!-- docsmcp:end:technical-notes -->
+
+<!-- docsmcp:start:non-goals -->
+## Out of Scope / Future Considerations
+
+- - Do not embed ReportLab or pypdf inside tapps-mcp scoring
+- Do not auto-run full suite PDF build on every validate_changed without when_changed guards
+- Do not replace consumer story modules with tapps-mcp templates
+
+<!-- docsmcp:end:non-goals -->

--- a/docs/epics/EPIC-105.md
+++ b/docs/epics/EPIC-105.md
@@ -1,0 +1,111 @@
+# Epic 105: Document consumer bootstrap (init, doctor, checklist)
+
+<!-- docsmcp:start:metadata -->
+**Status:** Proposed
+**Priority:** High
+**Estimated LOE:** M
+
+<!-- docsmcp:end:metadata -->
+
+---
+
+<!-- docsmcp:start:purpose-intent -->
+## Purpose & Intent
+
+We are doing this so that document-shipping repos get working validate_changed judges and checklist guidance out of the box after tapps_init or tapps_upgrade — without hand-authoring .tapps-mcp.yaml for every consumer.
+
+<!-- docsmcp:end:purpose-intent -->
+
+<!-- docsmcp:start:goal -->
+## Goal
+
+When document tooling is detected (e.g. nlt-report-studio pin, reports/ directory), auto-merge discovered judge presets, report judge configuration in doctor, and add a document task_type to the checklist.
+
+<!-- docsmcp:end:goal -->
+
+<!-- docsmcp:start:motivation -->
+## Motivation
+
+Today report-studio detection only adds a next_steps hint when validate_changed.judges is empty. Agents skip PDF audit gates unless manually prompted. Doctor shows installed status but not whether judges are configured.
+
+<!-- docsmcp:end:motivation -->
+
+<!-- docsmcp:start:acceptance-criteria -->
+## Acceptance Criteria
+
+- [ ] - [ ] tapps_init/tapps_upgrade merges discovered judge preset when document tooling detected
+- [ ] Judge paths discovered via heuristics (reports/
+- [ ] **/build-pdfs.mjs
+- [ ] tests/test_pdf_audit.py) not hard-coded ReportLab layout
+- [ ] tapps_doctor reports judges configured vs missing for document consumers
+- [ ] task_type document exists in checklist with validate_changed
+- [ ] validate_config
+- [ ] lookup_docs guidance
+- [ ] Fresh init on report-studio fixture consumer gets working blocking judges without manual YAML edits
+
+<!-- docsmcp:end:acceptance-criteria -->
+
+<!-- docsmcp:start:stories -->
+## Stories
+
+### 105.1 -- init.py: auto-merge discovered judge preset on init upgrade
+
+**Points:** 3
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement init.py: auto-merge discovered judge preset on init upgrade
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** init.py: auto-merge discovered judge preset on init upgrade is implemented, tests pass, and documentation is updated.
+
+---
+
+### 105.2 -- doctor.py: report judge configuration status
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement doctor.py: report judge configuration status
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** doctor.py: report judge configuration status is implemented, tests pass, and documentation is updated.
+
+---
+
+### 105.3 -- checklist.py: add task_type document profile
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement checklist.py: add task_type document profile
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** checklist.py: add task_type document profile is implemented, tests pass, and documentation is updated.
+
+---
+
+<!-- docsmcp:end:stories -->
+
+<!-- docsmcp:start:technical-notes -->
+## Technical Notes
+
+- Document architecture decisions for **Document consumer bootstrap (init, doctor, checklist)**...
+
+<!-- docsmcp:end:technical-notes -->
+
+<!-- docsmcp:start:non-goals -->
+## Out of Scope / Future Considerations
+
+- - Do not hard-code ReportLab-specific paths (apps/docs/scripts/build-pdfs.mjs) without discovery fallback
+- Do not ship ReportLab pydantic schemas in core
+
+<!-- docsmcp:end:non-goals -->

--- a/docs/epics/EPIC-106.md
+++ b/docs/epics/EPIC-106.md
@@ -1,0 +1,76 @@
+# Epic 106: Narrative code scoring for document repos
+
+<!-- docsmcp:start:metadata -->
+**Status:** Proposed
+**Priority:** Medium
+**Estimated LOE:** S
+
+<!-- docsmcp:end:metadata -->
+
+---
+
+<!-- docsmcp:start:purpose-intent -->
+## Purpose & Intent
+
+We are doing this so that layout-only narrative modules (e.g. reports/**/story.py) are not falsely failed by test_coverage weight when no per-module unit tests exist.
+
+<!-- docsmcp:end:purpose-intent -->
+
+<!-- docsmcp:start:goal -->
+## Goal
+
+Add a report_authoring quality preset or path-based scoring overrides that reduce or zero test_coverage weight for narrative/layout directories.
+
+<!-- docsmcp:end:goal -->
+
+<!-- docsmcp:start:motivation -->
+## Motivation
+
+Large reports/*/story.py files fail or depress gate on test-coverage heuristic (0 score when no test_{stem}.py), pulling overall below 70 and training agents to ignore the gate.
+
+<!-- docsmcp:end:motivation -->
+
+<!-- docsmcp:start:acceptance-criteria -->
+## Acceptance Criteria
+
+- [ ] - [ ] quality_preset report_authoring (or equivalent path override) is configurable in .tapps-mcp.yaml
+- [ ] reports/** or consumer-configured globs reduce or zero test_coverage category weight
+- [ ] reports/foo/story.py with no dedicated unit test can pass standard overall gate when other categories pass
+- [ ] Existing standard/strict/framework presets unchanged for non-narrative paths
+
+<!-- docsmcp:end:acceptance-criteria -->
+
+<!-- docsmcp:start:stories -->
+## Stories
+
+### 106.1 -- settings.py: report_authoring preset and path overrides
+
+**Points:** 3
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement settings.py: report_authoring preset and path overrides
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** settings.py: report_authoring preset and path overrides is implemented, tests pass, and documentation is updated.
+
+---
+
+<!-- docsmcp:end:stories -->
+
+<!-- docsmcp:start:technical-notes -->
+## Technical Notes
+
+- Document architecture decisions for **Narrative code scoring for document repos**...
+
+<!-- docsmcp:end:technical-notes -->
+
+<!-- docsmcp:start:non-goals -->
+## Out of Scope / Future Considerations
+
+- - Do not remove test_coverage category globally
+- Do not exempt all Python under reports/ from security or complexity scoring
+
+<!-- docsmcp:end:non-goals -->

--- a/docs/epics/EPIC-107.md
+++ b/docs/epics/EPIC-107.md
@@ -1,0 +1,138 @@
+# Epic 107: Document config validation and agent guidance
+
+<!-- docsmcp:start:metadata -->
+**Status:** Proposed
+**Priority:** Medium
+**Estimated LOE:** M
+
+<!-- docsmcp:end:metadata -->
+
+---
+
+<!-- docsmcp:start:purpose-intent -->
+## Purpose & Intent
+
+We are doing this so that agents working on document-shipping repos get schema validation for consumer YAML manifests, generic document-quality lookup_docs guidance, memory recall, and impact nudges — without embedding PDF logic in tapps-mcp core.
+
+<!-- docsmcp:end:purpose-intent -->
+
+<!-- docsmcp:start:goal -->
+## Goal
+
+Ship pluggable validate_config for consumer brand/template manifests, a document-quality lookup_docs topic pack, optional document-builder memory profile, and impact_analysis rebuild-documents nudges.
+
+<!-- docsmcp:end:goal -->
+
+<!-- docsmcp:start:motivation -->
+## Motivation
+
+Brand/template YAML affects shipped PDFs but is invisible to validate_changed. TROUBLESHOOTING references config_type yaml before core supports it. Agents lack generic guidance on PDF links, outlines, and thin pages. Impact analysis does not nudge document rebuilds when layout modules change.
+
+<!-- docsmcp:end:motivation -->
+
+<!-- docsmcp:start:acceptance-criteria -->
+## Acceptance Criteria
+
+- [ ] - [ ] validate_config supports consumer-registerable YAML manifest schemas (extension point
+- [ ] not ReportLab-specific enums in core)
+- [ ] TROUBLESHOOTING aligned with implemented config types
+- [ ] lookup_docs document-quality topic returns generic PDF/HTML quality guidance
+- [ ] memory.profile document-builder optional on init when document tooling detected
+- [ ] tapps_impact_analysis nudges rebuild + suggested shell judge when reports/templates/brands paths change
+
+<!-- docsmcp:end:acceptance-criteria -->
+
+<!-- docsmcp:start:stories -->
+## Stories
+
+### 107.1 -- validators: pluggable consumer YAML manifest validation
+
+**Points:** 3
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement validators: pluggable consumer yaml manifest validation
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** validators: pluggable consumer YAML manifest validation is implemented, tests pass, and documentation is updated.
+
+---
+
+### 107.2 -- session_start_helpers.py: document-quality lookup_docs pack
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement session_start_helpers.py: document-quality lookup_docs pack
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** session_start_helpers.py: document-quality lookup_docs pack is implemented, tests pass, and documentation is updated.
+
+---
+
+### 107.3 -- init.py: document-builder memory profile preset
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement init.py: document-builder memory profile preset
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** init.py: document-builder memory profile preset is implemented, tests pass, and documentation is updated.
+
+---
+
+### 107.4 -- server_analysis_tools.py: impact rebuild-documents nudge
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement server_analysis_tools.py: impact rebuild-documents nudge
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** server_analysis_tools.py: impact rebuild-documents nudge is implemented, tests pass, and documentation is updated.
+
+---
+
+### 107.5 -- TROUBLESHOOTING.md: fix yaml config_type doc drift
+
+**Points:** 1
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement troubleshooting.md: fix yaml config_type doc drift
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** TROUBLESHOOTING.md: fix yaml config_type doc drift is implemented, tests pass, and documentation is updated.
+
+---
+
+<!-- docsmcp:end:stories -->
+
+<!-- docsmcp:start:technical-notes -->
+## Technical Notes
+
+- Document architecture decisions for **Document config validation and agent guidance**...
+
+<!-- docsmcp:end:technical-notes -->
+
+<!-- docsmcp:start:non-goals -->
+## Out of Scope / Future Considerations
+
+- - Do not embed ReportLab-specific glossary.outward or audit_profile enums in tapps-core
+- Do not run PDF rendering inside tapps-mcp
+
+<!-- docsmcp:end:non-goals -->

--- a/docs/epics/stories/STORY-104.1.md
+++ b/docs/epics/stories/STORY-104.1.md
@@ -1,0 +1,23 @@
+# judge.py: wire blocking judges into all_gates_passed
+
+## What
+
+Fold blocking judge failures into the primary validate_changed pass/fail signal.
+
+## Where
+
+- `packages/tapps-core/src/tapps_core/metrics/judge.py:1-226`
+- `packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py:383-424`
+- `packages/tapps-mcp/src/tapps_mcp/common/output_schemas.py:125-136`
+
+## Acceptance
+
+- [ ] - [ ] When any blocking judge returns fail or error
+- [ ] all_gates_passed is false
+- [ ] ValidateChangedOutput.overall_passed reflects blocking judge failures
+- [ ] Non-blocking judge failures leave all_gates_passed unchanged
+- [ ] Unit tests in test_judge.py and validate_changed tests cover the integration
+
+## Refs
+
+docs/epics/EPIC-104.md

--- a/docs/epics/stories/STORY-104.2.md
+++ b/docs/epics/stories/STORY-104.2.md
@@ -1,0 +1,21 @@
+# validate_changed_output.py: judge rows in summary_rows
+
+## What
+
+Surface judge_results in the visible summary table and CLI output so agents do not ignore buried JSON fields.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py:286-322`
+- `packages/tapps-mcp/src/tapps_mcp/cli.py:512-577`
+
+## Acceptance
+
+- [ ] - [ ] Each judge result appends a PASS/FAIL row to summary_rows (grep-friendly)
+- [ ] CLI validate-changed echoes judge rows and exits non-zero on blocking judge fail
+- [ ] Human summary string mentions judge pass/fail counts
+- [ ] Unit test asserts summary_rows contains judge rows when judges run
+
+## Refs
+
+docs/epics/EPIC-104.md

--- a/docs/epics/stories/STORY-104.3.md
+++ b/docs/epics/stories/STORY-104.3.md
@@ -1,0 +1,27 @@
+# judge.py: add shell command judge type
+
+## What
+
+Add generic subprocess judge for consumer audit CLIs (report-studio audit, npm test, docker compose config).
+
+## Where
+
+- `packages/tapps-core/src/tapps_core/metrics/judge.py:1-226`
+- `packages/tapps-core/src/tapps_core/config/settings.py:748-758`
+
+## Acceptance
+
+- [ ] - [ ] JudgeDefinition accepts type shell (alias command) with target command string
+- [ ] Subprocess runs with cwd=project_root
+- [ ] inherited env
+- [ ] configurable timeout (default 300s)
+- [ ] Exit code 0 is pass; non-zero is fail with stderr tail in message
+- [ ] Settings docstring and validate_changed docstring list shell type
+- [ ] Unit tests cover pass
+- [ ] fail
+- [ ] timeout
+- [ ] and missing command
+
+## Refs
+
+docs/epics/EPIC-104.md

--- a/docs/epics/stories/STORY-104.4.md
+++ b/docs/epics/stories/STORY-104.4.md
@@ -1,0 +1,25 @@
+# judge.py: add when_changed glob filter for judges
+
+## What
+
+Optional glob list so slow document rebuild/audit judges run only when relevant paths change.
+
+## Where
+
+- `packages/tapps-core/src/tapps_core/metrics/judge.py:1-226`
+- `packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py:560-621`
+
+## Acceptance
+
+- [ ] - [ ] JudgeDefinition accepts optional when_changed list of glob patterns
+- [ ] Judge skipped (result pass
+- [ ] message skipped) when git diff vs base_ref touches no matching paths
+- [ ] Judge runs when any changed path matches a when_changed glob
+- [ ] Empty when_changed means always run (backward compatible)
+- [ ] Unit tests cover match
+- [ ] no-match skip
+- [ ] and empty when_changed
+
+## Refs
+
+docs/epics/EPIC-104.md

--- a/docs/epics/stories/STORY-105.1.md
+++ b/docs/epics/stories/STORY-105.1.md
@@ -1,0 +1,25 @@
+# init.py: auto-merge discovered judge preset
+
+## What
+
+Auto-merge discovered judge preset on init/upgrade for document-shipping consumers.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/pipeline/init.py:940-965`
+- `packages/tapps-mcp/src/tapps_mcp/pipeline/report_studio/installer.py:172-186`
+- `packages/tapps-core/src/tapps_core/config/settings.py:748-758`
+
+## Acceptance
+
+- [ ] - [ ] tapps_init and tapps_upgrade merge validate_changed.judges when document tooling detected
+- [ ] Preset uses path discovery (reports/
+- [ ] build script glob
+- [ ] audit test glob) not hard-coded ReportLab paths
+- [ ] Merged judges default blocking true for document audit gates
+- [ ] Existing consumer-defined judges are preserved (merge not overwrite)
+- [ ] Unit test uses fixture project_root with nlt-report-studio pin
+
+## Refs
+
+docs/epics/EPIC-105.md

--- a/docs/epics/stories/STORY-105.2.md
+++ b/docs/epics/stories/STORY-105.2.md
@@ -1,0 +1,25 @@
+# doctor.py: report judge configuration status
+
+## What
+
+Extend doctor report-studio row to surface validate_changed.judges configuration status.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py:3290-3410`
+- `packages/tapps-core/src/tapps_core/config/settings.py:748-758`
+
+## Acceptance
+
+- [ ] - [ ] doctor check_report_studio row includes judges configured or missing detail
+- [ ] When installed but judges empty
+- [ ] detail recommends validate_changed.judges preset
+- [ ] When judges present
+- [ ] lists count and blocking vs advisory split
+- [ ] Unit test covers installed+judges
+- [ ] installed+no-judges
+- [ ] not-installed
+
+## Refs
+
+docs/epics/EPIC-105.md

--- a/docs/epics/stories/STORY-105.3.md
+++ b/docs/epics/stories/STORY-105.3.md
@@ -1,0 +1,21 @@
+# checklist.py: add task_type document profile
+
+## What
+
+Add checklist profile for PDF/HTML/document work mentioning judges and config validation.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/tools/checklist.py:152-293`
+- `packages/tapps-mcp/src/tapps_mcp/tools/checklist_policy.py:1-100`
+
+## Acceptance
+
+- [ ] - [ ] task_type document added to TASK_TOOL_MAP and high/medium/low engagement maps
+- [ ] Required includes tapps_validate_changed; recommended includes tapps_validate_config and tapps_lookup_docs
+- [ ] TOOL_REASONS documents when to use document task_type
+- [ ] Unit test asserts document policy resolves and unknown task_type no longer falls back for document
+
+## Refs
+
+docs/epics/EPIC-105.md

--- a/docs/epics/stories/STORY-106.1.md
+++ b/docs/epics/stories/STORY-106.1.md
@@ -1,0 +1,23 @@
+# settings.py: report_authoring preset path overrides
+
+## What
+
+Add report_authoring preset or path-based test_coverage overrides for narrative layout modules.
+
+## Where
+
+- `packages/tapps-core/src/tapps_core/config/settings.py:73-78`
+- `packages/tapps-mcp/src/tapps_mcp/scoring/scorer.py:509-523`
+- `packages/tapps-mcp/src/tapps_mcp/config/default.yaml:1-20`
+
+## Acceptance
+
+- [ ] - [ ] quality_preset report_authoring registered in PRESETS or scoring path overrides config
+- [ ] Consumer can set narrative_path_globs (default reports/**) with test_coverage weight 0
+- [ ] reports/foo/story.py passes gate when other categories pass and no unit test exists
+- [ ] src/ modules still use standard test_coverage weight under report_authoring preset
+- [ ] Unit tests cover preset selection and path glob matching
+
+## Refs
+
+docs/epics/EPIC-106.md

--- a/docs/epics/stories/STORY-107.1.md
+++ b/docs/epics/stories/STORY-107.1.md
@@ -1,0 +1,22 @@
+# validators: pluggable consumer YAML manifest validation
+
+## What
+
+Extension point for consumer brand/template YAML validation without ReportLab-specific core schemas.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/validators/base.py:1-143`
+- `packages/tapps-mcp/src/tapps_mcp/server.py:364-373`
+
+## Acceptance
+
+- [ ] - [ ] validate_config accepts consumer-registered YAML manifest validators via extension hook or config
+- [ ] Core ships no ReportLab-specific field enums; consumer supplies pydantic model or JSON Schema path
+- [ ] Auto-detect document manifest YAML under brands/ or templates/ when registered
+- [ ] Unit test registers fixture schema and validates sample brand YAML
+- [ ] Invalid manifest returns structured findings like other config types
+
+## Refs
+
+docs/epics/EPIC-107.md

--- a/docs/epics/stories/STORY-107.2.md
+++ b/docs/epics/stories/STORY-107.2.md
@@ -1,0 +1,24 @@
+# session_start_helpers.py: document-quality lookup_docs pack
+
+## What
+
+Add generic document-quality lookup_docs topic pack for PDF/HTML output pitfalls.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py:800-810`
+- `packages/tapps-mcp/src/tapps_mcp/server.py:1-50`
+
+## Acceptance
+
+- [ ] - [ ] search_first includes document-quality topic with generic PDF/HTML guidance triggers
+- [ ] tapps_lookup_docs(library=document-quality
+- [ ] topic=...) returns cached guidance on links
+- [ ] outlines
+- [ ] thin pages
+- [ ] Guidance is library-agnostic; reportlab/weasyprint topics remain separate library lookups
+- [ ] Unit test asserts document-quality entry present when reports/ or document tooling detected
+
+## Refs
+
+docs/epics/EPIC-107.md

--- a/docs/epics/stories/STORY-107.3.md
+++ b/docs/epics/stories/STORY-107.3.md
@@ -1,0 +1,23 @@
+# init.py: document-builder memory profile preset
+
+## What
+
+Optional document-builder memory profile with auto-recall keys for document-shipping repos.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/pipeline/init.py:940-965`
+- `packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py:1-80`
+
+## Acceptance
+
+- [ ] - [ ] Optional memory.profile document-builder offered on init when document tooling detected
+- [ ] Profile seeds architectural keys: code gate vs document gate
+- [ ] audit profiles
+- [ ] env ROOT siblings pattern
+- [ ] Consumer can override or disable via .tapps-mcp.yaml
+- [ ] Unit test asserts profile suggestion in init result when reports/ present
+
+## Refs
+
+docs/epics/EPIC-107.md

--- a/docs/epics/stories/STORY-107.4.md
+++ b/docs/epics/stories/STORY-107.4.md
@@ -1,0 +1,23 @@
+# server_analysis_tools.py: impact rebuild-documents nudge
+
+## What
+
+Enrich impact analysis with rebuild-documents nudge when layout or template modules change.
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/server_analysis_tools.py:300-400`
+- `packages/tapps-mcp/src/tapps_mcp/server_helpers.py:268-290`
+
+## Acceptance
+
+- [ ] - [ ] tapps_impact_analysis adds recommendation when changed file is under reports/
+- [ ] templates/
+- [ ] or brands/
+- [ ] Recommendation includes suggested shell judge command placeholder and rebuild hint
+- [ ] Nudge suppressed for unrelated src/ changes outside document paths
+- [ ] Unit test covers document path match and non-match
+
+## Refs
+
+docs/epics/EPIC-107.md

--- a/docs/epics/stories/STORY-107.5.md
+++ b/docs/epics/stories/STORY-107.5.md
@@ -1,0 +1,21 @@
+# TROUBLESHOOTING.md: fix yaml config_type doc drift
+
+## What
+
+Align TROUBLESHOOTING validate_config yaml guidance with actual core config types.
+
+## Where
+
+- `docs/TROUBLESHOOTING.md:37-51`
+- `packages/tapps-mcp/src/tapps_mcp/server.py:364-373`
+
+## Acceptance
+
+- [ ] - [ ] TROUBLESHOOTING documents only implemented validate_config types OR points to extension hook from 107.1
+- [ ] Remove or qualify config_type yaml example until pluggable validator ships
+- [ ] Cross-link checklist-policy.yaml pattern for brand YAML changes
+- [ ] No misleading copy-paste example that returns invalid_config_type today
+
+## Refs
+
+docs/epics/EPIC-107.md

--- a/packages/tapps-core/src/tapps_core/config/settings.py
+++ b/packages/tapps-core/src/tapps_core/config/settings.py
@@ -75,6 +75,7 @@ PRESETS: dict[str, dict[str, float]] = {
     "standard": {"overall_min": 70.0, "security_min": 0.0, "maintainability_min": 0.0},
     "strict": {"overall_min": 80.0, "security_min": 8.0, "maintainability_min": 7.0},
     "framework": {"overall_min": 75.0, "security_min": 8.5, "maintainability_min": 7.5},
+    "report_authoring": {"overall_min": 70.0, "security_min": 0.0, "maintainability_min": 0.0},
 }
 
 
@@ -745,6 +746,23 @@ def _extra_mode() -> Literal["ignore", "forbid"]:
     return "ignore"
 
 
+class ManifestValidationSettings(BaseModel):
+    """Consumer YAML manifest validation for document repos."""
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable YAML manifest validation for configured path globs.",
+    )
+    path_globs: list[str] = Field(
+        default_factory=lambda: ["brands/**/*.yaml", "brands/**/*.yml", "templates/**/*.yaml"],
+        description="Glob patterns for manifest YAML files relative to project root.",
+    )
+    required_keys: list[str] = Field(
+        default_factory=list,
+        description="Optional top-level keys every matched manifest must contain.",
+    )
+
+
 class ValidateChangedSettings(BaseModel):
     """Defaults for ``tapps_validate_changed`` batch validation."""
 
@@ -752,8 +770,9 @@ class ValidateChangedSettings(BaseModel):
         default_factory=list,
         description=(
             "Default post-gate judges merged when the MCP tool is called without "
-            "an explicit judges argument. Each entry: type (pytest|grep|exists), "
-            "target, optional expect, description, blocking (default False)."
+            "an explicit judges argument. Each entry: type (pytest|grep|exists|shell), "
+            "target, optional expect, description, blocking (default False), "
+            "optional when_changed globs, optional timeout_s for shell judges."
         ),
     )
 
@@ -813,7 +832,18 @@ class TappsMCPSettings(BaseSettings):
     )
     quality_preset: str = Field(
         default="standard",
-        description="Quality gate preset: standard, strict, or framework.",
+        description="Quality gate preset: standard, strict, framework, or report_authoring.",
+    )
+    narrative_path_globs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Path globs where test_coverage weight is zeroed (e.g. reports/**). "
+            "Defaults to reports/** when quality_preset is report_authoring."
+        ),
+    )
+    manifest_validation: ManifestValidationSettings = Field(
+        default_factory=ManifestValidationSettings,
+        description="Optional consumer YAML manifest validation settings.",
     )
     log_level: str = Field(
         default="INFO",

--- a/packages/tapps-core/src/tapps_core/metrics/judge.py
+++ b/packages/tapps-core/src/tapps_core/metrics/judge.py
@@ -1,33 +1,38 @@
 """Judge pattern for tapps_validate_changed (TAP-478).
 
-Provides declarative pass/fail criteria (pytest, grep, exists) that run
+Provides declarative pass/fail criteria (pytest, grep, exists, shell) that run
 alongside the quality gate.  Stolen from the ECC eval-harness skill.
 """
 
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import re
+import shlex
+import subprocess
 from pathlib import Path
 from typing import Any, Literal
 
 import structlog
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 _logger = structlog.get_logger(__name__)
 
-JudgeType = Literal["pytest", "grep", "exists"]
+JudgeType = Literal["pytest", "grep", "exists", "shell", "command"]
+JudgeOutcome = Literal["pass", "fail", "error", "skipped"]
 
 
 class JudgeDefinition(BaseModel):
     """A single declarative pass/fail criterion."""
 
-    type: JudgeType = Field(description="Judge type: pytest | grep | exists")
+    type: JudgeType = Field(description="Judge type: pytest | grep | exists | shell | command")
     target: str = Field(
         description=(
             "For pytest: pytest target (e.g. 'tests/unit/', 'tests/unit/test_foo.py'). "
             "For grep: file path to search. "
-            "For exists: file path that must exist."
+            "For exists: file path that must exist. "
+            "For shell/command: command string to execute."
         )
     )
     expect: str = Field(
@@ -35,7 +40,8 @@ class JudgeDefinition(BaseModel):
         description=(
             "For pytest: ignored (exit 0 = pass). "
             "For grep: regex pattern that must match at least one line. "
-            "For exists: ignored (path must exist)."
+            "For exists: ignored (path must exist). "
+            "For shell/command: ignored (exit code 0 = pass)."
         ),
     )
     description: str = Field(
@@ -47,6 +53,23 @@ class JudgeDefinition(BaseModel):
         description="When True, judge failure counts as an overall validation failure. "
         "Default False (advisory only) for v1.",
     )
+    when_changed: list[str] = Field(
+        default_factory=list,
+        description="Optional glob list. Judge runs only when a changed path matches.",
+    )
+    timeout_s: int = Field(
+        default=300,
+        ge=1,
+        le=3600,
+        description="Timeout for shell/command judges (seconds).",
+    )
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def _normalise_shell_alias(cls, value: object) -> object:
+        if value == "command":
+            return "shell"
+        return value
 
 
 class JudgeResult(BaseModel):
@@ -54,27 +77,72 @@ class JudgeResult(BaseModel):
 
     judge: str = Field(description="Judge description or type:target key.")
     type: JudgeType
-    result: Literal["pass", "fail", "error"]
+    result: JudgeOutcome
     message: str = Field(default="")
     blocking: bool = Field(default=False)
 
 
-async def run_judge(jd: JudgeDefinition, cwd: Path | None = None) -> JudgeResult:
-    """Execute a single JudgeDefinition and return its result.
+def _path_matches_glob(path: str, pattern: str) -> bool:
+    normalised = path.replace("\\", "/")
+    return fnmatch.fnmatch(normalised, pattern)
 
-    Args:
-        jd: The judge definition to execute.
-        cwd: Working directory for subprocess judges (pytest). Defaults to cwd.
-    """
+
+def _should_run_judge(jd: JudgeDefinition, changed_paths: list[str] | None) -> bool:
+    if not jd.when_changed:
+        return True
+    if not changed_paths:
+        return True
+    return any(
+        _path_matches_glob(changed, pattern)
+        for changed in changed_paths
+        for pattern in jd.when_changed
+    )
+
+
+def _git_changed_paths(cwd: Path, base_ref: str) -> list[str]:
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", base_ref],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    return [line.strip().replace("\\", "/") for line in proc.stdout.splitlines() if line.strip()]
+
+
+async def run_judge(
+    jd: JudgeDefinition,
+    cwd: Path | None = None,
+    *,
+    changed_paths: list[str] | None = None,
+) -> JudgeResult:
+    """Execute a single JudgeDefinition and return its result."""
     label = jd.description or f"{jd.type}:{jd.target}"
     work_dir = cwd or Path.cwd()
 
+    if not _should_run_judge(jd, changed_paths):
+        return JudgeResult(
+            judge=label,
+            type=jd.type,
+            result="skipped",
+            message="Skipped: no changed paths matched when_changed globs",
+            blocking=jd.blocking,
+        )
+
     if jd.type == "exists":
-        return await _run_exists_judge(jd, label)
+        return await _run_exists_judge(jd, label, work_dir)
     if jd.type == "grep":
-        return await _run_grep_judge(jd, label)
+        return await _run_grep_judge(jd, label, work_dir)
     if jd.type == "pytest":
         return await _run_pytest_judge(jd, label, work_dir)
+    if jd.type == "shell":
+        return await _run_shell_judge(jd, label, work_dir)
 
     return JudgeResult(
         judge=label,
@@ -85,8 +153,10 @@ async def run_judge(jd: JudgeDefinition, cwd: Path | None = None) -> JudgeResult
     )
 
 
-async def _run_exists_judge(jd: JudgeDefinition, label: str) -> JudgeResult:
+async def _run_exists_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:
     path = Path(jd.target)
+    if not path.is_absolute():
+        path = cwd / path
     exists = path.exists()
     return JudgeResult(
         judge=label,
@@ -97,8 +167,10 @@ async def _run_exists_judge(jd: JudgeDefinition, label: str) -> JudgeResult:
     )
 
 
-async def _run_grep_judge(jd: JudgeDefinition, label: str) -> JudgeResult:
+async def _run_grep_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:
     file_path = Path(jd.target)
+    if not file_path.is_absolute():
+        file_path = cwd / file_path
     if not file_path.exists():
         return JudgeResult(
             judge=label,
@@ -184,21 +256,70 @@ async def _run_pytest_judge(jd: JudgeDefinition, label: str, cwd: Path) -> Judge
         )
 
 
+async def _run_shell_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *shlex.split(jd.target),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(cwd),
+        )
+        try:
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=jd.timeout_s)
+        except TimeoutError:
+            proc.kill()
+            return JudgeResult(
+                judge=label,
+                type="shell",
+                result="error",
+                message=f"shell judge timed out after {jd.timeout_s}s: {jd.target}",
+                blocking=jd.blocking,
+            )
+        passed = proc.returncode == 0
+        err_hint = stderr.decode(errors="replace").strip()[-200:] if stderr else ""
+        return JudgeResult(
+            judge=label,
+            type="shell",
+            result="pass" if passed else "fail",
+            message=(
+                f"shell exit {proc.returncode} for {jd.target!r}"
+                + (f": {err_hint}" if err_hint and not passed else "")
+            ),
+            blocking=jd.blocking,
+        )
+    except FileNotFoundError:
+        return JudgeResult(
+            judge=label,
+            type="shell",
+            result="error",
+            message=f"shell command not found: {jd.target}",
+            blocking=jd.blocking,
+        )
+    except Exception as exc:
+        return JudgeResult(
+            judge=label,
+            type="shell",
+            result="error",
+            message=f"Unexpected error running shell judge: {exc}",
+            blocking=jd.blocking,
+        )
+
+
 async def run_judges(
     definitions: list[dict[str, Any]],
     cwd: Path | None = None,
+    *,
+    changed_paths: list[str] | None = None,
+    base_ref: str = "HEAD",
 ) -> dict[str, Any]:
-    """Run a list of raw judge dicts and return aggregated results.
-
-    Args:
-        definitions: List of dicts matching JudgeDefinition fields.
-        cwd: Working directory for subprocess judges.
-
-    Returns:
-        Dict with ``judge_results`` list and ``judges_passed`` bool.
-    """
+    """Run a list of raw judge dicts and return aggregated results."""
     if not definitions:
         return {"judge_results": [], "judges_passed": True}
+
+    work_dir = cwd or Path.cwd()
+    effective_changed = changed_paths
+    if effective_changed is None and any(d.get("when_changed") for d in definitions):
+        effective_changed = _git_changed_paths(work_dir, base_ref)
 
     parsed: list[JudgeDefinition] = []
     parse_errors: list[str] = []
@@ -215,9 +336,16 @@ async def run_judges(
             "judge_parse_errors": parse_errors,
         }
 
-    results = await asyncio.gather(*[run_judge(jd, cwd) for jd in parsed])
+    results = await asyncio.gather(
+        *[
+            run_judge(jd, work_dir, changed_paths=effective_changed)
+            for jd in parsed
+        ]
+    )
 
-    any_blocking_fail = any(r.result in {"fail", "error"} and r.blocking for r in results)
+    any_blocking_fail = any(
+        r.result in {"fail", "error"} and r.blocking for r in results
+    )
 
     return {
         "judge_results": [r.model_dump() for r in results],

--- a/packages/tapps-core/tests/unit/test_judge.py
+++ b/packages/tapps-core/tests/unit/test_judge.py
@@ -28,6 +28,10 @@ class TestJudgeDefinition:
         jd = JudgeDefinition(type="pytest", target="tests/unit/")
         assert jd.type == "pytest"
 
+    def test_command_alias_normalises_to_shell(self) -> None:
+        jd = JudgeDefinition(type="command", target="true")
+        assert jd.type == "shell"
+
 
 class TestExistsJudge:
     @pytest.mark.asyncio
@@ -97,6 +101,55 @@ class TestPytestJudge:
             jd = JudgeDefinition(type="pytest", target="tests/")
             result = await run_judge(jd, cwd=tmp_path)
         assert result.result == "error"
+
+
+class TestShellJudge:
+    @pytest.mark.asyncio
+    async def test_successful_shell_returns_pass(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            jd = JudgeDefinition(type="shell", target="true")
+            result = await run_judge(jd, cwd=tmp_path)
+        assert result.result == "pass"
+
+    @pytest.mark.asyncio
+    async def test_failing_shell_returns_fail(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"failed"))
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            jd = JudgeDefinition(type="shell", target="false")
+            result = await run_judge(jd, cwd=tmp_path)
+        assert result.result == "fail"
+
+
+class TestWhenChanged:
+    @pytest.mark.asyncio
+    async def test_skipped_when_no_changed_paths_match(self, tmp_path: Path) -> None:
+        jd = JudgeDefinition(
+            type="exists",
+            target=str(tmp_path / "missing.txt"),
+            when_changed=["reports/**"],
+        )
+        result = await run_judge(jd, changed_paths=["src/foo.py"])
+        assert result.result == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_runs_when_changed_path_matches(self, tmp_path: Path) -> None:
+        target = tmp_path / "reports" / "foo.py"
+        target.parent.mkdir(parents=True)
+        target.touch()
+        jd = JudgeDefinition(
+            type="exists",
+            target=str(target),
+            when_changed=["reports/**"],
+        )
+        result = await run_judge(jd, changed_paths=["reports/foo.py"])
+        assert result.result == "pass"
 
 
 class TestRunJudges:

--- a/packages/tapps-mcp/src/tapps_mcp/cli.py
+++ b/packages/tapps-mcp/src/tapps_mcp/cli.py
@@ -573,7 +573,7 @@ def validate_changed_cmd(quick: bool, file_paths: str, project_root: str) -> Non
             raise SystemExit(1)
         data = result.get("data", {})
         _echo_validate_changed_data(data)
-        if not data.get("all_gates_passed", False):
+        if not data.get("all_gates_passed", False) or not data.get("judges_passed", True):
             raise SystemExit(1)
 
     asyncio.run(_run())

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -3300,7 +3300,22 @@ def check_report_studio(project_root: Path) -> CheckResult:
                 "Not installed (run tapps_init with with_report_studio=True)",
             )
         count = probe.get("report_count", 0)
-        detail = f"Pinned in pyproject.toml ({count} report(s) under reports/)"
+        from tapps_core.config.settings import load_settings
+        from tapps_mcp.pipeline.document_judges import summarise_configured_judges
+
+        settings = load_settings(project_root=project_root)
+        judge_summary = summarise_configured_judges(settings.validate_changed.judges)
+        if judge_summary["configured"]:
+            detail = (
+                f"Pinned in pyproject.toml ({count} report(s)); "
+                f"judges configured ({judge_summary['blocking']} blocking, "
+                f"{judge_summary['advisory']} advisory)"
+            )
+        else:
+            detail = (
+                f"Pinned in pyproject.toml ({count} report(s)); "
+                "judges missing — run tapps_init/tapps_upgrade or add validate_changed.judges"
+            )
         return CheckResult("report_studio", True, detail)
     except Exception as exc:
         return CheckResult("report_studio", False, f"Check failed: {exc}")

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/document_judges.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/document_judges.py
@@ -1,0 +1,205 @@
+"""Document-output judge presets and configuration helpers (EPIC-104/105)."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tapps_mcp.pipeline.report_studio.installer import check_report_studio
+
+_DOCUMENT_PATH_MARKERS = ("reports/", "templates/", "brands/")
+
+
+def is_document_consumer(project_root: Path) -> bool:
+    """Return True when the project looks like a document-shipping consumer."""
+    root = project_root.resolve()
+    if check_report_studio(root).get("installed"):
+        return True
+    return (root / "reports").is_dir()
+
+
+def _find_build_script(project_root: Path) -> Path | None:
+    candidates = sorted(project_root.glob("**/build-pdfs.mjs"))
+    if not candidates:
+        candidates = sorted(project_root.glob("**/build*.mjs"))
+    return candidates[0] if candidates else None
+
+
+def _find_pdf_audit_test(project_root: Path) -> Path | None:
+    for pattern in (
+        "tests/test_pdf_audit.py",
+        "tests/unit/test_pdf_audit.py",
+        "test/test_pdf_audit.py",
+    ):
+        candidate = project_root / pattern
+        if candidate.is_file():
+            return candidate
+    matches = sorted(project_root.glob("**/test_pdf_audit.py"))
+    return matches[0] if matches else None
+
+
+def discover_document_judge_preset(project_root: Path) -> list[dict[str, Any]]:
+    """Return blocking judge presets discovered for document consumers."""
+    root = project_root.resolve()
+    if not is_document_consumer(root):
+        return []
+
+    judges: list[dict[str, Any]] = []
+    build_script = _find_build_script(root)
+    if build_script is not None:
+        judges.append(
+            {
+                "type": "grep",
+                "target": str(build_script.relative_to(root)),
+                "expect": r"--audit",
+                "description": "Site prebuild runs document build with post-build audit",
+                "blocking": True,
+                "when_changed": [
+                    str(build_script.relative_to(root)),
+                    "reports/**",
+                    "src/**",
+                    "brands/**",
+                    "templates/**",
+                ],
+            }
+        )
+
+    audit_test = _find_pdf_audit_test(root)
+    if audit_test is not None:
+        rel = audit_test.relative_to(root)
+        judges.append(
+            {
+                "type": "pytest",
+                "target": str(rel.parent if rel.name.startswith("test_") else rel),
+                "description": "PDF audit CLI contract tests",
+                "blocking": True,
+                "when_changed": ["reports/**", "src/**", "brands/**", "templates/**"],
+            }
+        )
+        if rel.name == "test_pdf_audit.py":
+            judges[-1]["target"] = str(rel)
+
+    return judges
+
+
+def summarise_configured_judges(judges: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarise validate_changed.judges for doctor output."""
+    if not judges:
+        return {"configured": False, "count": 0, "blocking": 0, "advisory": 0}
+    blocking = sum(1 for j in judges if j.get("blocking"))
+    return {
+        "configured": True,
+        "count": len(judges),
+        "blocking": blocking,
+        "advisory": len(judges) - blocking,
+    }
+
+
+def merge_document_judges_into_yaml(project_root: Path, *, dry_run: bool = False) -> dict[str, Any]:
+    """Merge discovered document judges into `.tapps-mcp.yaml` when missing."""
+    root = project_root.resolve()
+    config_path = root / ".tapps-mcp.yaml"
+    preset = discover_document_judge_preset(root)
+    result: dict[str, Any] = {
+        "merged": False,
+        "preset_count": len(preset),
+        "messages": [],
+    }
+    if not preset:
+        result["messages"].append("No document tooling detected — judges unchanged")
+        return result
+
+    existing: dict[str, Any] = {}
+    if config_path.is_file():
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            existing = loaded
+
+    current = existing.get("validate_changed", {})
+    if not isinstance(current, dict):
+        current = {}
+    current_judges = current.get("judges", [])
+    if not isinstance(current_judges, list):
+        current_judges = []
+
+    if current_judges:
+        result["messages"].append(
+            f"validate_changed.judges already has {len(current_judges)} entries — preserved"
+        )
+        return result
+
+    merged = {**existing, "validate_changed": {**current, "judges": preset}}
+    if dry_run:
+        result["merged"] = True
+        result["messages"].append(f"Would merge {len(preset)} document judge(s)")
+        return result
+
+    config_path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+    result["merged"] = True
+    result["messages"].append(f"Merged {len(preset)} document judge(s) into .tapps-mcp.yaml")
+    return result
+
+
+def is_document_layout_path(file_path: Path, project_root: Path) -> bool:
+    """Return True when a changed file lives under document layout directories."""
+    try:
+        rel = file_path.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError:
+        return False
+    return any(marker in f"{rel}/" or rel.startswith(marker.rstrip("/")) for marker in _DOCUMENT_PATH_MARKERS)
+
+
+DOCUMENT_BUILDER_PROFILE = "document-builder"
+
+
+def merge_document_memory_profile(project_root: Path, *, dry_run: bool = False) -> dict[str, Any]:
+    """Set memory.profile to document-builder when document tooling is detected."""
+    root = project_root.resolve()
+    config_path = root / ".tapps-mcp.yaml"
+    result: dict[str, Any] = {
+        "merged": False,
+        "profile": DOCUMENT_BUILDER_PROFILE,
+        "messages": [],
+    }
+    if not is_document_consumer(root):
+        result["messages"].append("Not a document consumer — memory profile unchanged")
+        return result
+
+    existing: dict[str, Any] = {}
+    if config_path.is_file():
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            existing = loaded
+
+    memory = existing.get("memory", {})
+    if isinstance(memory, dict) and memory.get("profile"):
+        result["messages"].append(
+            f"memory.profile already set to {memory.get('profile')!r} — preserved"
+        )
+        return result
+
+    merged_memory = {**(memory if isinstance(memory, dict) else {}), "profile": DOCUMENT_BUILDER_PROFILE}
+    merged = {**existing, "memory": merged_memory}
+    if dry_run:
+        result["merged"] = True
+        result["messages"].append(f"Would set memory.profile to {DOCUMENT_BUILDER_PROFILE!r}")
+        return result
+
+    config_path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+    result["merged"] = True
+    result["messages"].append(f"Set memory.profile to {DOCUMENT_BUILDER_PROFILE!r}")
+    return result
+
+
+def path_matches_narrative_glob(file_path: Path, project_root: Path, globs: list[str]) -> bool:
+    """Return True when file_path matches any narrative path glob."""
+    if not globs:
+        return False
+    try:
+        rel = file_path.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError:
+        rel = file_path.as_posix()
+    return any(fnmatch.fnmatch(rel, pattern) for pattern in globs)

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/init.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/init.py
@@ -959,6 +959,22 @@ def _setup_platform(cfg: BootstrapConfig, state: _BootstrapState) -> None:
                     content_return=state.content_return,
                 )
                 state.created.extend(state.result["report_studio"].get("files_written", []))
+            from tapps_mcp.pipeline.document_judges import (
+                is_document_consumer,
+                merge_document_judges_into_yaml,
+            )
+
+            if is_document_consumer(state.project_root):
+                state.result["document_judges"] = merge_document_judges_into_yaml(
+                    state.project_root,
+                    dry_run=state.dry_run,
+                )
+                from tapps_mcp.pipeline.document_judges import merge_document_memory_profile
+
+                state.result["document_memory_profile"] = merge_document_memory_profile(
+                    state.project_root,
+                    dry_run=state.dry_run,
+                )
             state.result["agents"] = generate_subagent_definitions(state.project_root, "claude")
             state.result["skills"] = generate_skills(
                 state.project_root, "claude", engagement_level=engagement

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/upgrade.py
@@ -1925,6 +1925,27 @@ def upgrade_pipeline(
         result["errors"].append(f"linear_sdlc_refresh: {exc}")
         result["components"]["linear_sdlc_refresh"] = {"action": "error", "detail": str(exc)}
 
+    try:
+        from tapps_mcp.pipeline.document_judges import (
+            is_document_consumer,
+            merge_document_judges_into_yaml,
+        )
+
+        if is_document_consumer(project_root):
+            from tapps_mcp.pipeline.document_judges import merge_document_memory_profile
+
+            result["components"]["document_judges"] = merge_document_judges_into_yaml(
+                project_root,
+                dry_run=dry_run,
+            )
+            result["components"]["document_memory_profile"] = merge_document_memory_profile(
+                project_root,
+                dry_run=dry_run,
+            )
+    except Exception as exc:
+        result["errors"].append(f"document_judges: {exc}")
+        result["components"]["document_judges"] = {"action": "error", "detail": str(exc)}
+
     result["success"] = len(result["errors"]) == 0
     result["consumer_requirements"] = "docs/TAPPS_MCP_REQUIREMENTS.md"
 

--- a/packages/tapps-mcp/src/tapps_mcp/scoring/scorer.py
+++ b/packages/tapps-mcp/src/tapps_mcp/scoring/scorer.py
@@ -509,6 +509,14 @@ class CodeScorer(ScorerBase):
     def _score_test_coverage_category(self, file_path: Path) -> CategoryScore:
         """Test coverage category: heuristic based on test file existence."""
         w = self._weights
+        if self._is_narrative_path(file_path):
+            return CategoryScore(
+                name="test_coverage",
+                score=10.0,
+                weight=0.0,
+                details={"narrative_path": True, "stem": file_path.stem},
+                suggestions=[],
+            )
         coverage = self._coverage_heuristic(file_path)
         details: dict[str, object] = {"stem": file_path.stem}
         details["is_test_file"] = file_path.name.startswith("test_") or file_path.name.endswith(

--- a/packages/tapps-mcp/src/tapps_mcp/scoring/scorer_base.py
+++ b/packages/tapps-mcp/src/tapps_mcp/scoring/scorer_base.py
@@ -57,6 +57,24 @@ class ScorerBase(abc.ABC):
         self._settings = settings or load_settings()
         self._weights = weights or self._settings.scoring_weights
 
+    def _effective_narrative_globs(self) -> list[str]:
+        globs = list(self._settings.narrative_path_globs)
+        if not globs and self._settings.quality_preset == "report_authoring":
+            return ["reports/**"]
+        return globs
+
+    def _is_narrative_path(self, file_path: Path) -> bool:
+        globs = self._effective_narrative_globs()
+        if not globs:
+            return False
+        from tapps_mcp.pipeline.document_judges import path_matches_narrative_glob
+
+        return path_matches_narrative_glob(
+            file_path,
+            self._settings.project_root,
+            globs,
+        )
+
     # ------------------------------------------------------------------
     # Abstract properties (must be implemented by subclasses)
     # ------------------------------------------------------------------

--- a/packages/tapps-mcp/src/tapps_mcp/server.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server.py
@@ -369,6 +369,7 @@ _VALID_CONFIG_TYPES: frozenset[str] = frozenset(
         "mqtt",
         "influxdb",
         "mcp",
+        "yaml_manifest",
     }
 )
 
@@ -1366,10 +1367,11 @@ async def tapps_checklist(
 
     Args:
         task_type: One of ``"feature"``, ``"bugfix"``, ``"refactor"``,
-            ``"security"``, ``"review"`` (default), or ``"epic"``. Each
-            type has its own required-tools matrix; e.g. ``security``
-            requires a security scan, ``epic`` requires the markdown
-            structural check.
+            ``"security"``, ``"review"`` (default), ``"document"``, or
+            ``"epic"``. Each type has its own required-tools matrix; e.g.
+            ``security`` requires a security scan, ``document`` requires
+            ``validate_changed`` with judges for PDF/HTML output work,
+            ``epic`` requires the markdown structural check.
         auto_run: When ``True``, the checklist runs any missing required
             tools itself (``tapps_validate_changed``, etc.) and
             re-evaluates rather than returning a fail. Default ``False``

--- a/packages/tapps-mcp/src/tapps_mcp/server_analysis_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_analysis_tools.py
@@ -371,6 +371,15 @@ async def tapps_impact_analysis(
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_impact_analysis", start, file_path=str(resolved))
 
+    recommendations = list(report.recommendations)
+    from tapps_mcp.pipeline.document_judges import is_document_layout_path
+
+    if is_document_layout_path(resolved, root):
+        recommendations.append(
+            "Document layout/template changed — rebuild shipped PDFs/HTML and run "
+            "validate_changed shell judge (e.g. consumer audit CLI) before declaring done."
+        )
+
     data: dict[str, Any] = {
         "changed_file": report.changed_file,
         "change_type": report.change_type,
@@ -379,7 +388,7 @@ async def tapps_impact_analysis(
         "direct_dependents": [d.model_dump() for d in report.direct_dependents],
         "transitive_dependents": [d.model_dump() for d in report.transitive_dependents],
         "test_files": [t.model_dump() for t in report.test_files],
-        "recommendations": report.recommendations,
+        "recommendations": recommendations,
     }
     data.update(mem_ctx)
 
@@ -400,7 +409,7 @@ async def tapps_impact_analysis(
             total_affected=report.total_affected,
             direct_dependents=[d.file_path for d in report.direct_dependents],
             test_files=[t.file_path for t in report.test_files],
-            recommendations=report.recommendations,
+            recommendations=recommendations,
             memory_context=mem_ctx.get("memory_context", []),
         )
         resp["structuredContent"] = structured.to_structured_content()

--- a/packages/tapps-mcp/src/tapps_mcp/tools/checklist.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/checklist.py
@@ -107,13 +107,15 @@ TOOL_REASONS: dict[str, str] = {
     ),
     "tapps_lookup_docs": "Look up library docs before using an API to avoid hallucinated usage.",
     "tapps_validate_config": (
-        "Validate Dockerfile, docker-compose, or infra config against best practices."
+        "Validate Dockerfile, docker-compose, YAML manifests (config_type=yaml_manifest), "
+        "or other infra config against best practices."
     ),
     "tapps_checklist": (
         "Call before declaring work complete to verify no required steps were skipped."
     ),
     "tapps_validate_changed": (
-        "Batch-validate all changed Python files (score + gate; security when quick=False or security_depth='full') before declaring done."
+        "Batch-validate changed files (score + gate + optional blocking judges). "
+        "For document/PDF work use task_type=document and configure validate_changed.judges."
     ),
     "tapps_quick_check": (
         "Quick score + gate + security in one call. Minimum check after editing any Python file."
@@ -137,6 +139,9 @@ TOOL_REASONS: dict[str, str] = {
     "tapps_release_update": (
         "Generate and validate a release update document body from CHANGELOG or git log."
         " Call before posting a version release to Linear via the linear-release-update skill."
+    ),
+    "tapps_impact_analysis": (
+        "Map blast radius before editing layout modules; document work should rebuild outputs."
     ),
     "tapps_audit_close_coverage": (
         "Close an audit finding's brain coverage after a fix lands — updates the file's"
@@ -191,6 +196,11 @@ TASK_TOOL_MAP: dict[str, dict[str, list[str]]] = {
         "recommended": ["tapps_dependency_scan"],
         "optional": ["tapps_checklist"],
     },
+    "document": {
+        "required": ["tapps_validate_changed"],
+        "recommended": ["tapps_validate_config", "tapps_lookup_docs", "tapps_checklist"],
+        "optional": ["tapps_impact_analysis", "tapps_memory"],
+    },
 }
 
 # High engagement: more tools required (stricter)
@@ -240,6 +250,11 @@ TASK_TOOL_MAP_HIGH: dict[str, dict[str, list[str]]] = {
         "recommended": ["tapps_checklist", "tapps_security_scan"],
         "optional": [],
     },
+    "document": {
+        "required": ["tapps_validate_changed", "tapps_checklist"],
+        "recommended": ["tapps_validate_config", "tapps_lookup_docs", "tapps_quality_gate"],
+        "optional": ["tapps_impact_analysis", "tapps_memory"],
+    },
 }
 
 # Low engagement: fewer tools required (lighter)
@@ -279,6 +294,11 @@ TASK_TOOL_MAP_LOW: dict[str, dict[str, list[str]]] = {
         "recommended": ["tapps_dependency_scan"],
         "optional": ["tapps_checklist"],
     },
+    "document": {
+        "required": ["tapps_validate_changed"],
+        "recommended": ["tapps_validate_config", "tapps_lookup_docs"],
+        "optional": ["tapps_checklist", "tapps_impact_analysis"],
+    },
 }
 
 # Alias for medium (same as TASK_TOOL_MAP)
@@ -291,6 +311,14 @@ _ENGAGEMENT_TOOL_MAP: dict[str, dict[str, dict[str, list[str]]]] = {
 }
 
 KNOWN_TASK_TYPES: frozenset[str] = frozenset(TASK_TOOL_MAP.keys())
+
+TASK_TYPE_REASONS: dict[str, str] = {
+    "document": (
+        "Document/PDF/HTML output work: run validate_changed with blocking judges "
+        "(shell/pytest audit CLIs), validate_config for brand/template YAML manifests, "
+        "and rebuild shipped outputs after layout changes."
+    ),
+}
 
 # Primary tool -> checklist tool names satisfied by calling the primary (success only).
 _TOOL_EQUIVALENTS: dict[str, frozenset[str]] = {}
@@ -405,6 +433,10 @@ class ChecklistResult(BaseModel):
     )
     satisfied_optional_tools: list[str] = Field(
         default_factory=list, description="Optional tools satisfied (including equivalents)."
+    )
+    task_type_hint: str = Field(
+        default="",
+        description="When set, explains when to use this task_type (document, epic, etc.).",
     )
     complete: bool = Field(default=False, description="All required tools have been called.")
     total_calls: int = Field(default=0, description="Total tool calls this session.")
@@ -701,6 +733,7 @@ class CallTracker:
 
         return ChecklistResult(
             task_type=task_type,
+            task_type_hint=TASK_TYPE_REASONS.get(resolved_key, ""),
             resolved_policy_task_type=resolved_key,
             policy_fallback=policy_fallback,
             checklist_policy_version=policy_version,

--- a/packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py
@@ -803,6 +803,10 @@ _DOCS_COVERED: dict[str, tuple[str, str]] = {
     "jinja2": ("templates", "Environment, Template, filters, macros"),
     "reportlab": ("canvas", "Canvas, Platypus, flowables, PDF generation"),
     "pypdf": ("merging", "PdfReader, PdfWriter, pages, annotations"),
+    "document-quality": (
+        "pdf output",
+        "Thin pages, link annotations, PDF outlines/bookmarks, HTML-to-PDF pitfalls",
+    ),
     "aiohttp": ("client", "ClientSession, request, streaming"),
     "celery": ("tasks", "Task, apply_async, beat schedule"),
     "redis": ("commands", "Pipeline, pubsub, async client"),
@@ -939,6 +943,18 @@ def _build_search_first(project_root: Path) -> dict[str, Any] | None:
             covered.append({"library": norm, "topic": topic, "reason": reason})
         else:
             unknown.append(norm)
+
+    try:
+        from tapps_mcp.pipeline.document_judges import is_document_consumer
+
+        if is_document_consumer(project_root):
+            topic, reason = _DOCS_COVERED["document-quality"]
+            if not any(entry.get("library") == "document-quality" for entry in covered):
+                covered.append(
+                    {"library": "document-quality", "topic": topic, "reason": reason}
+                )
+    except Exception:
+        _logger.debug("search_first_document_quality_failed", exc_info=True)
 
     covered.sort(key=lambda x: x["library"])
 

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
@@ -38,7 +38,7 @@ import structlog
 from mcp.server.fastmcp import Context
 
 from tapps_core.knowledge.kg_keys import entity_spec
-from tapps_mcp.server_helpers import _get_brain_bridge, success_response
+from tapps_mcp.server_helpers import success_response
 
 _logger = structlog.get_logger(__name__)
 
@@ -72,6 +72,7 @@ from tapps_mcp.tools.validate_changed_output import (
     _handle_no_changed_files,
     _resolve_security_depth,
     _run_judges,
+    apply_judge_payload,
 )
 from tapps_mcp.tools.validation_progress import (
     _PROGRESS_HEARTBEAT_INTERVAL,
@@ -410,12 +411,30 @@ async def _assemble_response(
         correlation_id=bc.correlation_id,
         timeout_info=outcome.timeout_info,
     )
+    overall_passed = outcome.all_passed
     if bc.judges:
-        resp_data.update(await _run_judges(bc.judges, bc.settings.project_root))
+        changed_rel = [
+            str(p.relative_to(bc.settings.project_root))
+            if p.is_relative_to(bc.settings.project_root)
+            else str(p)
+            for p in bc.paths
+        ]
+        judge_payload = await _run_judges(
+            bc.judges,
+            bc.settings.project_root,
+            changed_paths=changed_rel,
+            base_ref=bc.base_ref,
+        )
+        summary = apply_judge_payload(resp_data, judge_payload, summary=summary)
+        overall_passed = bool(resp_data.get("all_gates_passed", overall_passed))
 
     resp = success_response("tapps_validate_changed", elapsed_ms, resp_data)
     _build_structured_validation_output(
-        outcome.results, outcome.all_passed, bc.security_depth, outcome.impact_data, resp
+        outcome.results,
+        overall_passed,
+        bc.security_depth,
+        outcome.impact_data,
+        resp,
     )
     resp = _with_nudges("tapps_validate_changed", resp)
     if outcome.timeout_info.timed_out:
@@ -545,7 +564,7 @@ async def tapps_validate_changed(
         correlation_id: Caller-provided ID echoed in the response for
             log correlation. Empty (default) omits the field.
         judges: Optional list of post-gate judges. Each dict has
-            ``type`` (``"pytest"``, ``"grep"``, ``"exists"``),
+            ``type`` (``"pytest"``, ``"grep"``, ``"exists"``, ``"shell"``),
             ``target`` (path or selector), ``expect`` (regex for
             ``grep``), ``description``, and ``blocking`` (default
             ``False``, advisory only). Use to layer task-specific

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
@@ -307,15 +307,79 @@ def _build_response_data(
     return resp_data
 
 
+def _build_judge_summary_rows(judge_results: list[dict[str, Any]]) -> list[str]:
+    """Build grep-friendly PASS/FAIL rows for post-gate judges."""
+    rows: list[str] = []
+    for item in judge_results:
+        outcome = str(item.get("result", "error"))
+        status = "PASS" if outcome == "pass" else "SKIP" if outcome == "skipped" else "FAIL"
+        label = str(item.get("judge", item.get("type", "judge")))
+        short = label if len(label) <= 40 else f"{label[:37]}..."
+        message = str(item.get("message", ""))
+        row = f"{status:<5}  judge:{short:<40}  {outcome}"
+        if message and status == "FAIL":
+            row = f"{row}  {message[:80]}"
+        rows.append(row)
+    return rows
+
+
+def _append_judge_summary(summary: str, judge_results: list[dict[str, Any]]) -> str:
+    """Append judge pass/fail counts to the human-readable summary."""
+    if not judge_results:
+        return summary
+    passed = sum(1 for r in judge_results if r.get("result") == "pass")
+    failed = sum(
+        1
+        for r in judge_results
+        if r.get("result") in {"fail", "error"} and r.get("blocking")
+    )
+    skipped = sum(1 for r in judge_results if r.get("result") == "skipped")
+    suffix = f" | judges: {passed} passed"
+    if failed:
+        suffix += f", {failed} blocking failed"
+    if skipped:
+        suffix += f", {skipped} skipped"
+    return f"{summary}{suffix}"
+
+
+def apply_judge_payload(
+    resp_data: dict[str, Any],
+    judge_payload: dict[str, Any],
+    *,
+    summary: str,
+) -> str:
+    """Fold judge results into response data and return updated summary."""
+    resp_data.update(judge_payload)
+    judge_results = list(judge_payload.get("judge_results") or [])
+    if judge_results:
+        resp_data["summary_rows"] = [
+            *list(resp_data.get("summary_rows") or []),
+            *_build_judge_summary_rows(judge_results),
+        ]
+        summary = _append_judge_summary(summary, judge_results)
+        resp_data["summary"] = summary
+    if not judge_payload.get("judges_passed", True):
+        resp_data["all_gates_passed"] = False
+    return summary
+
+
 async def _run_judges(
     judges: list[dict[str, Any]],
     project_root: Path,
+    *,
+    changed_paths: list[str] | None = None,
+    base_ref: str = "HEAD",
 ) -> dict[str, Any]:
-    """Invoke judges and return the judge-result payload (advisory by default)."""
+    """Invoke judges and return the judge-result payload."""
     try:
         from tapps_core.metrics.judge import run_judges
 
-        return await run_judges(judges, cwd=project_root)
+        return await run_judges(
+            judges,
+            cwd=project_root,
+            changed_paths=changed_paths,
+            base_ref=base_ref,
+        )
     except Exception:
         _logger.debug("judge_run_failed", exc_info=True)
         return {"judge_results": [], "judges_passed": False}
@@ -350,5 +414,8 @@ __all__ = [
     "_compute_impact_analysis",
     "_handle_no_changed_files",
     "_resolve_security_depth",
+    "apply_judge_payload",
+    "_append_judge_summary",
+    "_build_judge_summary_rows",
     "_run_judges",
 ]

--- a/packages/tapps-mcp/src/tapps_mcp/validators/base.py
+++ b/packages/tapps-mcp/src/tapps_mcp/validators/base.py
@@ -20,6 +20,10 @@ CONFIG_PATTERNS: dict[str, list[re.Pattern[str]]] = {
         re.compile(r"^docker-compose(?:\..+)?\.ya?ml$", re.IGNORECASE),
         re.compile(r"^compose\.ya?ml$", re.IGNORECASE),
     ],
+    "yaml_manifest": [
+        re.compile(r"^brands/.+\.ya?ml$", re.IGNORECASE),
+        re.compile(r"^templates/.+\.ya?ml$", re.IGNORECASE),
+    ],
     "websocket": [re.compile(r"\.py$|\.ts$|\.js$", re.IGNORECASE)],
     "mqtt": [re.compile(r"\.py$|\.ts$|\.js$", re.IGNORECASE)],
     "influxdb": [re.compile(r"\.py$|\.ts$|\.js$", re.IGNORECASE)],
@@ -50,7 +54,9 @@ def detect_config_type(file_path: str, content: str | None = None) -> str | None
     Returns:
         Config type string (e.g., ``"dockerfile"``) or ``None`` if unknown.
     """
-    name = Path(file_path).name
+    path = Path(file_path)
+    name = path.name
+    path_str = path.as_posix()
 
     # MCP config detection - covers mcp.json, .mcp.json, .cursor/mcp.json, etc.
     if name.lower() in ("mcp.json", ".mcp.json"):
@@ -60,8 +66,9 @@ def detect_config_type(file_path: str, content: str | None = None) -> str | None
     for config_type, patterns in CONFIG_PATTERNS.items():
         if config_type in ("websocket", "mqtt", "influxdb"):
             continue  # These need content signatures
+        search_target = path_str if config_type == "yaml_manifest" else name
         for pattern in patterns:
-            if pattern.search(name):
+            if pattern.search(search_target):
                 return config_type
 
     # Content-based detection for code files
@@ -132,6 +139,30 @@ def validate_config(
         from tapps_mcp.validators.mcp_config import validate_mcp_config
 
         return validate_mcp_config(file_path, content)
+
+    if resolved_type == "yaml_manifest":
+        from tapps_core.config.settings import load_settings
+        from tapps_mcp.validators.yaml_manifest import validate_yaml_manifest
+
+        settings = load_settings()
+        manifest = settings.manifest_validation
+        if not manifest.enabled:
+            return ConfigValidationResult(
+                file_path=file_path,
+                config_type="yaml_manifest",
+                valid=True,
+                findings=[],
+                suggestions=[
+                    "Enable manifest_validation in .tapps-mcp.yaml to enforce manifest schema."
+                ],
+            )
+        return validate_yaml_manifest(
+            file_path,
+            content,
+            path_globs=manifest.path_globs,
+            required_keys=manifest.required_keys,
+            project_root=settings.project_root,
+        )
 
     return ConfigValidationResult(
         file_path=file_path,

--- a/packages/tapps-mcp/src/tapps_mcp/validators/yaml_manifest.py
+++ b/packages/tapps-mcp/src/tapps_mcp/validators/yaml_manifest.py
@@ -1,0 +1,106 @@
+"""Generic YAML manifest validation for document consumer repos."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tapps_core.knowledge.models import ConfigValidationResult, ValidationFinding
+
+
+def _matches_manifest_glob(rel_path: str, globs: list[str]) -> bool:
+    normalised = rel_path.replace("\\", "/")
+    return any(fnmatch.fnmatch(normalised, pattern) for pattern in globs)
+
+
+def validate_yaml_manifest(
+    file_path: str,
+    content: str,
+    *,
+    path_globs: list[str] | None = None,
+    required_keys: list[str] | None = None,
+    project_root: Path | None = None,
+) -> ConfigValidationResult:
+    """Validate a consumer YAML manifest (brands/, templates/, etc.)."""
+    root = project_root or Path.cwd()
+    rel = Path(file_path)
+    if rel.is_absolute():
+        try:
+            rel = rel.relative_to(root)
+        except ValueError:
+            rel = Path(file_path).name
+    rel_str = rel.as_posix()
+
+    globs = path_globs or ["brands/**/*.yaml", "brands/**/*.yml", "templates/**/*.yaml"]
+    if not _matches_manifest_glob(rel_str, globs):
+        return ConfigValidationResult(
+            file_path=file_path,
+            config_type="yaml_manifest",
+            valid=True,
+            findings=[],
+            suggestions=["Path does not match manifest_validation.path_globs — syntax-only check."],
+        )
+
+    findings: list[ValidationFinding] = []
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        findings.append(
+            ValidationFinding(
+                severity="critical",
+                message=f"Invalid YAML: {exc}",
+                category="syntax",
+            )
+        )
+        return ConfigValidationResult(
+            file_path=file_path,
+            config_type="yaml_manifest",
+            valid=False,
+            findings=findings,
+            suggestions=[],
+        )
+
+    if data is None:
+        findings.append(
+            ValidationFinding(
+                severity="critical",
+                message="Manifest YAML is empty",
+                category="structure",
+            )
+        )
+    elif not isinstance(data, dict):
+        findings.append(
+            ValidationFinding(
+                severity="critical",
+                message="Manifest YAML root must be a mapping/object",
+                category="structure",
+            )
+        )
+    else:
+        for key in required_keys or []:
+            if key not in data:
+                findings.append(
+                    ValidationFinding(
+                        severity="critical",
+                        message=f"Missing required key: {key!r}",
+                        category="schema",
+                    )
+                )
+
+    valid = not any(f.severity == "critical" for f in findings)
+    return ConfigValidationResult(
+        file_path=file_path,
+        config_type="yaml_manifest",
+        valid=valid,
+        findings=findings,
+        suggestions=_manifest_suggestions(data if isinstance(data, dict) else {}),
+    )
+
+
+def _manifest_suggestions(data: dict[str, Any]) -> list[str]:
+    if not data:
+        return ["Add top-level manifest keys expected by your document toolchain."]
+    return []

--- a/packages/tapps-mcp/tests/unit/test_checklist.py
+++ b/packages/tapps-mcp/tests/unit/test_checklist.py
@@ -54,8 +54,31 @@ class TestTaskToolMap:
         assert "tapps_quality_gate" in m["required"]
 
     def test_all_task_types_present(self):
-        expected = {"feature", "bugfix", "refactor", "security", "review", "epic", "release"}
+        expected = {
+            "feature",
+            "bugfix",
+            "refactor",
+            "security",
+            "review",
+            "epic",
+            "release",
+            "document",
+        }
         assert set(TASK_TOOL_MAP.keys()) == expected
+
+    def test_document_task(self):
+        m = TASK_TOOL_MAP["document"]
+        assert "tapps_validate_changed" in m["required"]
+        assert "tapps_validate_config" in m["recommended"]
+
+    def test_document_task_type_resolves_without_fallback(self):
+        from tapps_mcp.tools.checklist import CallTracker, TASK_TYPE_REASONS
+
+        CallTracker.reset()
+        result = CallTracker.evaluate("document", engagement_level="medium")
+        assert result.resolved_policy_task_type == "document"
+        assert result.policy_fallback is False
+        assert result.task_type_hint == TASK_TYPE_REASONS["document"]
 
     def test_epic_task(self):
         m = TASK_TOOL_MAP["epic"]

--- a/packages/tapps-mcp/tests/unit/test_cli_validation_commands.py
+++ b/packages/tapps-mcp/tests/unit/test_cli_validation_commands.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from click.testing import CliRunner
 
 from tapps_mcp.cli import main
@@ -19,3 +21,26 @@ class TestValidationCliCommands:
         result = runner.invoke(main, ["validate-changed", "--help"])
         assert result.exit_code == 0
         assert "--file-paths" in result.output or "--paths" in result.output
+
+    def test_validate_changed_exits_nonzero_on_blocking_judge_fail(self) -> None:
+        runner = CliRunner()
+        mock_result = {
+            "success": True,
+            "data": {
+                "summary": "1 file validated",
+                "summary_rows": [
+                    "PASS   foo.py  score=100.0",
+                    "FAIL   judge:audit  fail",
+                ],
+                "all_gates_passed": False,
+                "judges_passed": False,
+            },
+        }
+        with patch(
+            "tapps_mcp.server_pipeline_tools.tapps_validate_changed",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = runner.invoke(main, ["validate-changed", "--quick"])
+        assert result.exit_code == 1
+        assert "judge:audit" in result.output

--- a/packages/tapps-mcp/tests/unit/test_document_impact_nudge.py
+++ b/packages/tapps-mcp/tests/unit/test_document_impact_nudge.py
@@ -1,0 +1,103 @@
+"""Tests for document layout impact-analysis nudges."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tapps_mcp.pipeline.document_judges import is_document_layout_path
+
+
+class TestDocumentLayoutPath:
+    def test_reports_path_matches(self, tmp_path: Path) -> None:
+        path = tmp_path / "reports" / "annual" / "page.tsx"
+        assert is_document_layout_path(path, tmp_path) is True
+
+    def test_src_path_does_not_match(self, tmp_path: Path) -> None:
+        path = tmp_path / "src" / "service.py"
+        path.parent.mkdir(parents=True)
+        path.touch()
+        assert is_document_layout_path(path, tmp_path) is False
+
+
+@pytest.mark.asyncio
+async def test_impact_analysis_adds_rebuild_nudge_for_layout_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tapps_mcp.project.models import ImpactReport
+    from tapps_mcp.server_analysis_tools import tapps_impact_analysis
+
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "reports" / "chapter.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def render() -> None: pass\n", encoding="utf-8")
+
+    report = ImpactReport(
+        changed_file="reports/chapter.py",
+        change_type="modified",
+        severity="low",
+        total_affected=0,
+        recommendations=[],
+    )
+
+    monkeypatch.setattr(
+        "tapps_mcp.server_analysis_tools._validate_file_path_lazy",
+        lambda p: Path(p),
+    )
+    monkeypatch.setattr(
+        "tapps_mcp.project.impact_analyzer.analyze_impact",
+        lambda *_a, **_k: report,
+    )
+    monkeypatch.setattr(
+        "tapps_mcp.server_analysis_tools.build_impact_memory_context",
+        lambda *_a, **_k: {},
+    )
+    monkeypatch.setattr("tapps_mcp.server_analysis_tools._with_nudges", lambda _t, r: r)
+    monkeypatch.setattr("tapps_mcp.server_analysis_tools._record_call", lambda *_a, **_k: None)
+    monkeypatch.setattr("tapps_mcp.server_analysis_tools._record_execution", lambda *_a, **_k: None)
+
+    result = await tapps_impact_analysis(str(target))
+    recs = result["data"]["recommendations"]
+    assert any("rebuild" in r.lower() for r in recs)
+
+
+@pytest.mark.asyncio
+async def test_impact_analysis_no_rebuild_nudge_for_src_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tapps_mcp.project.models import ImpactReport
+    from tapps_mcp.server_analysis_tools import tapps_impact_analysis
+
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "src" / "service.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    report = ImpactReport(
+        changed_file="src/service.py",
+        change_type="modified",
+        severity="low",
+        total_affected=0,
+        recommendations=[],
+    )
+
+    monkeypatch.setattr(
+        "tapps_mcp.server_analysis_tools._validate_file_path_lazy",
+        lambda p: Path(p),
+    )
+    monkeypatch.setattr(
+        "tapps_mcp.project.impact_analyzer.analyze_impact",
+        lambda *_a, **_k: report,
+    )
+    monkeypatch.setattr(
+        "tapps_mcp.server_analysis_tools.build_impact_memory_context",
+        lambda *_a, **_k: {},
+    )
+    monkeypatch.setattr("tapps_mcp.server_analysis_tools._with_nudges", lambda _t, r: r)
+    monkeypatch.setattr("tapps_mcp.server_analysis_tools._record_call", lambda *_a, **_k: None)
+    monkeypatch.setattr("tapps_mcp.server_analysis_tools._record_execution", lambda *_a, **_k: None)
+
+    result = await tapps_impact_analysis(str(target))
+    recs = result["data"]["recommendations"]
+    assert not any("rebuild shipped PDFs" in r for r in recs)

--- a/packages/tapps-mcp/tests/unit/test_document_judges.py
+++ b/packages/tapps-mcp/tests/unit/test_document_judges.py
@@ -1,0 +1,161 @@
+"""Tests for document judge presets and bootstrap helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from tapps_mcp.pipeline.document_judges import (
+    DOCUMENT_BUILDER_PROFILE,
+    discover_document_judge_preset,
+    is_document_consumer,
+    is_document_layout_path,
+    merge_document_judges_into_yaml,
+    merge_document_memory_profile,
+    path_matches_narrative_glob,
+    summarise_configured_judges,
+)
+
+
+class TestDocumentConsumerDetection:
+    def test_reports_dir_marks_consumer(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        assert is_document_consumer(tmp_path) is True
+
+    def test_non_consumer_without_markers(self, tmp_path: Path) -> None:
+        assert is_document_consumer(tmp_path) is False
+
+
+class TestJudgePresetDiscovery:
+    def test_discovers_build_script_grep_judge(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        build = tmp_path / "scripts" / "build-pdfs.mjs"
+        build.parent.mkdir()
+        build.write_text('import { exec } from "node:child_process";\nexec("node build --audit");\n')
+        judges = discover_document_judge_preset(tmp_path)
+        assert any(j["type"] == "grep" and "--audit" in j["expect"] for j in judges)
+        assert all(j.get("blocking") is True for j in judges)
+
+
+class TestMergeDocumentJudges:
+    def test_merges_when_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        build = tmp_path / "build-pdfs.mjs"
+        build.write_text("// --audit\n")
+        result = merge_document_judges_into_yaml(tmp_path)
+        assert result["merged"] is True
+        config = yaml.safe_load((tmp_path / ".tapps-mcp.yaml").read_text())
+        assert len(config["validate_changed"]["judges"]) >= 1
+
+    def test_preserves_existing_judges(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        (tmp_path / ".tapps-mcp.yaml").write_text(
+            yaml.safe_dump({"validate_changed": {"judges": [{"type": "exists", "target": "x"}]}})
+        )
+        result = merge_document_judges_into_yaml(tmp_path)
+        assert result["merged"] is False
+        config = yaml.safe_load((tmp_path / ".tapps-mcp.yaml").read_text())
+        assert config["validate_changed"]["judges"][0]["target"] == "x"
+
+
+class TestMemoryProfile:
+    def test_sets_document_builder_profile(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        result = merge_document_memory_profile(tmp_path)
+        assert result["merged"] is True
+        config = yaml.safe_load((tmp_path / ".tapps-mcp.yaml").read_text())
+        assert config["memory"]["profile"] == DOCUMENT_BUILDER_PROFILE
+
+    def test_preserves_existing_profile(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        (tmp_path / ".tapps-mcp.yaml").write_text(
+            yaml.safe_dump({"memory": {"profile": "repo-brain"}})
+        )
+        result = merge_document_memory_profile(tmp_path)
+        assert result["merged"] is False
+        config = yaml.safe_load((tmp_path / ".tapps-mcp.yaml").read_text())
+        assert config["memory"]["profile"] == "repo-brain"
+
+
+class TestSummariseConfiguredJudges:
+    def test_empty(self) -> None:
+        assert summarise_configured_judges([])["configured"] is False
+
+    def test_counts_blocking(self) -> None:
+        summary = summarise_configured_judges(
+            [{"blocking": True}, {"blocking": False}]
+        )
+        assert summary == {"configured": True, "count": 2, "blocking": 1, "advisory": 1}
+
+
+class TestPathHelpers:
+    def test_layout_path_under_reports(self, tmp_path: Path) -> None:
+        path = tmp_path / "reports" / "annual" / "page.tsx"
+        path.parent.mkdir(parents=True)
+        path.touch()
+        assert is_document_layout_path(path, tmp_path) is True
+
+    def test_narrative_glob_match(self, tmp_path: Path) -> None:
+        path = tmp_path / "reports" / "foo.py"
+        path.parent.mkdir(parents=True)
+        path.touch()
+        assert path_matches_narrative_glob(path, tmp_path, ["reports/**"]) is True
+
+    def test_report_studio_installed_via_check(self, tmp_path: Path) -> None:
+        with patch(
+            "tapps_mcp.pipeline.document_judges.check_report_studio",
+            return_value={"installed": True},
+        ):
+            assert is_document_consumer(tmp_path) is True
+
+
+class TestDoctorReportStudioJudges:
+    def test_installed_with_judges(self, tmp_path: Path, monkeypatch) -> None:
+        from tapps_core.config.settings import TappsMCPSettings, ValidateChangedSettings
+        from tapps_mcp.distribution.doctor import check_report_studio
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["nlt-report-studio>=1.0"]\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "reports").mkdir()
+
+        settings = TappsMCPSettings(
+            project_root=tmp_path,
+            validate_changed=ValidateChangedSettings(
+                judges=[{"type": "shell", "target": "true", "blocking": True}]
+            ),
+        )
+        monkeypatch.setattr(
+            "tapps_core.config.settings.load_settings",
+            lambda **_: settings,
+        )
+        result = check_report_studio(tmp_path)
+        assert result.ok is True
+        assert "judges configured" in result.message
+
+    def test_installed_without_judges(self, tmp_path: Path, monkeypatch) -> None:
+        from tapps_core.config.settings import TappsMCPSettings, ValidateChangedSettings
+        from tapps_mcp.distribution.doctor import check_report_studio
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["nlt-report-studio>=1.0"]\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "reports").mkdir()
+
+        settings = TappsMCPSettings(
+            project_root=tmp_path,
+            validate_changed=ValidateChangedSettings(judges=[]),
+        )
+        monkeypatch.setattr(
+            "tapps_core.config.settings.load_settings",
+            lambda **_: settings,
+        )
+        result = check_report_studio(tmp_path)
+        assert result.ok is True
+        assert "judges missing" in result.message

--- a/packages/tapps-mcp/tests/unit/test_scorer.py
+++ b/packages/tapps-mcp/tests/unit/test_scorer.py
@@ -1126,3 +1126,37 @@ class TestPerformanceCategoryScoring:
         # Without cap: 0.8+0.5+0.5+0.3+0.5+0.2+0.3 = 3.1 penalty
         # With cap: 3.0 penalty → score = 10.0 - 3.0 = 7.0
         assert cat.score >= 7.0
+
+
+class TestNarrativePathScoring:
+    def test_report_authoring_zeros_test_coverage_weight(self, tmp_path: Path) -> None:
+        from tapps_core.config.settings import load_settings
+
+        report_file = tmp_path / "reports" / "chapter.py"
+        report_file.parent.mkdir(parents=True)
+        report_file.write_text("def render() -> None:\n    pass\n", encoding="utf-8")
+
+        settings = load_settings(project_root=tmp_path)
+        settings.quality_preset = "report_authoring"
+        settings.project_root = tmp_path
+
+        scorer = CodeScorer(settings=settings)
+        cat = scorer._score_test_coverage_category(report_file)
+        assert cat.weight == 0.0
+        assert cat.details.get("narrative_path") is True
+
+    def test_src_path_keeps_test_coverage_weight(self, tmp_path: Path) -> None:
+        from tapps_core.config.settings import load_settings
+
+        src_file = tmp_path / "src" / "service.py"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text("def run() -> None:\n    pass\n", encoding="utf-8")
+
+        settings = load_settings(project_root=tmp_path)
+        settings.quality_preset = "report_authoring"
+        settings.project_root = tmp_path
+
+        scorer = CodeScorer(settings=settings)
+        cat = scorer._score_test_coverage_category(src_file)
+        assert cat.weight > 0.0
+        assert "narrative_path" not in cat.details

--- a/packages/tapps-mcp/tests/unit/test_server_pipeline_tools.py
+++ b/packages/tapps-mcp/tests/unit/test_server_pipeline_tools.py
@@ -1929,3 +1929,13 @@ class TestBuildSearchFirst:
         libraries = [e["library"] for e in result["covered"]]
         assert "reportlab" in libraries
         assert "pypdf" in libraries
+
+    def test_document_quality_added_for_document_consumer(self, tmp_path: Path) -> None:
+        from tapps_mcp.server_pipeline_tools import _build_search_first
+
+        (tmp_path / "reports").mkdir()
+        (tmp_path / "pyproject.toml").write_text("[project]\ndependencies = []\n")
+        result = _build_search_first(tmp_path)
+        assert result is not None
+        libraries = [e["library"] for e in result["covered"]]
+        assert "document-quality" in libraries

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_judges.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_judges.py
@@ -1,0 +1,72 @@
+"""Tests for validate_changed judge integration helpers."""
+
+from __future__ import annotations
+
+from tapps_mcp.tools.validate_changed_output import (
+    _append_judge_summary,
+    _build_judge_summary_rows,
+    apply_judge_payload,
+)
+
+
+class TestJudgeSummaryRows:
+    def test_pass_and_fail_rows(self) -> None:
+        rows = _build_judge_summary_rows(
+            [
+                {"judge": "audit CLI", "result": "pass"},
+                {
+                    "judge": "PDF tests",
+                    "result": "fail",
+                    "blocking": True,
+                    "message": "exit 1",
+                },
+                {"judge": "grep build", "result": "skipped"},
+            ]
+        )
+        assert rows[0].startswith("PASS")
+        assert rows[1].startswith("FAIL")
+        assert rows[2].startswith("SKIP")
+
+
+class TestApplyJudgePayload:
+    def test_blocking_failure_sets_all_gates_passed_false(self) -> None:
+        resp_data = {"all_gates_passed": True, "summary_rows": ["PASS  gate"]}
+        payload = {
+            "judges_passed": False,
+            "judge_results": [
+                {"judge": "audit", "result": "fail", "blocking": True, "message": "exit 2"}
+            ],
+        }
+        summary = apply_judge_payload(resp_data, payload, summary="2/2 passed")
+        assert resp_data["all_gates_passed"] is False
+        assert "blocking failed" in summary
+        assert len(resp_data["summary_rows"]) == 2
+
+    def test_advisory_failure_leaves_gates_passed(self) -> None:
+        resp_data = {"all_gates_passed": True, "summary_rows": []}
+        payload = {
+            "judges_passed": True,
+            "judge_results": [{"judge": "hint", "result": "fail", "blocking": False}],
+        }
+        summary = _append_judge_summary("ok", payload["judge_results"])
+        apply_judge_payload(resp_data, payload, summary=summary)
+        assert resp_data["all_gates_passed"] is True
+
+    def test_structured_overall_passed_follows_blocking_judges(self) -> None:
+        from tapps_mcp.common.output_schemas import ValidateChangedOutput
+
+        resp_data = {"all_gates_passed": True, "summary_rows": []}
+        payload = {
+            "judges_passed": False,
+            "judge_results": [{"judge": "audit", "result": "fail", "blocking": True}],
+        }
+        apply_judge_payload(resp_data, payload, summary="ok")
+        structured = ValidateChangedOutput(
+            files=[],
+            overall_passed=bool(resp_data["all_gates_passed"]),
+            total_files=0,
+            passed_count=0,
+            failed_count=0,
+            security_depth="basic",
+        )
+        assert structured.overall_passed is False

--- a/packages/tapps-mcp/tests/unit/test_validators.py
+++ b/packages/tapps-mcp/tests/unit/test_validators.py
@@ -36,6 +36,10 @@ class TestDetectConfigType:
         assert detect_config_type("README.md") is None
         assert detect_config_type("app.py") is None
 
+    def test_yaml_manifest_detected_by_path(self):
+        assert detect_config_type("brands/acme/brand.yaml") == "yaml_manifest"
+        assert detect_config_type("templates/report/template.yml") == "yaml_manifest"
+
 
 class TestValidateConfig:
     def test_auto_detect_dockerfile(self):

--- a/packages/tapps-mcp/tests/unit/test_yaml_manifest_validator.py
+++ b/packages/tapps-mcp/tests/unit/test_yaml_manifest_validator.py
@@ -1,0 +1,47 @@
+"""Tests for generic YAML manifest validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tapps_mcp.validators.yaml_manifest import validate_yaml_manifest
+
+
+class TestYamlManifestValidator:
+    def test_invalid_yaml_fails(self, tmp_path: Path) -> None:
+        result = validate_yaml_manifest(
+            "brands/acme/brand.yaml",
+            "key: [unclosed",
+            project_root=tmp_path,
+        )
+        assert result.valid is False
+        assert result.config_type == "yaml_manifest"
+
+    def test_missing_required_key_fails(self, tmp_path: Path) -> None:
+        result = validate_yaml_manifest(
+            "brands/acme/brand.yaml",
+            "name: acme\n",
+            required_keys=["version"],
+            project_root=tmp_path,
+        )
+        assert result.valid is False
+        assert any("version" in f.message for f in result.findings)
+
+    def test_valid_manifest_passes(self, tmp_path: Path) -> None:
+        result = validate_yaml_manifest(
+            "templates/report/template.yaml",
+            "id: annual-report\nname: Annual Report\n",
+            required_keys=["id"],
+            project_root=tmp_path,
+        )
+        assert result.valid is True
+
+    def test_outside_glob_syntax_only_pass(self, tmp_path: Path) -> None:
+        result = validate_yaml_manifest(
+            "README.yaml",
+            "not: a manifest\n",
+            path_globs=["brands/**/*.yaml"],
+            project_root=tmp_path,
+        )
+        assert result.valid is True
+        assert result.suggestions


### PR DESCRIPTION
## Summary

- Adds blocking `validate_changed.judges` (`pytest`, `grep`, `exists`, `shell`) with `when_changed` globs that fold into `all_gates_passed`, appear in `summary_rows`, and fail the CLI on blocking judge errors.
- Bootstraps document consumers on `tapps_init` / `tapps_upgrade`: auto-merge discovered judge presets and optional `memory.profile: document-builder` when `reports/` or report-studio is detected.
- Ships `task_type=document` checklist profile, `report_authoring` scoring preset (zero `test_coverage` under `reports/**`), pluggable `yaml_manifest` config validation, `document-quality` lookup_docs in `search_first`, and impact-analysis rebuild nudges for layout paths.

Linear: [TAP-3591](https://linear.app/tappscodingagents/issue/TAP-3591) · [TAP-3592](https://linear.app/tappscodingagents/issue/TAP-3592) · [TAP-3593](https://linear.app/tappscodingagents/issue/TAP-3593) · [TAP-3594](https://linear.app/tappscodingagents/issue/TAP-3594) (stories TAP-3595–3607)

## Test plan

- [x] `uv run pytest packages/tapps-core/tests/unit/test_judge.py` (22 passed)
- [x] `uv run pytest` document pipeline unit tests (42 passed)
- [x] `tapps_validate_changed` on all changed source + test files (gates passed)
- [x] `tapps_checklist(task_type=feature)` complete
- [x] Bootstrap dry-run on tapps-mcp repo: `is_document_consumer=True`, judge + memory profile merge preview OK
- [ ] ReportLab consumer: after merge, run `tapps-mcp upgrade` and confirm `.tapps-mcp.yaml` gets `validate_changed.judges` + `memory.profile: document-builder`; use `task_type=document` checklist

## Consumer rollout (ReportLab)

```bash
# In ReportLab repo after this release is available:
tapps-mcp upgrade
tapps-mcp doctor   # report_studio row should show judges configured or missing
tapps-mcp validate-changed --quick
```

Enable optional manifest validation in `.tapps-mcp.yaml`:

```yaml
manifest_validation:
  enabled: true
quality_preset: report_authoring
```


Made with [Cursor](https://cursor.com)