### PR TITLE
feat(call-graph): Epic 114 agent automation (TAP-4266–4272)

### DIFF
--- a/docs/CALL_GRAPH.md
+++ b/docs/CALL_GRAPH.md
@@ -40,12 +40,18 @@ Check status anytime via `tapps_session_start` (`call_graph` block) or `tapps_do
 
 | Metric | Meaning |
 |--------|---------|
-| `gap_rate` | `resolution_gaps / edges` — primary health signal |
+| `gap_rate` | `resolution_gaps / edges` — total unresolved call sites |
+| `in_repo_gap_rate` | Actionable in-repo unresolved calls / edges — primary trust signal |
+| `external_gaps` | Stdlib, builtin, and expected dynamic dispatch (not graph breakage) |
+| `in_repo_gaps` | Unresolved calls that may be fixable via better static analysis |
 | `gap_reasons` | Taxonomy: `unresolved_static_call`, `dynamic_dispatch`, `callback_opaque`, `framework_hof`, … |
+| `in_repo_gap_reasons` | Gap reasons counted only for in-repo gaps |
 | `parse_failures` | Files with syntax/decode errors omitted from the graph |
-| `degraded` | Tool response flag when gaps or parse failures exist |
+| `degraded` | Tool response flag when in-repo gaps or parse failures exist |
 
-High `gap_rate` on dynamic codebases is **expected**. Static analysis cannot resolve all Python dispatch. Gaps are honest uncertainty — prefer them over silent wrong edges ([ADR-0004](adr/0004-deterministic-tools-only-contract.md)).
+High total `gap_rate` on dynamic codebases is **expected** — most gaps are stdlib/builtin calls.
+Use `in_repo_gap_rate` to judge whether the graph is trustworthy for refactor workflows.
+Static analysis cannot resolve all Python dispatch. Gaps are honest uncertainty — prefer them over silent wrong edges ([ADR-0004](adr/0004-deterministic-tools-only-contract.md)).
 
 ---
 
@@ -66,7 +72,7 @@ Format: `code_symbol<TAB>test_file<TAB>test_symbol` — useful for CI scripts an
 
 ## Recommended agent workflow
 
-1. **Session start** — confirm `call_graph.ready` or follow the rebuild hint.
+1. **Session start** — confirm `call_graph.ready` or wait for background rebuild (`rebuild_scheduled`).
 2. **Before editing a function** — `tapps_call_graph(symbol="handler_name", query="callers")`.
 3. **After editing Python files** — `tapps_diff_impact` or `tapps_validate_changed(include_impact=true)`.
 4. **Before deleting a symbol** — `tapps_impact_analysis(..., symbol="...", granularity="both")`.

--- a/packages/docs-mcp/src/docs_mcp/generators/api_docs.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/api_docs.py
@@ -306,10 +306,10 @@ class APIDocGenerator:
             return ""
 
         if output_format == "mkdocs":
-            return self._render_mkdocs(module)
+            return self._render_mkdocs(module, project_root=project_root)
         if output_format == "sphinx_rst":
-            return self._render_sphinx_rst(module)
-        return self._render_markdown(module)
+            return self._render_sphinx_rst(module, project_root=project_root)
+        return self._render_markdown(module, project_root=project_root)
 
     # ------------------------------------------------------------------
     # Extraction
@@ -871,15 +871,47 @@ class APIDocGenerator:
 
         return re.sub(r"`(\w+)`", _replace, text)
 
+    @staticmethod
+    def _append_call_graph_sections(
+        lines: list[str],
+        project_root: Path,
+        module_name: str,
+    ) -> None:
+        """Append Used By / Depends On from TappsMCP call graph index (TAP-4271)."""
+        from docs_mcp.integrations.call_graph import module_depends_on, module_used_by
+
+        used = module_used_by(project_root, module_name, limit=10)
+        if used.get("available") and used.get("used_by"):
+            lines.append("## Used By")
+            lines.append("")
+            for entry in used["used_by"]:
+                if isinstance(entry, dict):
+                    caller = entry.get("caller", "")
+                    if caller:
+                        lines.append(f"- `{caller}`")
+            lines.append("")
+
+        depends = module_depends_on(project_root, module_name, limit=10)
+        if depends.get("available") and depends.get("depends_on"):
+            lines.append("## Depends On")
+            lines.append("")
+            for entry in depends["depends_on"]:
+                if isinstance(entry, dict):
+                    callee = entry.get("callee", "")
+                    if callee:
+                        lines.append(f"- `{callee}`")
+            lines.append("")
+
     # ------------------------------------------------------------------
     # Markdown renderer
     # ------------------------------------------------------------------
 
-    def _render_markdown(self, module: APIDocModule) -> str:
+    def _render_markdown(self, module: APIDocModule, *, project_root: Path | None = None) -> str:
         """Render API documentation as GitHub-flavored markdown.
 
         Args:
             module: The extracted module information.
+            project_root: Project root for optional call-graph used-by sections.
 
         Returns:
             The rendered markdown string.
@@ -895,6 +927,9 @@ class APIDocGenerator:
                 self._resolve_cross_refs(module.docstring, known_symbols),
             )
             lines.append("")
+
+        if project_root is not None:
+            self._append_call_graph_sections(lines, project_root, module.name)
 
         # Classes section
         if module.classes:
@@ -1098,7 +1133,7 @@ class APIDocGenerator:
     # MkDocs renderer
     # ------------------------------------------------------------------
 
-    def _render_mkdocs(self, module: APIDocModule) -> str:
+    def _render_mkdocs(self, module: APIDocModule, *, project_root: Path | None = None) -> str:
         """Render API documentation in MkDocs-compatible markdown.
 
         Adds YAML frontmatter and `:::` autodoc syntax for compatibility
@@ -1126,7 +1161,7 @@ class APIDocGenerator:
         lines.append("")
 
         # Append the standard markdown rendering
-        md = self._render_markdown(module)
+        md = self._render_markdown(module, project_root=project_root)
         lines.append(md)
 
         return "\n".join(lines)
@@ -1135,7 +1170,7 @@ class APIDocGenerator:
     # Sphinx RST renderer
     # ------------------------------------------------------------------
 
-    def _render_sphinx_rst(self, module: APIDocModule) -> str:
+    def _render_sphinx_rst(self, module: APIDocModule, *, project_root: Path | None = None) -> str:
         """Render API documentation as Sphinx reStructuredText.
 
         Args:

--- a/packages/docs-mcp/src/docs_mcp/integrations/call_graph.py
+++ b/packages/docs-mcp/src/docs_mcp/integrations/call_graph.py
@@ -1,0 +1,137 @@
+"""Read-only call graph adapter for DocsMCP (TAP-4271).
+
+Loads ``.tapps-mcp/call-graph-index.json`` without importing tapps-mcp so
+doc generators can include used-by / depends-on sections from CALLS edges.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+CALL_GRAPH_CACHE_REL = ".tapps-mcp/call-graph-index.json"
+
+
+@dataclass(frozen=True)
+class CallGraphSnapshot:
+    symbols: tuple[str, ...]
+    edges: tuple[tuple[str, str], ...]
+    stale: bool = False
+    missing: bool = False
+
+
+def load_call_graph_snapshot(project_root: Path) -> CallGraphSnapshot | None:
+    """Load call graph index JSON; return None when unreadable."""
+    path = project_root / CALL_GRAPH_CACHE_REL
+    if not path.is_file():
+        return CallGraphSnapshot(symbols=(), edges=(), missing=True)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug("call_graph_adapter_read_failed", path=str(path), error=str(exc))
+        return None
+    if not isinstance(raw, dict):
+        return None
+    symbols = tuple(
+        str(s.get("qualified_name", ""))
+        for s in raw.get("symbols", [])
+        if isinstance(s, dict) and s.get("qualified_name")
+    )
+    edges = tuple(
+        (str(e.get("caller", "")), str(e.get("callee", "")))
+        for e in raw.get("edges", [])
+        if isinstance(e, dict) and e.get("caller") and e.get("callee")
+    )
+    return CallGraphSnapshot(symbols=symbols, edges=edges)
+
+
+def _symbols_for_module(snapshot: CallGraphSnapshot, module: str) -> set[str]:
+    prefix = f"{module}."
+    return {name for name in snapshot.symbols if name == module or name.startswith(prefix)}
+
+
+def module_used_by(project_root: Path, module: str, *, limit: int = 20) -> dict[str, Any]:
+    """Compact callers of symbols defined in *module*."""
+    snapshot = load_call_graph_snapshot(project_root)
+    if snapshot is None:
+        return {"available": False, "reason": "unreadable"}
+    if snapshot.missing:
+        return {"available": False, "reason": "missing_index"}
+    module_symbols = _symbols_for_module(snapshot, module)
+    if not module_symbols:
+        return {"available": True, "module": module, "used_by": []}
+    used_by: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for caller, callee in snapshot.edges:
+        if callee not in module_symbols:
+            continue
+        if caller in seen:
+            continue
+        seen.add(caller)
+        used_by.append({"caller": caller, "callee": callee})
+        if len(used_by) >= limit:
+            break
+    return {"available": True, "module": module, "used_by": used_by}
+
+
+def module_depends_on(project_root: Path, module: str, *, limit: int = 20) -> dict[str, Any]:
+    """Compact callees invoked from symbols defined in *module*."""
+    snapshot = load_call_graph_snapshot(project_root)
+    if snapshot is None:
+        return {"available": False, "reason": "unreadable"}
+    if snapshot.missing:
+        return {"available": False, "reason": "missing_index"}
+    module_symbols = _symbols_for_module(snapshot, module)
+    if not module_symbols:
+        return {"available": True, "module": module, "depends_on": []}
+    depends_on: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for caller, callee in snapshot.edges:
+        if caller not in module_symbols:
+            continue
+        if callee in seen:
+            continue
+        seen.add(callee)
+        depends_on.append({"caller": caller, "callee": callee})
+        if len(depends_on) >= limit:
+            break
+    return {"available": True, "module": module, "depends_on": depends_on}
+
+
+def symbol_used_by(project_root: Path, symbol: str, *, limit: int = 20) -> dict[str, Any]:
+    """Direct callers of a qualified or short symbol name."""
+    snapshot = load_call_graph_snapshot(project_root)
+    if snapshot is None:
+        return {"available": False, "reason": "unreadable"}
+    if snapshot.missing:
+        return {"available": False, "reason": "missing_index"}
+    trimmed = symbol.strip()
+    matches = {name for name in snapshot.symbols if name == trimmed or name.endswith(f".{trimmed}")}
+    if len(matches) > 1:
+        exact = [name for name in matches if name.rsplit(".", maxsplit=1)[-1] == trimmed]
+        if len(exact) == 1:
+            matches = {exact[0]}
+    if not matches:
+        return {"available": True, "symbol": symbol, "used_by": [], "found": False}
+    qualified = next(iter(matches))
+    used_by: list[str] = []
+    for caller, callee in snapshot.edges:
+        if callee != qualified:
+            continue
+        if caller not in used_by:
+            used_by.append(caller)
+        if len(used_by) >= limit:
+            break
+    return {
+        "available": True,
+        "symbol": symbol,
+        "qualified_name": qualified,
+        "found": True,
+        "used_by": used_by,
+    }

--- a/packages/docs-mcp/tests/unit/test_api_docs.py
+++ b/packages/docs-mcp/tests/unit/test_api_docs.py
@@ -1374,3 +1374,65 @@ class TestQualityMetrics:
         result = gen.generate(source, project_root=tmp_path)
 
         assert "missing return docs" in result or "missing examples" in result
+
+
+class TestAPIDocCallGraphSections:
+    def test_markdown_includes_used_by_and_depends_on(self, tmp_path: Path) -> None:
+        import json
+
+        (tmp_path / "app").mkdir()
+        (tmp_path / "app" / "__init__.py").write_text("", encoding="utf-8")
+        (tmp_path / "app" / "core.py").write_text(
+            '"""Core module."""\n\ndef compute():\n    return 1\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "app" / "api.py").write_text(
+            '"""API module."""\n\nfrom app.core import compute\n\ndef run():\n    return compute()\n',
+            encoding="utf-8",
+        )
+        cache_dir = tmp_path / ".tapps-mcp"
+        cache_dir.mkdir()
+        (cache_dir / "call-graph-index.json").write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "symbols": [
+                        {
+                            "qualified_name": "app.core.compute",
+                            "module": "app.core",
+                            "file_path": "app/core.py",
+                            "line": 3,
+                            "kind": "function",
+                        },
+                        {
+                            "qualified_name": "app.api.run",
+                            "module": "app.api",
+                            "file_path": "app/api.py",
+                            "line": 5,
+                            "kind": "function",
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "caller": "app.api.run",
+                            "callee": "app.core.compute",
+                            "callee_expr": "compute()",
+                            "line": 5,
+                            "resolved": True,
+                        }
+                    ],
+                    "resolution_gaps": [],
+                    "parse_failures": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        gen = APIDocGenerator()
+        core_doc = gen.generate(tmp_path / "app" / "core.py", project_root=tmp_path)
+        assert "## Used By" in core_doc
+        assert "app.api.run" in core_doc
+
+        api_doc = gen.generate(tmp_path / "app" / "api.py", project_root=tmp_path)
+        assert "## Depends On" in api_doc
+        assert "app.core.compute" in api_doc

--- a/packages/docs-mcp/tests/unit/test_call_graph_adapter.py
+++ b/packages/docs-mcp/tests/unit/test_call_graph_adapter.py
@@ -1,0 +1,57 @@
+"""Tests for DocsMCP call graph adapter (TAP-4271)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from docs_mcp.integrations.call_graph import (
+    module_depends_on,
+    module_used_by,
+    symbol_used_by,
+)
+
+
+def _write_index(root: Path) -> None:
+    payload = {
+        "version": 2,
+        "symbols": [
+            {"qualified_name": "app.core.compute", "module": "app.core", "file_path": "app/core.py", "line": 1, "kind": "function"},
+            {"qualified_name": "app.api.run", "module": "app.api", "file_path": "app/api.py", "line": 1, "kind": "function"},
+        ],
+        "edges": [
+            {"caller": "app.api.run", "callee": "app.core.compute", "callee_expr": "compute()", "line": 2, "resolved": True},
+        ],
+        "resolution_gaps": [],
+        "parse_failures": [],
+    }
+    cache_dir = root / ".tapps-mcp"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "call-graph-index.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_module_used_by(tmp_path: Path) -> None:
+    _write_index(tmp_path)
+    result = module_used_by(tmp_path, "app.core")
+    assert result["available"] is True
+    assert result["used_by"][0]["caller"] == "app.api.run"
+
+
+def test_module_depends_on(tmp_path: Path) -> None:
+    _write_index(tmp_path)
+    result = module_depends_on(tmp_path, "app.api")
+    assert result["available"] is True
+    assert result["depends_on"][0]["callee"] == "app.core.compute"
+
+
+def test_symbol_used_by_short_name(tmp_path: Path) -> None:
+    _write_index(tmp_path)
+    result = symbol_used_by(tmp_path, "compute")
+    assert result["found"] is True
+    assert result["used_by"] == ["app.api.run"]
+
+
+def test_missing_index_graceful(tmp_path: Path) -> None:
+    result = module_used_by(tmp_path, "app.core")
+    assert result["available"] is False
+    assert result["reason"] == "missing_index"

--- a/packages/tapps-mcp/src/tapps_mcp/cli.py
+++ b/packages/tapps-mcp/src/tapps_mcp/cli.py
@@ -78,13 +78,88 @@ def fleet_status_cmd() -> None:
 
 @fleet.command("restart")
 @click.option("--force", is_flag=True, help="Force restart even when PIDs look healthy.")
-def fleet_restart(force: bool) -> None:
-    """Stop then start the HTTP fleet."""
-    from tapps_mcp.distribution.fleet_control import start_fleet, stop_fleet
+@click.option(
+    "--skip-smoke",
+    is_flag=True,
+    default=False,
+    help="Skip post-restart MCP handshake smoke (not recommended).",
+)
+@click.option(
+    "--project-root",
+    default=".",
+    show_default=True,
+    help="Project root sent as X-Tapps-Project-Root during smoke probes.",
+)
+def fleet_restart(force: bool, skip_smoke: bool, project_root: str) -> None:
+    """Stop then start the HTTP fleet and verify MCP handshakes."""
+    from tapps_mcp.distribution.fleet_control import (
+        restart_fleet_with_smoke,
+        start_fleet,
+        stop_fleet,
+    )
 
-    stop_fleet()
-    result = start_fleet(force=True)
-    click.echo(click.style("Restarted: " + ", ".join(result["started"]), fg="green"))
+    root = Path(project_root).resolve()
+    if skip_smoke:
+        stop_fleet()
+        result = start_fleet(force=True)
+        click.echo(click.style("Restarted: " + ", ".join(result["started"]), fg="green"))
+        for err in result.get("errors", []):
+            click.echo(click.style(err, fg="red"))
+        if result.get("errors"):
+            raise SystemExit(1)
+        return
+
+    report = restart_fleet_with_smoke(project_root=root)
+    click.echo(click.style("Restarted: " + ", ".join(report["started"]), fg="green"))
+    smoke = report["smoke"]
+    for server_id, row in smoke.get("servers", {}).items():
+        if row.get("ok"):
+            click.echo(
+                click.style(
+                    f"  smoke {server_id}: ok ({row.get('tool_count', 0)} tools)",
+                    fg="green",
+                )
+            )
+        else:
+            click.echo(click.style(f"  smoke {server_id}: FAIL ({row.get('stage')})", fg="red"))
+    for err in report.get("errors", []):
+        click.echo(click.style(err, fg="red"))
+    if not report.get("ok"):
+        raise SystemExit(1)
+
+
+@fleet.command("smoke")
+@click.option(
+    "--project-root",
+    default=".",
+    show_default=True,
+    help="Project root sent as X-Tapps-Project-Root during smoke probes.",
+)
+def fleet_smoke_cmd(project_root: str) -> None:
+    """Verify initialize + tools/list on every HTTP fleet server (Cursor-like)."""
+    from tapps_mcp.distribution.fleet_smoke import smoke_test_fleet
+
+    root = Path(project_root).resolve()
+    result = smoke_test_fleet(project_root=root)
+    for server_id, row in result.get("servers", {}).items():
+        if row.get("ok"):
+            click.echo(
+                click.style(
+                    f"PASS {server_id}: {row.get('tool_count', 0)} tools @ {row.get('url')}",
+                    fg="green",
+                )
+            )
+        else:
+            detail = row.get("error") or f"http={row.get('http_status')}"
+            click.echo(
+                click.style(
+                    f"FAIL {server_id} ({row.get('stage', '?')}): {detail}",
+                    fg="red",
+                )
+            )
+    if not result.get("ok"):
+        raise SystemExit(1)
+    click.echo(click.style(f"All {result['total']} fleet servers passed MCP smoke.", fg="green"))
 
 
 @fleet.command("ensure")

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/blue_green.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/blue_green.py
@@ -290,6 +290,15 @@ def _deploy_under_lock(
             report["ok"] = False
             return report
 
+    from tapps_mcp.distribution.fleet_control import fleet_any_running, restart_fleet_with_smoke
+
+    if fleet_any_running():
+        fleet_smoke = restart_fleet_with_smoke(project_root=checkout)
+        report["fleet_restart_smoke"] = fleet_smoke
+        if not fleet_smoke.get("ok"):
+            report["ok"] = False
+            return report
+
     report["gc"] = gc_releases(keep=keep_releases, protect=release.path)
     report["ok"] = True
     report["current"] = str(CURRENT_LINK)

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -3622,11 +3622,14 @@ def check_call_graph_index_cache(root: Path, *, quick: bool = False) -> CheckRes
         gap_count = int(summary.get("resolution_gaps", 0))
         if gap_count:
             gap_reasons = summary.get("gap_reasons")
+            in_repo_rate = summary.get("in_repo_gap_rate")
             if isinstance(gap_reasons, dict) and gap_reasons:
                 reason_bits = ", ".join(f"{k}={v}" for k, v in gap_reasons.items())
                 parts.append(f"{gap_count} resolution gaps ({reason_bits})")
             else:
                 parts.append(f"{gap_count} resolution gaps")
+            if in_repo_rate is not None:
+                parts.append(f"in_repo_gap_rate={in_repo_rate}")
         parse_failures = int(summary.get("parse_failures", 0))
         if parse_failures:
             parts.append(f"{parse_failures} parse failure(s)")

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_control.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_control.py
@@ -329,6 +329,26 @@ def ensure_fleet_running() -> dict[str, Any]:
     return {"action": "direct_start", "healthy": False, "unhealthy": unhealthy}
 
 
+def fleet_any_running() -> bool:
+    """Return True when at least one supervised fleet server has a live PID."""
+    return fleet_status()["running"] > 0
+
+
+def restart_fleet_with_smoke(*, project_root: Path | None = None) -> dict[str, Any]:
+    """Stop, start, then run Cursor-style MCP smoke on every fleet server."""
+    from tapps_mcp.distribution.fleet_smoke import smoke_test_fleet
+
+    stop_fleet()
+    started = start_fleet(force=True)
+    smoke = smoke_test_fleet(project_root=project_root)
+    return {
+        "ok": bool(smoke.get("ok")),
+        "started": started.get("started", []),
+        "errors": started.get("errors", []),
+        "smoke": smoke,
+    }
+
+
 def fleet_status() -> dict[str, Any]:
     """Return running/reachable status for each fleet server."""
     host = resolve_fleet_host()

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_smoke.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_smoke.py
@@ -1,0 +1,206 @@
+"""Streamable HTTP MCP smoke probes for the shared NLT fleet (ADR-0024).
+
+TCP/port checks (``fleet status``, doctor liveness) only prove a process is
+listening. Cursor clients need a full ``initialize`` + ``tools/list`` handshake
+with the ``Accept: application/json, text/event-stream`` header — without that
+probe, fleet restarts look healthy while every IDE session is dead.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from tapps_core.http.request_context import PROJECT_ROOT_HEADER
+from tapps_mcp.distribution.nlt_http_fleet import (
+    NLT_HTTP_FLEET_PORTS,
+    build_http_fleet_url,
+    resolve_fleet_host,
+    resolve_http_project_root_header,
+)
+
+_MCP_ACCEPT = "application/json, text/event-stream"
+_INIT_PROTOCOL = "2025-03-26"
+
+
+def parse_sse_json(body: str) -> dict[str, Any] | None:
+    """Return the first JSON object from an SSE ``data:`` line."""
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            try:
+                parsed = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+    return None
+
+
+def _post_mcp(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    project_root: str,
+    session_id: str | None = None,
+    timeout: float = 15.0,
+) -> tuple[int, str | None, str]:
+    if not url.startswith("http://127.0.0.1:") and not url.startswith(
+        f"http://{resolve_fleet_host()}:"
+    ):
+        msg = f"refusing non-local fleet URL: {url}"
+        raise ValueError(msg)
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": _MCP_ACCEPT,
+        PROJECT_ROOT_HEADER: project_root,
+    }
+    if session_id:
+        headers["mcp-session-id"] = session_id
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return resp.status, resp.headers.get("mcp-session-id"), resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers.get("mcp-session-id"), exc.read().decode()
+
+
+def probe_fleet_mcp_session(
+    server_id: str,
+    *,
+    project_root: Path | None = None,
+    fleet_host: str | None = None,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    """Run initialize + initialized + tools/list against one fleet server."""
+    if server_id not in NLT_HTTP_FLEET_PORTS:
+        return {"ok": False, "server_id": server_id, "error": f"unknown server: {server_id}"}
+
+    root_header = resolve_http_project_root_header(project_root)
+    url = build_http_fleet_url(server_id, fleet_host=fleet_host)
+
+    status, session_id, body = _post_mcp(
+        url,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": _INIT_PROTOCOL,
+                "capabilities": {},
+                "clientInfo": {"name": "tapps-mcp-fleet-smoke", "version": "1"},
+            },
+        },
+        project_root=root_header,
+        timeout=timeout,
+    )
+    if status != 200 or not session_id:
+        return {
+            "ok": False,
+            "server_id": server_id,
+            "url": url,
+            "stage": "initialize",
+            "http_status": status,
+            "error": body[:500],
+        }
+
+    init_payload = parse_sse_json(body)
+    if init_payload is None or "result" not in init_payload:
+        return {
+            "ok": False,
+            "server_id": server_id,
+            "url": url,
+            "stage": "initialize",
+            "error": f"invalid SSE payload: {body[:200]!r}",
+        }
+
+    init_status, _, _ = _post_mcp(
+        url,
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        project_root=root_header,
+        session_id=session_id,
+        timeout=timeout,
+    )
+    if init_status not in (200, 202):
+        return {
+            "ok": False,
+            "server_id": server_id,
+            "url": url,
+            "stage": "initialized",
+            "http_status": init_status,
+        }
+
+    list_status, _, list_body = _post_mcp(
+        url,
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        project_root=root_header,
+        session_id=session_id,
+        timeout=timeout,
+    )
+    listed = parse_sse_json(list_body)
+    tools = (listed or {}).get("result", {}).get("tools", [])
+    tool_count = len(tools) if isinstance(tools, list) else 0
+    if list_status != 200 or tool_count == 0:
+        return {
+            "ok": False,
+            "server_id": server_id,
+            "url": url,
+            "stage": "tools/list",
+            "http_status": list_status,
+            "tool_count": tool_count,
+            "error": list_body[:500],
+        }
+
+    server_info = init_payload.get("result", {}).get("serverInfo", {})
+    return {
+        "ok": True,
+        "server_id": server_id,
+        "url": url,
+        "tool_count": tool_count,
+        "server_name": server_info.get("name"),
+        "server_version": server_info.get("version"),
+    }
+
+
+def smoke_test_fleet(
+    *,
+    project_root: Path | None = None,
+    fleet_host: str | None = None,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    """Smoke-test every NLT HTTP fleet server with a Cursor-like MCP handshake."""
+    host = fleet_host or resolve_fleet_host()
+    servers: dict[str, dict[str, Any]] = {}
+    failures: list[str] = []
+
+    for server_id in NLT_HTTP_FLEET_PORTS:
+        result = probe_fleet_mcp_session(
+            server_id,
+            project_root=project_root,
+            fleet_host=host,
+            timeout=timeout,
+        )
+        servers[server_id] = result
+        if not result.get("ok"):
+            stage = result.get("stage", "unknown")
+            detail = result.get("error") or f"http={result.get('http_status')}"
+            failures.append(f"{server_id} ({stage}): {detail}")
+
+    passed = sum(1 for row in servers.values() if row.get("ok"))
+    return {
+        "ok": not failures,
+        "passed": passed,
+        "total": len(NLT_HTTP_FLEET_PORTS),
+        "project_root": resolve_http_project_root_header(project_root),
+        "fleet_host": host,
+        "servers": servers,
+        "failures": failures,
+    }

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
@@ -21,6 +21,7 @@ from tapps_mcp.project.call_graph_fingerprint import (
     compute_index_fingerprint,
     fingerprint_settings,
 )
+from tapps_mcp.project.call_graph_gap_classify import split_gap_counts
 from tapps_mcp.project.call_graph_types import (
     CALL_GRAPH_CACHE_REL,
     INDEX_VERSION,
@@ -176,8 +177,11 @@ def summarize_call_graph_cache(
     except OSError:
         pass
 
+    external_gaps, in_repo_gaps, in_repo_gap_reasons = split_gap_counts(cached.resolution_gaps)
+    in_repo_gap_rate = round(in_repo_gaps / max(edge_count, 1), 3)
+
     status = "stale" if stale else "ready"
-    degraded = parse_fail_count > 0 or gap_count > 0
+    degraded = parse_fail_count > 0 or in_repo_gaps > 0
     result: dict[str, object] = {
         "status": status,
         "ready": not stale,
@@ -186,8 +190,12 @@ def summarize_call_graph_cache(
         "symbols": len(cached.symbols),
         "edges": edge_count,
         "resolution_gaps": gap_count,
+        "external_gaps": external_gaps,
+        "in_repo_gaps": in_repo_gaps,
         "gap_rate": round(gap_count / max(edge_count, 1), 3),
+        "in_repo_gap_rate": in_repo_gap_rate,
         "gap_reasons": _gap_reason_counts(cached.resolution_gaps),
+        "in_repo_gap_reasons": in_repo_gap_reasons,
         "parse_failures": parse_fail_count,
         "age_hours": age_hours,
     }
@@ -197,7 +205,7 @@ def summarize_call_graph_cache(
         result["hint"] = (
             f"{parse_fail_count} file(s) failed to parse — graph is incomplete for those modules."
         )
-    elif degraded and gap_count:
+    elif degraded and in_repo_gaps:
         result["hint"] = CALL_GRAPH_DEGRADED_HINT
     return result
 

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_gap_classify.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_gap_classify.py
@@ -1,0 +1,95 @@
+"""Resolution gap classification: in-repo vs external (TAP-4269)."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from functools import lru_cache
+
+from tapps_mcp.project.call_graph_types import ResolutionGap
+
+_EXTERNAL_REASONS = frozenset(
+    {
+        "dynamic_dispatch",
+        "callback_opaque",
+        "framework_hof",
+        "import_unresolved",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _stdlib_module_names() -> frozenset[str]:
+    names = getattr(sys, "stdlib_module_names", None)
+    if names:
+        return frozenset(names)
+    return frozenset(
+        {
+            "abc",
+            "argparse",
+            "ast",
+            "asyncio",
+            "collections",
+            "contextlib",
+            "dataclasses",
+            "enum",
+            "functools",
+            "importlib",
+            "io",
+            "itertools",
+            "json",
+            "logging",
+            "os",
+            "pathlib",
+            "re",
+            "sys",
+            "tempfile",
+            "time",
+            "typing",
+            "urllib",
+        }
+    )
+
+
+@lru_cache(maxsize=1)
+def _builtin_names() -> frozenset[str]:
+    return frozenset(name for name in dir(builtins) if not name.startswith("_"))
+
+
+def expr_root(expr: str) -> str:
+    """First identifier token from a call expression string."""
+    trimmed = expr.strip()
+    if not trimmed or trimmed == "<expr>":
+        return ""
+    token = trimmed.split("(", maxsplit=1)[0].strip()
+    if not token:
+        return ""
+    return token.split(".", maxsplit=1)[0]
+
+
+def is_external_gap(gap: ResolutionGap) -> bool:
+    """True when the gap is stdlib/builtin/third-party or expected dynamic dispatch."""
+    if gap.reason in _EXTERNAL_REASONS:
+        return True
+    root = expr_root(gap.expr)
+    if not root:
+        return True
+    if root in _builtin_names():
+        return True
+    if root in _stdlib_module_names():
+        return True
+    return False
+
+
+def split_gap_counts(gaps: list[ResolutionGap]) -> tuple[int, int, dict[str, int]]:
+    """Return (external_count, in_repo_count, in_repo_reasons)."""
+    external = 0
+    in_repo = 0
+    in_repo_reasons: dict[str, int] = {}
+    for gap in gaps:
+        if is_external_gap(gap):
+            external += 1
+            continue
+        in_repo += 1
+        in_repo_reasons[gap.reason] = in_repo_reasons.get(gap.reason, 0) + 1
+    return external, in_repo, dict(sorted(in_repo_reasons.items()))

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_queries.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_queries.py
@@ -200,3 +200,61 @@ def query_call_graph(
         "truncated": truncated,
         "token_budget": token_budget,
     }
+
+
+def compact_symbol_impact(
+    index: CallGraphIndex,
+    file_path: str,
+    *,
+    max_callers: int = 5,
+    max_tests: int = 5,
+    token_budget: int = 500,
+) -> dict[str, Any] | None:
+    """Token-capped caller/test summary for symbols defined in *file_path* (TAP-4270)."""
+    normalized = file_path.replace("\\", "/")
+    file_symbols = [
+        s
+        for s in index.symbols
+        if s.file_path.replace("\\", "/") == normalized and s.kind in ("function", "method")
+    ]
+    if not file_symbols:
+        return None
+
+    from tapps_mcp.project.test_linker import build_test_edges, get_tests_for_symbol
+
+    test_edges = build_test_edges(index)
+    symbols_out: list[dict[str, Any]] = []
+    truncated = False
+
+    for sym in file_symbols:
+        callers = [
+            edge.caller.rsplit(".", maxsplit=1)[-1]
+            for edge in index.callers_of(sym.qualified_name)[:max_callers]
+        ]
+        tests = get_tests_for_symbol(test_edges, sym.qualified_name, index=index)[:max_tests]
+        entry = {
+            "symbol": sym.qualified_name.rsplit(".", maxsplit=1)[-1],
+            "qualified_name": sym.qualified_name,
+            "callers": callers,
+            "tests": [
+                {
+                    "test_file": t.get("test_file", ""),
+                    "test_symbol": t.get("test_symbol", ""),
+                }
+                for t in tests
+            ],
+        }
+        trial = {"symbols": [*symbols_out, entry]}
+        if _estimate_tokens(trial) > token_budget:
+            truncated = True
+            break
+        symbols_out.append(entry)
+
+    if not symbols_out:
+        return None
+    return {
+        "file_path": normalized,
+        "symbols": symbols_out,
+        "truncated": truncated,
+        "token_budget": token_budget,
+    }

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_resolve.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_resolve.py
@@ -31,6 +31,25 @@ def unparse_expr(node: ast.expr) -> str:
         return "<expr>"
 
 
+def _apply_import_bindings(
+    idx: FileIndex,
+    bindings: dict[str, str],
+    node: ast.Import | ast.ImportFrom,
+) -> None:
+    """Record Import/ImportFrom bindings (module-level or in-function lazy imports)."""
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            bound = alias.asname or alias.name.split(".", maxsplit=1)[0]
+            bindings[bound] = alias.name
+        return
+    base = node.module or ""
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        bound = alias.asname or alias.name
+        bindings[bound] = f"{base}.{alias.name}" if base else alias.name
+
+
 def local_bindings(
     idx: FileIndex,
     node: ast.FunctionDef | ast.AsyncFunctionDef,
@@ -38,6 +57,9 @@ def local_bindings(
 ) -> dict[str, str]:
     bindings = {a.arg: a.arg for a in node.args.args}
     for child in ast.walk(node):
+        if isinstance(child, ast.Import | ast.ImportFrom):
+            _apply_import_bindings(idx, bindings, child)
+            continue
         if not isinstance(child, ast.Assign):
             continue
         for target in child.targets:

--- a/packages/tapps-mcp/src/tapps_mcp/project/diff_impact.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/diff_impact.py
@@ -11,6 +11,7 @@ from tapps_mcp.project.impact_analyzer import analyze_impact, build_import_graph
 from tapps_mcp.project.test_linker import build_test_edges, edges_for_symbols
 
 DEFAULT_AFFECTED_TESTS_LIMIT = 20
+DEFAULT_DOC_DRIFT_CALLER_THRESHOLD = 5
 
 
 @dataclass
@@ -20,6 +21,56 @@ class RankedTest:
     reasons: list[str]
     test_symbols: list[str]
     code_symbols: list[str]
+
+
+def _doc_paths_for_module(module: str) -> list[str]:
+    """Heuristic doc paths agents may want to refresh after structural edits."""
+    parts = module.split(".")
+    candidates = [
+        f"docs/{'/'.join(parts)}.md",
+        f"docs/{parts[-1]}.md",
+        f"docs/architecture/{parts[-1]}.md",
+    ]
+    if len(parts) >= 2:
+        candidates.append(f"docs/{parts[0]}/{parts[-1]}.md")
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for path in candidates:
+        if path not in seen:
+            seen.add(path)
+            ordered.append(path)
+    return ordered
+
+
+def _collect_doc_drift_hints(
+    index: object,
+    changed_symbols: set[str],
+    *,
+    caller_threshold: int = DEFAULT_DOC_DRIFT_CALLER_THRESHOLD,
+) -> list[dict[str, object]]:
+    from tapps_mcp.project.call_graph_types import CallGraphIndex
+
+    if not isinstance(index, CallGraphIndex):
+        return []
+    hints: list[dict[str, object]] = []
+    for sym in sorted(changed_symbols):
+        direct_callers = index.callers_of(sym)
+        if len(direct_callers) < caller_threshold:
+            continue
+        record = next((s for s in index.symbols if s.qualified_name == sym), None)
+        module = record.module if record else sym.rsplit(".", maxsplit=1)[0]
+        hints.append(
+            {
+                "symbol": sym,
+                "direct_callers": len(direct_callers),
+                "suggested_doc_paths": _doc_paths_for_module(module),
+                "message": (
+                    f"{sym} has {len(direct_callers)} direct callers — "
+                    "consider updating related documentation."
+                ),
+            }
+        )
+    return hints
 
 
 def _symbols_in_file(index: object, rel_path: str) -> set[str]:
@@ -36,6 +87,7 @@ def analyze_diff_impact(
     project_root: Path,
     *,
     max_tests: int = DEFAULT_AFFECTED_TESTS_LIMIT,
+    doc_drift_caller_threshold: int = DEFAULT_DOC_DRIFT_CALLER_THRESHOLD,
 ) -> dict[str, object]:
     """Rank tests affected by *changed_files* using TESTS edges and import impact."""
     index = build_call_graph_index(project_root)
@@ -99,7 +151,20 @@ def analyze_diff_impact(
     ordered = sorted(ranked.values(), key=lambda r: (-r.score, r.test_file))
     cap = max(1, max_tests)
     degraded = bool(index.resolution_gaps or index.parse_failures)
-    return {
+    all_changed_symbols: set[str] = set()
+    for changed in changed_files:
+        try:
+            rel = str(changed.resolve().relative_to(project_root.resolve()))
+        except ValueError:
+            rel = str(changed)
+        all_changed_symbols.update(_symbols_in_file(index, rel.replace("\\", "/")))
+
+    doc_drift_hints = _collect_doc_drift_hints(
+        index,
+        all_changed_symbols,
+        caller_threshold=doc_drift_caller_threshold,
+    )
+    payload: dict[str, object] = {
         "changed_files": [str(p) for p in changed_files],
         "affected_tests": [asdict(r) for r in ordered[:cap]],
         "total_affected_tests": len(ordered),
@@ -108,6 +173,9 @@ def analyze_diff_impact(
         "degraded": degraded,
         "parse_failures": len(index.parse_failures),
     }
+    if doc_drift_hints:
+        payload["doc_drift_hints"] = doc_drift_hints
+    return payload
 
 
 def export_test_map(

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -694,8 +694,13 @@ async def tapps_session_start(
     # Epic 114: surface call-graph cache readiness for symbol-level refactors.
     try:
         from tapps_mcp.project.call_graph_cache import summarize_call_graph_cache
+        from tapps_mcp.tools.session_start_helpers import _schedule_call_graph_rebuild
 
-        data["call_graph"] = summarize_call_graph_cache(Path(settings.project_root))
+        call_graph_summary = summarize_call_graph_cache(Path(settings.project_root))
+        rebuild = _schedule_call_graph_rebuild(Path(settings.project_root), call_graph_summary)
+        if rebuild.get("scheduled"):
+            call_graph_summary["rebuild_scheduled"] = True
+        data["call_graph"] = call_graph_summary
     except Exception:
         _logger.debug("call_graph_session_start_failed", exc_info=True)
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_scoring_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_scoring_tools.py
@@ -604,6 +604,29 @@ def _attach_cross_file_analysis(
         data["cross_file_analysis"] = "degraded"
 
 
+def _attach_symbol_impact(
+    data: dict[str, Any],
+    resolved: Path,
+    project_root: Path,
+) -> None:
+    """Attach compact call-graph symbol impact when index is available (TAP-4270)."""
+    if resolved.suffix not in {".py", ".pyi"}:
+        return
+    try:
+        from tapps_mcp.project.call_graph_cache import load_call_graph_index
+        from tapps_mcp.project.call_graph_queries import compact_symbol_impact
+
+        index = load_call_graph_index(project_root)
+        if index is None:
+            return
+        rel = str(resolved.relative_to(project_root)).replace("\\", "/")
+        block = compact_symbol_impact(index, rel)
+        if block is not None:
+            data["symbol_impact"] = block
+    except Exception:
+        logger.debug("quick_check_symbol_impact_failed", exc_info=True)
+
+
 def _attach_uncached_libraries_hint(
     data: dict[str, Any],
     resolved: Path,
@@ -795,6 +818,7 @@ async def _quick_check_single(
     # Story 75.2: Cross-file kwarg mismatch detection (Python only)
     if is_python:
         _attach_cross_file_analysis(data, resolved, settings.project_root)
+        _attach_symbol_impact(data, resolved, settings.project_root)
 
     data["success"] = True
     data["gate_passed"] = gate_result.passed
@@ -1055,6 +1079,7 @@ async def tapps_quick_check(
     # Story 75.2: Cross-file kwarg mismatch detection (Python only)
     if is_python:
         _attach_cross_file_analysis(data, resolved, settings.project_root)
+        _attach_symbol_impact(data, resolved, settings.project_root)
 
     resp = success_response(
         "tapps_quick_check",

--- a/packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py
@@ -1289,3 +1289,38 @@ def _schedule_lookup_docs_warm(
         }
     except RuntimeError:
         return {"scheduled": False, "skipped": "no_running_loop"}
+
+
+# ---------------------------------------------------------------------------
+# TAP-4266: background call-graph rebuild on session_start when stale/missing
+# ---------------------------------------------------------------------------
+
+
+def _schedule_call_graph_rebuild(
+    project_root: Path,
+    call_graph_summary: dict[str, object],
+) -> dict[str, object]:
+    """Fire-and-forget rebuild when cache is stale or missing."""
+    status = str(call_graph_summary.get("status", ""))
+    stale = bool(call_graph_summary.get("stale"))
+    if status not in {"missing", "stale", "unreadable"} and not stale:
+        return {"scheduled": False, "skipped": "cache_fresh"}
+
+    from tapps_mcp import server_pipeline_tools as _host
+
+    async def _runner() -> None:
+        try:
+            from tapps_mcp.project.call_graph import build_call_graph_index
+
+            await asyncio.to_thread(build_call_graph_index, project_root)
+        except Exception:
+            _logger.debug("call_graph_background_rebuild_failed", exc_info=True)
+
+    try:
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(_runner())
+        _host._background_tasks.add(task)
+        task.add_done_callback(_host._background_tasks.discard)
+        return {"scheduled": True, "reason": status or "stale"}
+    except RuntimeError:
+        return {"scheduled": False, "skipped": "no_running_loop"}

--- a/packages/tapps-mcp/tests/unit/test_call_graph.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph.py
@@ -417,3 +417,33 @@ class TestSummarizeCallGraphCache:
         assert summary.get("stale") is True
         assert summary.get("hint") == CALL_GRAPH_STALE_HINT
         assert "automatically" in str(summary.get("hint"))
+
+    def test_summary_includes_in_repo_gap_metrics(self, tmp_path: Path) -> None:
+        from tapps_mcp.project.call_graph_cache import save_call_graph_index, summarize_call_graph_cache
+        from tapps_mcp.project.call_graph_types import (
+            CallEdge,
+            CallGraphIndex,
+            INDEX_VERSION,
+            ResolutionGap,
+        )
+        from tapps_mcp.project.call_graph_fingerprint import compute_index_fingerprint, fingerprint_settings
+
+        settings = fingerprint_settings(tmp_path)
+        fp = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        save_call_graph_index(
+            tmp_path,
+            CallGraphIndex(
+                project_root=str(tmp_path),
+                fingerprint=fp,
+                version=INDEX_VERSION,
+                edges=[CallEdge("a.f", "b.g", "helper()", 1, True)],
+                resolution_gaps=[
+                    ResolutionGap("a.f", "len(x)", 1, "unresolved_static_call"),
+                    ResolutionGap("a.f", "helper()", 2, "unresolved_static_call"),
+                ],
+            ),
+        )
+        summary = summarize_call_graph_cache(tmp_path)
+        assert summary.get("external_gaps") == 1
+        assert summary.get("in_repo_gaps") == 1
+        assert summary.get("in_repo_gap_rate") == 1.0

--- a/packages/tapps-mcp/tests/unit/test_call_graph_gap_classify.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_gap_classify.py
@@ -1,0 +1,46 @@
+"""Tests for resolution gap classification (TAP-4269)."""
+
+from __future__ import annotations
+
+from tapps_mcp.project.call_graph_gap_classify import (
+    expr_root,
+    is_external_gap,
+    split_gap_counts,
+)
+from tapps_mcp.project.call_graph_types import ResolutionGap
+
+
+def test_expr_root_simple_call() -> None:
+    assert expr_root("json.loads(x)") == "json"
+
+
+def test_is_external_gap_stdlib() -> None:
+    gap = ResolutionGap("demo.main.run", "len(items)", 10, "unresolved_static_call")
+    assert is_external_gap(gap) is True
+
+
+def test_is_external_gap_dynamic_dispatch() -> None:
+    gap = ResolutionGap("demo.main.run", "getattr(obj, name)()", 10, "dynamic_dispatch")
+    assert is_external_gap(gap) is True
+
+
+def test_is_external_gap_in_repo_unresolved() -> None:
+    gap = ResolutionGap(
+        "demo.main.run",
+        "helper()",
+        10,
+        "unresolved_static_call",
+    )
+    assert is_external_gap(gap) is False
+
+
+def test_split_gap_counts() -> None:
+    gaps = [
+        ResolutionGap("a", "len(x)", 1, "unresolved_static_call"),
+        ResolutionGap("a", "helper()", 2, "unresolved_static_call"),
+        ResolutionGap("a", "getattr(x)", 3, "dynamic_dispatch"),
+    ]
+    external, in_repo, reasons = split_gap_counts(gaps)
+    assert external == 2
+    assert in_repo == 1
+    assert reasons == {"unresolved_static_call": 1}

--- a/packages/tapps-mcp/tests/unit/test_call_graph_queries.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_queries.py
@@ -69,3 +69,30 @@ def mystery(obj):
         index = build_call_graph_index(tmp_path, force_rebuild=True)
         result = query_call_graph(index, "pkg.big.f", mode="callers", max_depth=10, token_budget=50)
         assert result["truncated"] is True
+
+
+def test_compact_symbol_impact_budget(tmp_path: Path) -> None:
+    from tapps_mcp.project.call_graph_queries import compact_symbol_impact
+
+    _write(
+        tmp_path,
+        "pkg/target.py",
+        """
+def target():
+    return 1
+""",
+    )
+    _write(
+        tmp_path,
+        "pkg/caller.py",
+        """
+from pkg.target import target
+
+def run():
+    return target()
+""",
+    )
+    index = build_call_graph_index(tmp_path, force_rebuild=True)
+    block = compact_symbol_impact(index, "pkg/target.py", token_budget=500)
+    assert block is not None
+    assert block["symbols"][0]["callers"] == ["run"]

--- a/packages/tapps-mcp/tests/unit/test_call_graph_resolve.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_resolve.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from tapps_mcp.project.call_graph import build_call_graph_index
 from tapps_mcp.project.call_graph_analyze import FileIndex
 from tapps_mcp.project.call_graph_resolve import qualify, resolve_attribute, resolve_name
 
@@ -28,6 +31,32 @@ def test_resolve_imported_name() -> None:
     idx = FileIndex(module="demo.main", rel_path="demo/main.py")
     idx.imports["helper"] = "other.helper"
     assert resolve_name(idx, "helper", [], {}) == "other.helper"
+
+
+def test_lazy_import_binding_resolves_in_function(tmp_path: Path) -> None:
+    pkg = tmp_path / "demo"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "worker.py").write_text(
+        """
+def build_index():
+    return 1
+""",
+        encoding="utf-8",
+    )
+    (pkg / "handler.py").write_text(
+        """
+def run_handler():
+    from demo.worker import build_index
+    return build_index()
+""",
+        encoding="utf-8",
+    )
+    index = build_call_graph_index(tmp_path, force_rebuild=True)
+    assert any(
+        edge.caller == "demo.handler.run_handler" and edge.callee == "demo.worker.build_index"
+        for edge in index.edges
+    )
 
 
 def _attr(base: str, name: str):

--- a/packages/tapps-mcp/tests/unit/test_diff_impact.py
+++ b/packages/tapps-mcp/tests/unit/test_diff_impact.py
@@ -64,3 +64,29 @@ def test_compute_{i}():
         result = analyze_diff_impact([changed], tmp_path, max_tests=2)
         assert len(result["affected_tests"]) == 2
         assert result["total_affected_tests"] >= 2
+
+    def test_doc_drift_hint_for_high_caller_symbol(self, tmp_path: Path) -> None:
+        callers = "\n".join(
+            f"""
+def caller_{i}():
+    from app.core import compute
+    return compute()
+"""
+            for i in range(6)
+        )
+        _write(
+            tmp_path,
+            "app/core.py",
+            """
+def compute():
+    return 42
+""",
+        )
+        _write(tmp_path, "app/callers.py", callers)
+        changed = tmp_path / "app/core.py"
+        result = analyze_diff_impact([changed], tmp_path, doc_drift_caller_threshold=5)
+        hints = result.get("doc_drift_hints")
+        assert isinstance(hints, list)
+        assert len(hints) >= 1
+        assert hints[0]["direct_callers"] >= 5
+        assert hints[0]["suggested_doc_paths"]

--- a/packages/tapps-mcp/tests/unit/test_fleet_smoke.py
+++ b/packages/tapps-mcp/tests/unit/test_fleet_smoke.py
@@ -1,0 +1,118 @@
+"""Tests for HTTP fleet MCP smoke probes (ADR-0024)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tapps_mcp.distribution import fleet_smoke
+
+
+def _sse(payload: dict[str, Any]) -> str:
+    return f"event: message\ndata: {json.dumps(payload)}\n\n"
+
+
+class TestParseSseJson:
+    def test_extracts_first_data_line(self) -> None:
+        body = _sse({"jsonrpc": "2.0", "id": 1, "result": {"tools": []}})
+        parsed = fleet_smoke.parse_sse_json(body)
+        assert parsed is not None
+        assert parsed["id"] == 1
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert fleet_smoke.parse_sse_json("not sse") is None
+
+
+class TestProbeFleetMcpSession:
+    def test_happy_path(self) -> None:
+        init_body = _sse(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "serverInfo": {"name": "TappsMCP", "version": "3.12.46"},
+                },
+            }
+        )
+        tools_body = _sse(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {"tools": [{"name": "tapps_session_start"}]},
+            }
+        )
+        responses = [
+            (200, "sess-1", init_body),
+            (202, "sess-1", ""),
+            (200, "sess-1", tools_body),
+        ]
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> tuple[int, str | None, str]:
+            return responses.pop(0)
+
+        with patch.object(fleet_smoke, "_post_mcp", side_effect=fake_post):
+            result = fleet_smoke.probe_fleet_mcp_session("nlt-build")
+
+        assert result["ok"] is True
+        assert result["tool_count"] == 1
+        assert result["server_name"] == "TappsMCP"
+
+    def test_initialize_failure(self) -> None:
+        with patch.object(
+            fleet_smoke,
+            "_post_mcp",
+            return_value=(406, None, "Not Acceptable"),
+        ):
+            result = fleet_smoke.probe_fleet_mcp_session("nlt-build")
+
+        assert result["ok"] is False
+        assert result["stage"] == "initialize"
+
+
+class TestSmokeTestFleet:
+    def test_aggregates_failures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_probe(server_id: str, **_kw: Any) -> dict[str, Any]:
+            if server_id == "nlt-build":
+                return {"ok": True, "server_id": server_id, "tool_count": 3}
+            return {"ok": False, "server_id": server_id, "stage": "initialize", "error": "down"}
+
+        monkeypatch.setattr(fleet_smoke, "probe_fleet_mcp_session", fake_probe)
+        result = fleet_smoke.smoke_test_fleet()
+        assert result["ok"] is False
+        assert result["passed"] == 1
+        assert result["total"] == 6
+        assert any("nlt-memory" in item for item in result["failures"])
+
+    def test_all_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            fleet_smoke,
+            "probe_fleet_mcp_session",
+            lambda server_id, **_kw: {"ok": True, "server_id": server_id, "tool_count": 1},
+        )
+        result = fleet_smoke.smoke_test_fleet()
+        assert result["ok"] is True
+        assert result["passed"] == 6
+
+
+class TestRestartFleetWithSmoke:
+    def test_restart_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tapps_mcp.distribution import fleet_control
+
+        calls: list[str] = []
+        monkeypatch.setattr(fleet_control, "stop_fleet", lambda: calls.append("stop") or {})
+        monkeypatch.setattr(
+            fleet_control,
+            "start_fleet",
+            lambda *, force: calls.append(f"start:{force}") or {"started": ["nlt-build"], "errors": []},
+        )
+        monkeypatch.setattr(
+            fleet_smoke,
+            "smoke_test_fleet",
+            lambda **_: {"ok": True, "passed": 6, "total": 6, "servers": {}, "failures": []},
+        )
+        report = fleet_control.restart_fleet_with_smoke()
+        assert calls == ["stop", "start:True"]
+        assert report["ok"] is True

--- a/packages/tapps-mcp/tests/unit/test_session_start_call_graph.py
+++ b/packages/tapps-mcp/tests/unit/test_session_start_call_graph.py
@@ -1,0 +1,48 @@
+"""Tests for session-start call graph background rebuild (TAP-4266)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tapps_mcp.project.call_graph_cache import save_call_graph_index
+from tapps_mcp.project.call_graph_types import CallGraphIndex, INDEX_VERSION
+from tapps_mcp.tools.session_start_helpers import _schedule_call_graph_rebuild
+
+
+def test_schedule_call_graph_rebuild_skips_fresh_cache(tmp_path: Path) -> None:
+    result = _schedule_call_graph_rebuild(
+        tmp_path,
+        {"status": "ready", "stale": False},
+    )
+    assert result["scheduled"] is False
+    assert result["skipped"] == "cache_fresh"
+
+
+@pytest.mark.asyncio
+async def test_schedule_call_graph_rebuild_runs_for_stale_cache(tmp_path: Path) -> None:
+    from tapps_mcp import server_pipeline_tools as host
+
+    host._reset_background_tasks()
+    save_call_graph_index(
+        tmp_path,
+        CallGraphIndex(
+            project_root=str(tmp_path),
+            fingerprint="stale",
+            version=INDEX_VERSION,
+        ),
+    )
+    with patch(
+        "tapps_mcp.project.call_graph.build_call_graph_index",
+        autospec=True,
+    ) as mock_build:
+        scheduled = _schedule_call_graph_rebuild(
+            tmp_path,
+            {"status": "stale", "stale": True},
+        )
+        assert scheduled["scheduled"] is True
+        await asyncio.gather(*host._background_tasks)
+        mock_build.assert_called_once_with(tmp_path)


### PR DESCRIPTION
## Summary

- **TAP-4266:** Background call-graph rebuild on `tapps_session_start` when cache is stale/missing (`rebuild_scheduled` flag).
- **TAP-4267:** Already default-on — `tapps_validate_changed` includes ranked `affected_tests` via `include_impact=true`.
- **TAP-4268:** Resolve function-local lazy imports so MCP handler patterns create CALLS edges.
- **TAP-4269:** Split gap health into `in_repo_gap_rate` vs external (stdlib/builtin/dynamic); `degraded` keyed off in-repo gaps.
- **TAP-4270:** Attach compact `symbol_impact` to `tapps_quick_check` for Python files when index exists.
- **TAP-4271:** docs-mcp call-graph adapter + **Used By / Depends On** sections in `APIDocGenerator` markdown output.
- **TAP-4272:** `doc_drift_hints` in `tapps_diff_impact` for high-caller symbol changes (≥5 direct callers).
- **Fleet smoke (ADR-0024):** `tapps-mcp fleet smoke` runs Cursor-like MCP handshakes (`initialize` → `tools/list`) on all six HTTP fleet servers; `fleet restart` and `deploy-local` run it automatically and fail closed when any server is unreachable.

Closes TAP-4266, TAP-4267, TAP-4268, TAP-4269, TAP-4270, TAP-4271, TAP-4272.

## Test plan

- [x] `pytest packages/tapps-mcp/tests/unit/test_call_graph*.py packages/tapps-mcp/tests/unit/test_diff_impact.py packages/tapps-mcp/tests/unit/test_session_start_call_graph.py`
- [x] `pytest packages/docs-mcp/tests/unit/test_call_graph_adapter.py packages/docs-mcp/tests/unit/test_api_docs.py::TestAPIDocCallGraphSections`
- [x] `pytest packages/tapps-mcp/tests/unit/test_fleet_smoke.py`
- [x] Pre-commit validate-changed on staged Python files (all gates passed)
- [x] `tapps-mcp fleet smoke --project-root .` (6/6 servers pass)
- [x] `tapps-mcp deploy-local` → release `3.12.46-7a13a5b` (reload Cursor MCP after fleet restart)