### PR TITLE
feat(judges): uv-aware pytest and shell audit preset (EPIC-108)

### DIFF
--- a/docs/epics/EPIC-108.md
+++ b/docs/epics/EPIC-108.md
@@ -1,0 +1,95 @@
+# Epic 108: EPIC-108: MCP-environment judge reliability (uv-aware pytest)
+
+<!-- docsmcp:start:metadata -->
+**Status:** Proposed
+**Priority:** High
+**Estimated LOE:** S
+
+<!-- docsmcp:end:metadata -->
+
+---
+
+<!-- docsmcp:start:purpose-intent -->
+## Purpose & Intent
+
+We are doing this so that validate_changed pytest judges pass when the consumer project uses uv-managed venvs, even though the MCP server process runs in an isolated tool environment without project pytest installed.
+
+<!-- docsmcp:end:purpose-intent -->
+
+<!-- docsmcp:start:goal -->
+## Goal
+
+Make pytest judges resolve the consumer project virtualenv (uv run pytest, .venv/bin/python -m pytest) before falling back to bare python -m pytest, with optional command override in judge config.
+
+<!-- docsmcp:end:goal -->
+
+<!-- docsmcp:start:motivation -->
+## Motivation
+
+ReportLab production proved local uv run pytest passes but MCP validate_changed returns python -m pytest not found, causing judges_passed=false and training agents to ignore document gates. EPIC-104 shipped shell/when_changed/blocking integration but left pytest resolution MCP-host-only.
+
+<!-- docsmcp:end:motivation -->
+
+<!-- docsmcp:start:acceptance-criteria -->
+## Acceptance Criteria
+
+- [ ] - [ ] pytest judge tries uv run pytest
+- [ ] then .venv/bin/python -m pytest
+- [ ] then python -m pytest
+- [ ] Judge runs with cwd=project_root and inherits env
+- [ ] Optional command field on pytest judge overrides auto-resolution
+- [ ] Unit tests mock subprocess and cover uv-first resolution
+- [ ] ReportLab fixture: tapps_validate_changed pytest judge passes when uv run pytest passes locally
+
+<!-- docsmcp:end:acceptance-criteria -->
+
+<!-- docsmcp:start:stories -->
+## Stories
+
+### 108.1 -- judge.py: uv-aware pytest resolution for MCP env
+
+**Points:** 3
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement judge.py: uv-aware pytest resolution for mcp env
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** judge.py: uv-aware pytest resolution for MCP env is implemented, tests pass, and documentation is updated.
+
+---
+
+### 108.2 -- document_judges.py: optional shell audit judge in discovered preset
+
+**Points:** 2
+
+Describe what this story delivers...
+
+**Tasks:**
+- [ ] Implement document_judges.py: optional shell audit judge in discovered preset
+- [ ] Write unit tests
+- [ ] Update documentation
+
+**Definition of Done:** document_judges.py: optional shell audit judge in discovered preset is implemented, tests pass, and documentation is updated.
+
+---
+
+<!-- docsmcp:end:stories -->
+
+<!-- docsmcp:start:technical-notes -->
+## Technical Notes
+
+- Document architecture decisions for **EPIC-108: MCP-environment judge reliability (uv-aware pytest)**...
+
+<!-- docsmcp:end:technical-notes -->
+
+<!-- docsmcp:start:non-goals -->
+## Out of Scope / Future Considerations
+
+- - Do not install pytest into the MCP server global env as the primary fix
+- Do not embed ReportLab-specific pytest paths
+- Do not auto-run full PDF build without when_changed
+
+<!-- docsmcp:end:non-goals -->

--- a/docs/epics/stories/STORY-108.1.md
+++ b/docs/epics/stories/STORY-108.1.md
@@ -1,0 +1,20 @@
+# judge.py: uv-aware pytest resolution for MCP env
+
+## What
+
+judge.py: uv-aware pytest resolution for MCP env
+
+## Where
+
+- `packages/tapps-core/src/tapps_core/metrics/judge.py:204-256`
+- `packages/tapps-core/tests/unit/test_judge.py:75-120`
+
+## Acceptance
+
+- [ ] - [ ] `_run_pytest_judge` tries `uv run pytest`
+- [ ] then `.venv/bin/python -m pytest`
+- [ ] then `python -m pytest`
+- [ ] Optional `command` field on judge dict overrides auto-resolution
+- [ ] cwd=project_root; inherit os.environ
+- [ ] Error message names which strategies were attempted when all fail
+- [ ] Unit tests in test_judge.py cover uv-first path with mocked subprocess

--- a/docs/epics/stories/STORY-108.2.md
+++ b/docs/epics/stories/STORY-108.2.md
@@ -1,0 +1,21 @@
+# document_judges.py: optional shell audit judge preset
+
+## What
+
+document_judges.py: optional shell audit judge preset
+
+## Where
+
+- `packages/tapps-mcp/src/tapps_mcp/pipeline/document_judges.py:44-85`
+- `packages/tapps-mcp/tests/unit/test_document_judges.py:1-120`
+
+## Acceptance
+
+- [ ] - [ ] When report-studio CLI is on PATH or pyproject scripts entry exists
+- [ ] discovered preset includes optional shell judge for audit CLI
+- [ ] Shell judge uses when_changed globs for reports/**
+- [ ] templates/**
+- [ ] brands/**
+- [ ] src/**
+- [ ] Judge is blocking only when consumer has built reference PDF fixture path discoverable
+- [ ] dry_run init/upgrade preview lists discovered shell judge without hard-coded ReportLab paths

--- a/packages/tapps-core/src/tapps_core/metrics/judge.py
+++ b/packages/tapps-core/src/tapps_core/metrics/judge.py
@@ -63,6 +63,14 @@ class JudgeDefinition(BaseModel):
         le=3600,
         description="Timeout for shell/command judges (seconds).",
     )
+    command: str = Field(
+        default="",
+        description=(
+            "For pytest: optional command prefix override (e.g. 'uv run pytest'). "
+            "When set, skips auto-resolution. "
+            "For other types: unused."
+        ),
+    )
 
     @field_validator("type", mode="before")
     @classmethod
@@ -201,19 +209,63 @@ async def _run_grep_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeRe
         )
 
 
-async def _run_pytest_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "python",
-            "-m",
-            "pytest",
-            jd.target,
-            "--tb=no",
-            "-q",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(cwd),
+def _project_venv_python(cwd: Path) -> Path | None:
+    for candidate in (cwd / ".venv" / "bin" / "python", cwd / ".venv" / "Scripts" / "python.exe"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _pytest_argv_candidates(jd: JudgeDefinition, cwd: Path) -> tuple[list[list[str]], list[str]]:
+    """Return pytest argv lists to try and human-readable strategy labels."""
+    target = jd.target
+    flags = ["--tb=no", "-q"]
+
+    if jd.command.strip():
+        base = shlex.split(jd.command)
+        if target in jd.command:
+            return [base], [jd.command.strip()]
+        return [[*base, target, *flags]], [jd.command.strip()]
+
+    strategies: list[tuple[str, list[str]]] = [
+        ("uv run pytest", ["uv", "run", "pytest", target, *flags]),
+    ]
+    venv_python = _project_venv_python(cwd)
+    if venv_python is not None:
+        strategies.append(
+            (
+                f"{venv_python} -m pytest",
+                [str(venv_python), "-m", "pytest", target, *flags],
+            )
         )
+    strategies.append(("python -m pytest", ["python", "-m", "pytest", target, *flags]))
+    return [argv for _, argv in strategies], [name for name, _ in strategies]
+
+
+async def _run_pytest_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:
+    argvs, strategy_labels = _pytest_argv_candidates(jd, cwd)
+    attempted: list[str] = []
+
+    for argv, strategy in zip(argvs, strategy_labels, strict=True):
+        attempted.append(strategy)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(cwd),
+            )
+        except FileNotFoundError:
+            continue
+        except Exception as exc:
+            return JudgeResult(
+                judge=label,
+                type="pytest",
+                result="error",
+                message=f"Unexpected error running pytest ({strategy}): {exc}",
+                blocking=jd.blocking,
+            )
+
         try:
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
         except TimeoutError:
@@ -222,7 +274,7 @@ async def _run_pytest_judge(jd: JudgeDefinition, label: str, cwd: Path) -> Judge
                 judge=label,
                 type="pytest",
                 result="error",
-                message=f"pytest timed out after 120s for target: {jd.target}",
+                message=f"pytest timed out after 120s ({strategy}) for target: {jd.target}",
                 blocking=jd.blocking,
             )
 
@@ -233,27 +285,23 @@ async def _run_pytest_judge(jd: JudgeDefinition, label: str, cwd: Path) -> Judge
             type="pytest",
             result="pass" if passed else "fail",
             message=(
-                f"pytest exit {proc.returncode} for {jd.target}"
+                f"pytest ({strategy}) exit {proc.returncode} for {jd.target}"
                 + (f": {err_hint}" if err_hint and not passed else "")
             ),
             blocking=jd.blocking,
         )
-    except FileNotFoundError:
-        return JudgeResult(
-            judge=label,
-            type="pytest",
-            result="error",
-            message="python -m pytest not found. Is pytest installed in this environment?",
-            blocking=jd.blocking,
-        )
-    except Exception as exc:
-        return JudgeResult(
-            judge=label,
-            type="pytest",
-            result="error",
-            message=f"Unexpected error running pytest: {exc}",
-            blocking=jd.blocking,
-        )
+
+    tried = ", ".join(attempted) if attempted else "none"
+    return JudgeResult(
+        judge=label,
+        type="pytest",
+        result="error",
+        message=(
+            f"pytest not found via any strategy (tried: {tried}). "
+            "Install pytest in the project venv or set judge command override."
+        ),
+        blocking=jd.blocking,
+    )
 
 
 async def _run_shell_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:

--- a/packages/tapps-core/tests/unit/test_judge.py
+++ b/packages/tapps-core/tests/unit/test_judge.py
@@ -9,6 +9,7 @@ import pytest
 
 from tapps_core.metrics.judge import (
     JudgeDefinition,
+    _pytest_argv_candidates,
     run_judge,
     run_judges,
 )
@@ -79,10 +80,11 @@ class TestPytestJudge:
         mock_proc.returncode = 0
         mock_proc.communicate = AsyncMock(return_value=(b"", b""))
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             jd = JudgeDefinition(type="pytest", target="tests/unit/")
             result = await run_judge(jd, cwd=tmp_path)
         assert result.result == "pass"
+        assert mock_exec.call_args[0][0] == "uv"
 
     @pytest.mark.asyncio
     async def test_failing_tests_returns_fail(self, tmp_path: Path) -> None:
@@ -101,6 +103,65 @@ class TestPytestJudge:
             jd = JudgeDefinition(type="pytest", target="tests/")
             result = await run_judge(jd, cwd=tmp_path)
         assert result.result == "error"
+        assert "tried:" in result.message
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_python_when_uv_missing(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        calls: list[list[str]] = []
+
+        async def _exec(*args: object, **kwargs: object) -> MagicMock:
+            calls.append([str(a) for a in args])
+            if args and args[0] == "uv":
+                raise FileNotFoundError("uv")
+            return mock_proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_exec):
+            jd = JudgeDefinition(type="pytest", target="tests/unit/")
+            result = await run_judge(jd, cwd=tmp_path)
+        assert result.result == "pass"
+        assert calls[-1][0] == "python"
+
+    @pytest.mark.asyncio
+    async def test_command_override_skips_auto_resolution(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            jd = JudgeDefinition(
+                type="pytest",
+                target="tests/test_pdf_audit.py",
+                command="uv run pytest",
+            )
+            result = await run_judge(jd, cwd=tmp_path)
+        assert result.result == "pass"
+        assert mock_exec.call_args[0][:3] == ("uv", "run", "pytest")
+
+
+class TestPytestArgvCandidates:
+    def test_default_order_includes_uv_then_python(self, tmp_path: Path) -> None:
+        jd = JudgeDefinition(type="pytest", target="tests/")
+        argvs, labels = _pytest_argv_candidates(jd, tmp_path)
+        assert labels[0] == "uv run pytest"
+        assert labels[-1] == "python -m pytest"
+        assert argvs[0][:3] == ["uv", "run", "pytest"]
+
+    def test_command_override(self, tmp_path: Path) -> None:
+        jd = JudgeDefinition(type="pytest", target="tests/foo.py", command="uv run pytest")
+        argvs, labels = _pytest_argv_candidates(jd, tmp_path)
+        assert len(argvs) == 1
+        assert argvs[0] == ["uv", "run", "pytest", "tests/foo.py", "--tb=no", "-q"]
+
+    def test_venv_python_inserted_when_present(self, tmp_path: Path) -> None:
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").write_text("")
+        jd = JudgeDefinition(type="pytest", target="tests/")
+        _, labels = _pytest_argv_candidates(jd, tmp_path)
+        assert any("-m pytest" in label for label in labels)
 
 
 class TestShellJudge:

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/document_judges.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/document_judges.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,38 @@ def _find_build_script(project_root: Path) -> Path | None:
     if not candidates:
         candidates = sorted(project_root.glob("**/build*.mjs"))
     return candidates[0] if candidates else None
+
+
+_WHEN_CHANGED_DOC_PATHS = ["reports/**", "src/**", "brands/**", "templates/**"]
+
+
+def _report_studio_cli_prefix(project_root: Path) -> str | None:
+    """Return a shell prefix when report-studio CLI is likely available."""
+    if shutil.which("report-studio"):
+        return "report-studio"
+    pyproject = project_root / "pyproject.toml"
+    if pyproject.is_file():
+        text = pyproject.read_text(encoding="utf-8")
+        if "report-studio" in text or "nlt-report-studio" in text:
+            return "uv run report-studio"
+    if check_report_studio(project_root).get("installed"):
+        return "uv run report-studio"
+    return None
+
+
+def _find_reference_pdf(project_root: Path) -> Path | None:
+    """Return the first discoverable built PDF fixture for audit judges."""
+    patterns = (
+        "**/public/downloads/vol-*.pdf",
+        "**/public/downloads/*.pdf",
+        "**/downloads/vol-*.pdf",
+        "**/out/**/*.pdf",
+    )
+    for pattern in patterns:
+        matches = sorted(project_root.glob(pattern))
+        if matches:
+            return matches[0]
+    return None
 
 
 def _find_pdf_audit_test(project_root: Path) -> Path | None:
@@ -59,10 +92,7 @@ def discover_document_judge_preset(project_root: Path) -> list[dict[str, Any]]:
                 "blocking": True,
                 "when_changed": [
                     str(build_script.relative_to(root)),
-                    "reports/**",
-                    "src/**",
-                    "brands/**",
-                    "templates/**",
+                    *_WHEN_CHANGED_DOC_PATHS,
                 ],
             }
         )
@@ -76,11 +106,26 @@ def discover_document_judge_preset(project_root: Path) -> list[dict[str, Any]]:
                 "target": str(rel.parent if rel.name.startswith("test_") else rel),
                 "description": "PDF audit CLI contract tests",
                 "blocking": True,
-                "when_changed": ["reports/**", "src/**", "brands/**", "templates/**"],
+                "when_changed": list(_WHEN_CHANGED_DOC_PATHS),
             }
         )
         if rel.name == "test_pdf_audit.py":
             judges[-1]["target"] = str(rel)
+
+    cli_prefix = _report_studio_cli_prefix(root)
+    reference_pdf = _find_reference_pdf(root)
+    if cli_prefix is not None and reference_pdf is not None:
+        pdf_rel = reference_pdf.relative_to(root).as_posix()
+        judges.append(
+            {
+                "type": "shell",
+                "target": f"{cli_prefix} audit --profile reference {pdf_rel}",
+                "description": "Rendered PDF passes report-studio reference audit profile",
+                "blocking": True,
+                "when_changed": list(_WHEN_CHANGED_DOC_PATHS),
+                "timeout_s": 120,
+            }
+        )
 
     return judges
 

--- a/packages/tapps-mcp/tests/unit/test_document_judges.py
+++ b/packages/tapps-mcp/tests/unit/test_document_judges.py
@@ -38,6 +38,32 @@ class TestJudgePresetDiscovery:
         assert any(j["type"] == "grep" and "--audit" in j["expect"] for j in judges)
         assert all(j.get("blocking") is True for j in judges)
 
+    def test_discovers_shell_audit_when_pdf_and_report_studio(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["nlt-report-studio>=0.1.3"]\n',
+            encoding="utf-8",
+        )
+        pdf = tmp_path / "apps" / "docs" / "public" / "downloads" / "vol-06-sample.pdf"
+        pdf.parent.mkdir(parents=True)
+        pdf.write_bytes(b"%PDF-1.4")
+
+        judges = discover_document_judge_preset(tmp_path)
+        shell = [j for j in judges if j["type"] == "shell"]
+        assert len(shell) == 1
+        assert "audit --profile reference" in shell[0]["target"]
+        assert "vol-06-sample.pdf" in shell[0]["target"]
+        assert shell[0]["when_changed"] == ["reports/**", "src/**", "brands/**", "templates/**"]
+
+    def test_skips_shell_audit_without_reference_pdf(self, tmp_path: Path) -> None:
+        (tmp_path / "reports").mkdir()
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["nlt-report-studio>=0.1.3"]\n',
+            encoding="utf-8",
+        )
+        judges = discover_document_judge_preset(tmp_path)
+        assert not any(j["type"] == "shell" for j in judges)
+
 
 class TestMergeDocumentJudges:
     def test_merges_when_empty(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Pytest judges now resolve the consumer project venv (`uv run pytest`, `.venv/bin/python -m pytest`, then `python -m pytest`) with optional `command` override — fixes MCP env false failures when local `uv run pytest` passes (TAP-3637).
- Document judge preset auto-discovers a blocking shell `report-studio audit --profile reference` judge when a reference PDF fixture exists (TAP-3636).
- Adds EPIC-108 planning artifacts and unit tests for both paths.

## Test plan
- [x] `uv run pytest packages/tapps-core/tests/unit/test_judge.py -v`
- [x] `uv run pytest packages/tapps-mcp/tests/unit/test_document_judges.py -v`
- [ ] ReportLab consumer: `tapps_validate_changed` pytest judge passes when `uv run pytest` passes locally


Made with [Cursor](https://cursor.com)