### PR TITLE
fix(validate): run document judges on non-scorable diffs (TAP-3688–3691)

### DIFF
--- a/packages/tapps-core/src/tapps_core/metrics/judge.py
+++ b/packages/tapps-core/src/tapps_core/metrics/judge.py
@@ -175,6 +175,29 @@ async def _run_exists_judge(jd: JudgeDefinition, label: str, cwd: Path) -> Judge
     )
 
 
+def _grep_searchable_text(text: str) -> str:
+    """Return file text with whole-line comments stripped for grep judges."""
+    lines: list[str] = []
+    in_block = False
+    for raw_line in text.splitlines():
+        line = raw_line
+        stripped = line.strip()
+        if in_block:
+            if "*/" in stripped:
+                in_block = False
+            continue
+        if stripped.startswith("/*"):
+            if "*/" not in stripped:
+                in_block = True
+            continue
+        if stripped.startswith("//") or stripped.startswith("#"):
+            continue
+        if "//" in line:
+            line = line[: line.index("//")]
+        lines.append(line)
+    return "\n".join(lines)
+
+
 async def _run_grep_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeResult:
     file_path = Path(jd.target)
     if not file_path.is_absolute():
@@ -188,7 +211,7 @@ async def _run_grep_judge(jd: JudgeDefinition, label: str, cwd: Path) -> JudgeRe
             blocking=jd.blocking,
         )
     try:
-        text = file_path.read_text(encoding="utf-8", errors="replace")
+        text = _grep_searchable_text(file_path.read_text(encoding="utf-8", errors="replace"))
         matched = bool(re.search(jd.expect, text, re.MULTILINE))
         return JudgeResult(
             judge=label,

--- a/packages/tapps-core/tests/unit/test_judge.py
+++ b/packages/tapps-core/tests/unit/test_judge.py
@@ -72,6 +72,22 @@ class TestGrepJudge:
         result = await run_judge(jd)
         assert result.result == "fail"
 
+    @pytest.mark.asyncio
+    async def test_whole_line_comment_does_not_match(self, tmp_path: Path) -> None:
+        f = tmp_path / "build.mjs"
+        f.write_text("// --audit\n")
+        jd = JudgeDefinition(type="grep", target=str(f), expect=r"--audit")
+        result = await run_judge(jd)
+        assert result.result == "fail"
+
+    @pytest.mark.asyncio
+    async def test_executable_line_matches(self, tmp_path: Path) -> None:
+        f = tmp_path / "build.mjs"
+        f.write_text("await exec('node build.mjs --audit');\n")
+        jd = JudgeDefinition(type="grep", target=str(f), expect=r"--audit")
+        result = await run_judge(jd)
+        assert result.result == "pass"
+
 
 class TestPytestJudge:
     @pytest.mark.asyncio

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
@@ -413,16 +413,10 @@ async def _assemble_response(
     )
     overall_passed = outcome.all_passed
     if bc.judges:
-        changed_rel = [
-            str(p.relative_to(bc.settings.project_root))
-            if p.is_relative_to(bc.settings.project_root)
-            else str(p)
-            for p in bc.paths
-        ]
         judge_payload = await _run_judges(
             bc.judges,
             bc.settings.project_root,
-            changed_paths=changed_rel,
+            changed_paths=None,
             base_ref=bc.base_ref,
         )
         summary = apply_judge_payload(resp_data, judge_payload, summary=summary)
@@ -589,7 +583,7 @@ async def tapps_validate_changed(
         effective_judges = [*preset_judges, *(judges or [])]
 
     if not paths:
-        return _handle_no_changed_files(
+        return await _handle_no_changed_files(
             start,
             settings,
             _record_execution,
@@ -597,6 +591,7 @@ async def tapps_validate_changed(
             explicit_paths=bool(file_paths.strip()),
             base_ref=base_ref,
             correlation_id=correlation_id,
+            judges=effective_judges,
         )
 
     bc = _prepare_batch_context(

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
@@ -225,7 +225,7 @@ def _no_changed_warnings(
     return warnings
 
 
-def _handle_no_changed_files(
+async def _handle_no_changed_files(
     start: int,
     settings: TappsMCPSettings,
     record_execution: Callable[..., object],
@@ -234,8 +234,9 @@ def _handle_no_changed_files(
     explicit_paths: bool = False,
     base_ref: str = "HEAD",
     correlation_id: str = "",
+    judges: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Return early response when no changed Python files are found."""
+    """Return early response when no changed scorable files are found."""
     from tapps_mcp import server_pipeline_tools as _host
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
@@ -247,8 +248,6 @@ def _handle_no_changed_files(
     _host._background_tasks.add(task)
     task.add_done_callback(_host._background_tasks.discard)
 
-    _host._write_validate_ok_marker(settings.project_root)
-
     resp_data: dict[str, Any] = {
         "files_validated": 0,
         "all_gates_passed": True,
@@ -256,6 +255,19 @@ def _handle_no_changed_files(
         "results": [],
         "summary": "No changed scorable files found.",
     }
+
+    summary = resp_data["summary"]
+    if judges:
+        judge_payload = await _run_judges(
+            judges,
+            settings.project_root,
+            changed_paths=None,
+            base_ref=base_ref,
+        )
+        summary = apply_judge_payload(resp_data, judge_payload, summary=summary)
+
+    if resp_data.get("all_gates_passed", True):
+        _host._write_validate_ok_marker(settings.project_root)
 
     warnings = _no_changed_warnings(explicit_paths, base_ref)
     if explicit_paths:
@@ -380,9 +392,20 @@ async def _run_judges(
             changed_paths=changed_paths,
             base_ref=base_ref,
         )
-    except Exception:
+    except Exception as exc:
         _logger.debug("judge_run_failed", exc_info=True)
-        return {"judge_results": [], "judges_passed": False}
+        return {
+            "judge_results": [
+                {
+                    "judge": "judge runner",
+                    "type": "shell",
+                    "result": "error",
+                    "message": str(exc),
+                    "blocking": True,
+                }
+            ],
+            "judges_passed": False,
+        }
 
 
 def _append_timeout_hint(

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_judges.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_judges.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tapps_core.config.settings import TappsMCPSettings
 from tapps_mcp.tools.validate_changed_output import (
     _append_judge_summary,
     _build_judge_summary_rows,
+    _handle_no_changed_files,
+    _run_judges,
     apply_judge_payload,
 )
 
@@ -70,3 +78,103 @@ class TestApplyJudgePayload:
             security_depth="basic",
         )
         assert structured.overall_passed is False
+
+
+class TestHandleNoChangedFilesWithJudges:
+    @pytest.mark.asyncio
+    async def test_runs_judges_when_configured(self, tmp_path: Path) -> None:
+        judges = [{"type": "exists", "target": "missing.txt", "blocking": True}]
+        judge_payload = {
+            "judges_passed": False,
+            "judge_results": [
+                {"judge": "exists", "result": "fail", "blocking": True, "message": "Missing"}
+            ],
+        }
+        with (
+            patch(
+                "tapps_mcp.tools.validate_changed_output._run_judges",
+                AsyncMock(return_value=judge_payload),
+            ) as mock_run,
+            patch("tapps_mcp.server_pipeline_tools._write_validate_ok_marker") as mock_marker,
+        ):
+            resp = await _handle_no_changed_files(
+                0,
+                TappsMCPSettings(project_root=tmp_path),
+                lambda *_a, **_k: None,
+                lambda _tool, resp: resp,
+                judges=judges,
+            )
+
+        mock_run.assert_awaited_once()
+        assert resp["data"]["all_gates_passed"] is False
+        mock_marker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_writes_marker_when_judges_pass(self, tmp_path: Path) -> None:
+        judges = [{"type": "exists", "target": "x"}]
+        with (
+            patch(
+                "tapps_mcp.tools.validate_changed_output._run_judges",
+                AsyncMock(
+                    return_value={
+                        "judges_passed": True,
+                        "judge_results": [{"judge": "exists", "result": "pass"}],
+                    }
+                ),
+            ),
+            patch("tapps_mcp.server_pipeline_tools._write_validate_ok_marker") as mock_marker,
+        ):
+            await _handle_no_changed_files(
+                0,
+                TappsMCPSettings(project_root=tmp_path),
+                lambda *_a, **_k: None,
+                lambda _tool, resp: resp,
+                judges=judges,
+            )
+
+        mock_marker.assert_called_once_with(tmp_path)
+
+
+class TestRunJudgesExceptionPayload:
+    @pytest.mark.asyncio
+    async def test_exception_surfaces_error_result(self, tmp_path: Path) -> None:
+        with patch(
+            "tapps_core.metrics.judge.run_judges",
+            AsyncMock(side_effect=RuntimeError("judge boom")),
+        ):
+            payload = await _run_judges([{"type": "exists", "target": "x"}], tmp_path)
+
+        assert payload["judges_passed"] is False
+        assert len(payload["judge_results"]) == 1
+        assert payload["judge_results"][0]["result"] == "error"
+        assert "judge boom" in payload["judge_results"][0]["message"]
+
+
+class TestRunJudgesGitDiffWhenChanged:
+    @pytest.mark.asyncio
+    async def test_uses_git_diff_for_when_changed(self, tmp_path: Path) -> None:
+        from tapps_core.metrics.judge import run_judges
+
+        target = tmp_path / "brands" / "acme.yaml"
+        target.parent.mkdir(parents=True)
+        target.touch()
+
+        with patch(
+            "tapps_core.metrics.judge._git_changed_paths",
+            return_value=["brands/acme.yaml"],
+        ):
+            result = await run_judges(
+                [
+                    {
+                        "type": "exists",
+                        "target": str(target),
+                        "when_changed": ["brands/**"],
+                        "blocking": True,
+                    }
+                ],
+                cwd=tmp_path,
+                changed_paths=None,
+                base_ref="HEAD",
+            )
+
+        assert result["judge_results"][0]["result"] == "pass"


### PR DESCRIPTION
## Summary
- Run configured blocking judges when `validate_changed` finds zero scorable files (TAP-3688)
- Resolve `when_changed` from full git diff instead of scorable paths only (TAP-3689)
- Strip whole-line comments from grep judges so `--audit` in comments cannot false-pass (TAP-3690)
- Surface judge runner exceptions in the response payload (TAP-3691)

## Test plan
- [x] `uv run pytest packages/tapps-core/tests/unit/test_judge.py`
- [x] `uv run pytest packages/tapps-mcp/tests/unit/test_validate_changed_judges.py`
- [x] `tapps_validate_changed` on changed files


Made with [Cursor](https://cursor.com)