### PR TITLE
fix(pipeline): enforce tapps_lookup_docs before external API edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.12.47] - 2026-06-22
+
+Patch: enforce lookup-first discipline in init/upgrade scaffolding and doctor.
+
+### Added
+
+- **`check_lookup_docs_discipline` (doctor)** — fails when python-quality / pipeline rules or
+  `tapps-finish-task` skill lack lookup-first markers; reports 7d
+  `lookup_docs_to_edit_ratio`.
+- **Shared lookup-first contract strings** — `agent_contract.py` now owns Cursor pipeline
+  section, ordered python-quality actions, and `LOOKUP_FIRST_RULE_MARKERS` for doctor.
+
+### Changed
+
+- **Init/upgrade templates** — `.cursor/rules/tapps-pipeline.mdc` and
+  `tapps-python-quality.mdc`, `.claude/rules/python-quality.md`, post-edit hooks, session
+  nudges, and init next-steps all require `tapps_lookup_docs` **before the first edit** on
+  external library APIs; `lookup_docs_underused` blocks Done.
+- **`tapps-finish-task` skill** — step 3 explicitly clears `lookup_docs_underused` gaps.
+- **`check_pipeline_enforce_recommendations`** — warns when 7d lookup-to-edit ratio is below
+  20% at medium/high engagement.
+
 ## [3.12.46] - 2026-06-22
 
 Patch: call-graph agent UX, Cursor hook migration fix, and refreshed Cursor marketplace plugin.

--- a/packages/tapps-mcp/pyproject.toml
+++ b/packages/tapps-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-mcp"
-version = "3.12.46"
+version = "3.12.47"
 description = "MCP server providing deterministic code quality tools for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/packages/tapps-mcp/src/tapps_mcp/common/nudges.py
+++ b/packages/tapps-mcp/src/tapps_mcp/common/nudges.py
@@ -99,7 +99,8 @@ _TOOL_NUDGES: dict[str, list[NudgeRule]] = {
         ),
         (
             lambda called, _ctx: "tapps_lookup_docs" not in called,
-            "NEXT: Call tapps_lookup_docs() for any external libraries you will use.",
+            "NEXT: Call tapps_lookup_docs(library=..., topic=...) **before the first edit** "
+            "that uses an external library API — not after.",
             _IMPACT_LOW,
         ),
     ],

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -1512,7 +1512,9 @@ def _memory_skill_content_ok(skill_name: str, content: str) -> bool:
     if skill_name == "tapps-finish-task":
         if "tapps_validate_changed" not in lowered or "tapps_checklist" not in lowered:
             return False
-        return "tapps-mcp memory save" in lowered
+        return (
+            "tapps-mcp memory save" in lowered and "lookup_docs_underused" in lowered
+        )
     return False
 
 
@@ -1722,6 +1724,7 @@ def check_session_handoff_schema(project_root: Path) -> CheckResult:
 
 _CACHE_GATE_BLOCK_HINT_THRESHOLD = 20
 _PIPELINE_ENFORCE_SKIP_THRESHOLD = 0.30
+_PIPELINE_ENFORCE_LOOKUP_THRESHOLD = 0.20
 _PIPELINE_ENFORCE_MIN_LOOPS = 7
 
 
@@ -1736,9 +1739,14 @@ def check_pipeline_enforce_recommendations(project_root: Path) -> CheckResult:
 
     stats = compute_rolling_stats(project_root, window_days=_PROMOTE_WINDOW_DAYS)
     skip_rate = float(stats.get("gate_skip_rate", 0.0))
+    lookup_ratio = float(stats.get("lookup_docs_to_edit_ratio", 0.0))
     loops = int(stats.get("loops", 0))
     skip_pct = int(round(skip_rate * 100))
-    message = f"7d gate_skip_rate={skip_pct}% ({loops} loops in loop-metrics)"
+    lookup_pct = int(round(lookup_ratio * 100))
+    message = (
+        f"7d gate_skip_rate={skip_pct}% lookup_docs_to_edit_ratio={lookup_pct}% "
+        f"({loops} loops in loop-metrics)"
+    )
 
     engagement = _read_engagement_level(project_root) or "medium"
     settings = None
@@ -1764,6 +1772,16 @@ def check_pipeline_enforce_recommendations(project_root: Path) -> CheckResult:
                 f"Chronic gate skips ({skip_pct}% ≥ {_PIPELINE_ENFORCE_SKIP_THRESHOLD:.0%}) "
                 f"at {engagement} engagement — enforce validate-changed on commit"
             )
+
+    if (
+        loops >= _PIPELINE_ENFORCE_MIN_LOOPS
+        and lookup_ratio < _PIPELINE_ENFORCE_LOOKUP_THRESHOLD
+        and engagement in ("medium", "high")
+    ):
+        hints.append(
+            f"Low tapps_lookup_docs usage ({lookup_pct}% of edit loops) — call "
+            "tapps_lookup_docs before the first edit on external library APIs"
+        )
 
     cache_mode = _detect_cache_gate_mode(project_root)
     if settings is not None:
@@ -1805,6 +1823,69 @@ def check_pipeline_enforce_recommendations(project_root: Path) -> CheckResult:
         True,
         message + suffix,
         detail,
+    )
+
+
+def check_lookup_docs_discipline(project_root: Path) -> CheckResult:
+    """Verify lookup-first rules/skills are deployed and report chronic underuse."""
+    from tapps_mcp.pipeline.agent_contract import LOOKUP_FIRST_RULE_MARKERS
+    from tapps_mcp.tools.loop_metrics import (
+        _PROMOTE_WINDOW_DAYS,
+        compute_rolling_stats,
+    )
+
+    stale: list[str] = []
+    rule_paths = (
+        project_root / ".claude" / "rules" / "python-quality.md",
+        project_root / ".cursor" / "rules" / "tapps-python-quality.mdc",
+        project_root / ".cursor" / "rules" / "tapps-pipeline.mdc",
+    )
+    for path in rule_paths:
+        if not path.is_file():
+            continue
+        content = path.read_text(encoding="utf-8")
+        if not all(marker in content for marker in LOOKUP_FIRST_RULE_MARKERS):
+            try:
+                stale.append(str(path.relative_to(project_root.resolve())))
+            except ValueError:
+                stale.append(str(path))
+
+    for host_label, base in _tapps_skill_bases(project_root):
+        skill_path = base / "tapps-finish-task" / "SKILL.md"
+        if skill_path.is_file():
+            content = skill_path.read_text(encoding="utf-8")
+            if not _memory_skill_content_ok("tapps-finish-task", content):
+                stale.append(f"{host_label}/tapps-finish-task")
+
+    stats = compute_rolling_stats(project_root, window_days=_PROMOTE_WINDOW_DAYS)
+    lookup_ratio = float(stats.get("lookup_docs_to_edit_ratio", 0.0))
+    lookup_pct = int(round(lookup_ratio * 100))
+    loops = int(stats.get("loops", 0))
+
+    parts = [f"7d lookup_docs_to_edit_ratio={lookup_pct}% ({loops} loops)"]
+    detail_parts: list[str] = []
+    if stale:
+        detail_parts.append(
+            "Stale lookup-first scaffolding: "
+            + ", ".join(sorted(stale))
+            + ". Run: tapps-mcp upgrade --force"
+        )
+    if (
+        loops >= _PIPELINE_ENFORCE_MIN_LOOPS
+        and lookup_ratio < _PIPELINE_ENFORCE_LOOKUP_THRESHOLD
+    ):
+        detail_parts.append(
+            "Chronic lookup_docs_underused pattern — call tapps_lookup_docs before "
+            "the first edit on external library APIs; finish-task must clear "
+            "usage_gaps before Done."
+        )
+
+    ok = not stale
+    return CheckResult(
+        "Lookup-docs discipline",
+        ok,
+        "; ".join(parts),
+        "\n".join(detail_parts) if detail_parts else None,
     )
 
 
@@ -4720,6 +4801,7 @@ def _collect_checks(root: Path, *, quick: bool = False) -> list[CheckResult]:
     checks.append(check_cache_gate_block_hint(root))
     checks.append(check_install_git_hooks_hint(root))
     checks.append(check_pipeline_enforce_recommendations(root))
+    checks.append(check_lookup_docs_discipline(root))
     checks.append(check_cursor_loop_metrics_telemetry(root))
     checks.append(check_cursor_stop_completion_gate(root))
     checks.append(check_continuous_learning_v2_skill(root))

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/plugin_builder.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/plugin_builder.py
@@ -159,8 +159,9 @@ class PluginBuilder:
             "- Security floor: minimum 50/100 on security category\n\n"
             "## Workflow\n"
             "1. Call `tapps_session_start` at the beginning of each session\n"
-            "2. Use `tapps_quick_check` after editing Python files\n"
-            "3. Run `tapps_validate_changed` before declaring work complete\n"
+            "2. Call `tapps_lookup_docs` **before the first edit** that uses an external library API\n"
+            "3. Use `tapps_quick_check` after editing Python files\n"
+            "4. Run `tapps_validate_changed` before declaring work complete\n"
         )
         (rules_dir / "python-quality.md").write_text(rule_content, encoding="utf-8")
         self._result["components"]["rules"] = "created"

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
@@ -1724,6 +1724,10 @@ def _print_next_steps(host: str, *, project_root: Path | None = None) -> None:
     """
     click.echo("")
     click.echo("Next steps:")
+    click.echo(
+        "  • Pipeline: tapps_lookup_docs **before** external API edits → "
+        "tapps_quick_check after edits → /tapps-finish-task before done"
+    )
     if host == "claude-code":
         click.echo("  1. Restart Claude Code (or run: claude mcp list)")
         click.echo("  2. Ask Claude to use TappsMCP tools")

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/agent_contract.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/agent_contract.py
@@ -13,7 +13,8 @@ POST_EDIT_QUICK_CHECK_MSG = (
 )
 POST_EDIT_IMPORT_LOOKUP_MSG = (
     "Imports detected ({libs}) — call tapps_lookup_docs(library=..., topic=...) "
-    "before using those APIs in this session."
+    "**before editing** code that uses those APIs. Retrospective lookups at "
+    "finish-task do not excuse skipped pre-edit lookups."
 )
 POST_EDIT_PUBLIC_API_DRIFT_MSG = (
     "Public API change detected in {file} — call docs_check_drift and "
@@ -71,7 +72,8 @@ TOOL_REFERENCE_CALL_GRAPH_ROWS = (
 # Bash hook templates use $LIBS / $FILE instead of Python format fields.
 POST_EDIT_IMPORT_LOOKUP_BASH = (
     "Imports detected ($LIBS) — call tapps_lookup_docs(library=..., topic=...) "
-    "before using those APIs in this session (TAP-1330)."
+    "**before editing** code that uses those APIs (TAP-1330). Retrospective "
+    "lookups at finish-task do not excuse skipped pre-edit lookups."
 )
 POST_EDIT_QUICK_CHECK_BASH = (
     "Edited: $FILE — run tapps_quick_check after this edit."
@@ -100,14 +102,58 @@ LOOKUP_GAP_RETRO_NOTE = (
     "retrospective MCP lookups clear telemetry gaps; cache hits are fine"
 )
 LOOKUP_TIMING_RULE = (
-    "Call tapps_lookup_docs before first use of each external library in a session; "
-    "retrospective lookups only clear telemetry gaps (ADR-0021), not missing knowledge."
+    "Call tapps_lookup_docs **before the first edit** that uses each external "
+    "library in a session; retrospective lookups only clear telemetry gaps "
+    "(ADR-0021), not missing knowledge."
 )
+
+LOOKUP_DOCS_UNDERUSED_GAP = "lookup_docs_underused"
+
+# Doctor / upgrade freshness markers for lookup-first python-quality rules.
+LOOKUP_FIRST_RULE_MARKERS = (
+    "before the first edit",
+    LOOKUP_DOCS_UNDERUSED_GAP,
+)
+
+CURSOR_PIPELINE_BEFORE_EDIT_LOOKUP = """\
+## Before Editing External Library APIs (REQUIRED)
+
+Call `tapps_lookup_docs(library, topic)` **before the first edit** that uses an
+external library API (`reportlab`, `pytest`, `yaml`, …). Cache hits are free.
+Skipping this triggers `lookup_docs_underused` in `tapps_checklist` `usage_gaps`.
+
+"""
+
+CURSOR_PYTHON_QUALITY_ACTIONS = """\
+## Actions (order matters)
+
+1. **`tapps_lookup_docs(library, topic)` before the first edit** that uses an external
+   library API. Skipping triggers `lookup_docs_underused` in checklist `usage_gaps`.
+2. **`tapps_quick_check(file_path)` after each Python edit**
+3. **`tapps_security_scan(file_path)`** on security-sensitive changes
+4. **`tapps_score_file(file_path)`** when any category scores below 70
+
+Do not guess API signatures from training data. Retrospective lookups at finish-task
+clear telemetry but do not excuse skipped pre-edit lookups.
+"""
+
+PYTHON_QUALITY_SCORING_SECTION = """\
+## Quality Scoring (7 Categories, 0-100 each)
+
+1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
+2. **Security** - Bandit + pattern heuristics
+3. **Maintainability** - Maintainability index (radon mi / AST fallback)
+4. **Test Coverage** - Heuristic from matching test file existence
+5. **Performance** - Halstead metrics, perflint anti-patterns, nested loops, large functions, deep nesting
+6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
+7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
+"""
 
 # SubagentStart hook (Claude) — no stale direct tapps-mcp tapps_memory routing
 SUBAGENT_START_INTRO = "[TappsMCP] This project uses TappsMCP for code quality."
 SUBAGENT_START_TOOLS_LINE = (
-    "Tools: tapps_quick_check, tapps_score_file, tapps_validate_changed. "
+    "Tools: tapps_lookup_docs (before external API edits), tapps_quick_check, "
+    "tapps_score_file, tapps_validate_changed. "
     "Memory: uv run tapps-mcp memory …; tapps_memory on nlt-memory when enabled (TAP-3895)."
 )
 
@@ -163,11 +209,12 @@ this repo or the linked tracker project is not. Specifically:
   user before proceeding."""
 
 _FINISH_TASK_DOC_GAPS_STEP3_BODY = """\
-3. **Clear doc-lookup gaps.** When `usage_gaps.gaps` includes `library_uses_without_lookup_docs` or `libraries_without_lookup` is non-empty:
+3. **Clear doc-lookup gaps.** When `usage_gaps.gaps` includes `lookup_docs_underused`,
+   `library_uses_without_lookup_docs`, or `libraries_without_lookup` is non-empty:
    - Call `{lookup_tool}` for **each** listed library (retrospective MCP lookups clear telemetry gaps; cache hits are fine — ADR-0021).
    - CLI `tapps-mcp lookup-docs` also records `.lookup-docs-events.jsonl` for the next session.
    - Re-run `{checklist_tool}` until `usage_gaps.gaps` is empty **and** `complete: true`.
-   Prefer lookup **before first use** of each external library in future sessions."""
+   Prefer lookup **before the first edit** that uses each external library in future sessions."""
 
 AGENTS_TEMPLATE_TOOL_COUNT_PLACEHOLDER = "{{TAPPS_MCP_TOOL_COUNT}}"
 AGENTS_TEMPLATE_MEMORY_SYSTEMS_PLACEHOLDER = "{{MEMORY_SYSTEMS_BULLET}}"
@@ -256,7 +303,12 @@ __all__ = [
     "COPILOT_PROJECT_SCOPE_SECTION",
     "DOC_GAP_TELEMETRY_NOTE",
     "LOOKUP_GAP_RETRO_NOTE",
+    "LOOKUP_DOCS_UNDERUSED_GAP",
+    "LOOKUP_FIRST_RULE_MARKERS",
     "LOOKUP_TIMING_RULE",
+    "CURSOR_PIPELINE_BEFORE_EDIT_LOOKUP",
+    "CURSOR_PYTHON_QUALITY_ACTIONS",
+    "PYTHON_QUALITY_SCORING_SECTION",
     "MEMORY_ACTIONS_ACCESS_NOTE",
     "MEMORY_RECALL_SESSION_START",
     "MEMORY_SYSTEMS_BULLET",

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_bundles.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_bundles.py
@@ -17,6 +17,7 @@ from tapps_core.brain_bridge import BRAIN_PROFILE_SERVER
 from tapps_mcp import __version__
 from tapps_mcp.pipeline.agent_contract import (
     MEMORY_RECALL_SESSION_START,
+    PYTHON_QUALITY_SCORING_SECTION,
     VALIDATION_QUICK_VS_BATCH,
 )
 from tapps_mcp.pipeline.platform_docs_automation import (
@@ -655,24 +656,16 @@ paths:
 ---
 # Python Quality Rules (TappsMCP)
 
+REQUIRED: Call `tapps_lookup_docs(library, topic)` **before the first edit** that uses an
+external library API. Skipping triggers `lookup_docs_underused` in checklist `usage_gaps`.
+
 REQUIRED: Run `tapps_quick_check(file_path)` after editing Python files.
 
 REQUIRED: Call `tapps_validate_changed(file_paths="file1.py,file2.py")` with explicit paths before declaring work complete. Never call without `file_paths`. Default is quick mode; only use `quick=false` as a last resort.
 
-REQUIRED: Use `tapps_lookup_docs(library, topic)` before using unfamiliar library APIs.
+Do NOT mark tasks complete if quality gate has not passed or `usage_gaps` lists `lookup_docs_underused`.
 
-Do NOT mark tasks complete if quality gate has not passed.
-
-## Quality Scoring (7 Categories, 0-100 each)
-
-1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
-2. **Security** - Bandit + pattern heuristics
-3. **Maintainability** - Maintainability index (radon mi / AST fallback)
-4. **Test Coverage** - Heuristic from matching test file existence
-5. **Performance** - Halstead metrics, perflint anti-patterns, nested loops, large functions, deep nesting
-6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
-7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
-
+""" + PYTHON_QUALITY_SCORING_SECTION + """
 Any category scoring below 70 MUST be addressed immediately.
 """
 
@@ -683,22 +676,16 @@ paths:
 ---
 # Python Quality Rules (TappsMCP)
 
-Run `tapps_quick_check(file_path)` after editing Python files.
+Run tools in this order when editing Python:
 
-Use `tapps_lookup_docs(library, topic)` before using unfamiliar library APIs.
+1. **`tapps_lookup_docs(library, topic)` before the first edit** that uses an external
+   library API. Skipping triggers `lookup_docs_underused` in checklist `usage_gaps`.
+2. **`tapps_quick_check(file_path)` after each edit**
+3. **`tapps_validate_changed(file_paths="file1.py,file2.py")`** with explicit paths before declaring work complete. Never call without `file_paths`. Default is quick mode; only use `quick=false` as a last resort.
 
-Call `tapps_validate_changed(file_paths="file1.py,file2.py")` with explicit paths before declaring work complete. Never call without `file_paths`. Default is quick mode; only use `quick=false` as a last resort.
+Do not guess API signatures from training data.
 
-## Quality Scoring (7 Categories, 0-100 each)
-
-1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
-2. **Security** - Bandit + pattern heuristics
-3. **Maintainability** - Maintainability index (radon mi / AST fallback)
-4. **Test Coverage** - Heuristic from matching test file existence
-5. **Performance** - Halstead metrics, perflint anti-patterns, nested loops, large functions, deep nesting
-6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
-7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
-
+""" + PYTHON_QUALITY_SCORING_SECTION + """
 Any category scoring below 70 should be addressed.
 """
 
@@ -709,22 +696,13 @@ paths:
 ---
 # Python Quality Rules (TappsMCP)
 
-Consider running `tapps_quick_check(file_path)` after editing Python files.
+Consider this order when editing Python:
 
-Consider using `tapps_lookup_docs(library, topic)` for unfamiliar APIs.
+1. **`tapps_lookup_docs(library, topic)` before the first edit** on external library APIs
+2. **`tapps_quick_check(file_path)` after edits**
+3. **`tapps_validate_changed(file_paths="file1.py,file2.py")`** before declaring work complete
 
-Consider calling `tapps_validate_changed(file_paths="file1.py,file2.py")` with explicit paths before declaring work complete. Default is quick mode; only use `quick=false` as a last resort.
-
-## Quality Scoring (7 Categories, 0-100 each)
-
-1. **Complexity** - Cyclomatic complexity (radon cc / AST fallback)
-2. **Security** - Bandit + pattern heuristics
-3. **Maintainability** - Maintainability index (radon mi / AST fallback)
-4. **Test Coverage** - Heuristic from matching test file existence
-5. **Performance** - Halstead metrics, perflint anti-patterns, nested loops, large functions, deep nesting
-6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
-7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
-
+""" + PYTHON_QUALITY_SCORING_SECTION + """
 Categories scoring below 70 may benefit from attention.
 """
 

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_rules.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_rules.py
@@ -14,8 +14,11 @@ if TYPE_CHECKING:
 
 from tapps_mcp.pipeline.agent_contract import (
     COPILOT_PROJECT_SCOPE_SECTION,
+    CURSOR_PIPELINE_BEFORE_EDIT_LOOKUP,
+    CURSOR_PYTHON_QUALITY_ACTIONS,
     MEMORY_RECALL_SESSION_START,
     MEMORY_SYSTEMS_BULLET,
+    PYTHON_QUALITY_SCORING_SECTION,
 )
 
 # ---------------------------------------------------------------------------
@@ -37,6 +40,7 @@ Call `tapps_session_start()` as the FIRST action in every session.
 {MEMORY_RECALL_SESSION_START}
 Read `.tapps-mcp/session-handoff.md` when continuing work.
 
+""" + CURSOR_PIPELINE_BEFORE_EDIT_LOOKUP + """\
 ## After Editing Python Files (REQUIRED)
 
 Call `tapps_quick_check(file_path)` after editing any Python file.
@@ -72,14 +76,7 @@ TappsMCP scores Python code across 7 categories (0-100 each):
 6. **Structure** - Project layout (pyproject.toml, tests/, README, .git)
 7. **DevEx** - Developer experience (docs, AGENTS.md, tooling config)
 
-## Actions
-
-- Call `tapps_quick_check(file_path)` on edited Python files
-- Use `tapps_lookup_docs(library, topic)` before using unfamiliar library APIs
-- Run `tapps_security_scan(file_path)` on security-sensitive changes
-- Any category scoring below 70 needs immediate attention
-- Call `tapps_score_file(file_path)` for full breakdown
-"""
+""" + CURSOR_PYTHON_QUALITY_ACTIONS
 
 _CURSOR_RULE_EXPERT = """\
 ---

--- a/packages/tapps-mcp/tests/unit/test_doctor.py
+++ b/packages/tapps-mcp/tests/unit/test_doctor.py
@@ -1650,12 +1650,44 @@ class TestCheckLinearIssueSkillCurrent:
         assert "cursor" in result.message
 
 
+class TestCheckLookupDocsDiscipline:
+    """check_lookup_docs_discipline flags stale lookup-first scaffolding."""
+
+    _FRESH_RULE = (
+        "# rules\nCall tapps_lookup_docs before the first edit.\n"
+        "lookup_docs_underused blocks Done.\n"
+    )
+
+    def test_fresh_rules_pass(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_lookup_docs_discipline
+
+        rules = tmp_path / ".cursor" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "tapps-python-quality.mdc").write_text(self._FRESH_RULE, encoding="utf-8")
+        result = check_lookup_docs_discipline(tmp_path)
+        assert result.ok is True
+
+    def test_stale_python_quality_rule_fails(self, tmp_path):
+        from tapps_mcp.distribution.doctor import check_lookup_docs_discipline
+
+        rules = tmp_path / ".cursor" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "tapps-python-quality.mdc").write_text(
+            "# old\nUse tapps_lookup_docs for unfamiliar APIs.\n",
+            encoding="utf-8",
+        )
+        result = check_lookup_docs_discipline(tmp_path)
+        assert result.ok is False
+        assert "upgrade" in (result.detail or "").lower()
+
+
 class TestCheckFinishTaskSkill:
     """check_finish_task_skill covers the composite tapps-finish-task skill."""
 
     _BODY = (
         "---\nname: tapps-finish-task\n---\n"
-        "tapps_validate_changed\ntapps_checklist\ntapps-mcp memory save\n" * 5
+        "tapps_validate_changed\ntapps_checklist\nlookup_docs_underused\n"
+        "tapps-mcp memory save\n" * 5
     )
 
     def test_present_passes(self, tmp_path):

--- a/packages/tapps-mcp/tests/unit/test_hint_string_consistency.py
+++ b/packages/tapps-mcp/tests/unit/test_hint_string_consistency.py
@@ -100,7 +100,17 @@ class TestGeneratedSurfacesEchoContract:
 
     def test_claude_post_edit_lookup_phrasing(self) -> None:
         assert POST_EDIT_IMPORT_LOOKUP_BASH in CLAUDE_HOOK_SCRIPTS["tapps-post-edit.sh"]
-        assert "before using those APIs" in POST_EDIT_IMPORT_LOOKUP_BASH
+        assert "before editing" in POST_EDIT_IMPORT_LOOKUP_BASH
+
+    def test_cursor_pipeline_lookup_before_edit(self) -> None:
+        body = CURSOR_RULE_TEMPLATES["tapps-pipeline.mdc"]
+        assert "before the first edit" in body
+        assert "lookup_docs_underused" in body
+
+    def test_cursor_python_quality_lookup_before_edit(self) -> None:
+        body = CURSOR_RULE_TEMPLATES["tapps-python-quality.mdc"]
+        assert "before the first edit" in body
+        assert "lookup_docs_underused" in body
 
     def test_subagent_start_no_legacy_tapps_memory_mcp(self) -> None:
         script = CLAUDE_HOOK_SCRIPTS["tapps-subagent-start.sh"]

--- a/packages/tapps-mcp/tests/unit/test_platform_skills.py
+++ b/packages/tapps-mcp/tests/unit/test_platform_skills.py
@@ -424,6 +424,7 @@ class TestFinishTaskSkill:
     def test_finish_task_clears_doc_lookup_gaps(self) -> None:
         for content in (CLAUDE_SKILLS["tapps-finish-task"], CURSOR_SKILLS["tapps-finish-task"]):
             assert "library_uses_without_lookup_docs" in content
+            assert "lookup_docs_underused" in content
             assert "libraries_without_lookup" in content
             assert "usage_gaps" in content
             assert "Doc gaps:" in content

--- a/packages/tapps-mcp/tests/unit/test_python_quality_rule.py
+++ b/packages/tapps-mcp/tests/unit/test_python_quality_rule.py
@@ -94,6 +94,8 @@ class TestEngagementLevelVariants:
         # tapps_research removed in EPIC-94; replaced by tapps_lookup_docs
         content = generate_python_quality_rule("medium")
         assert "tapps_lookup_docs" in content
+        assert "before the first edit" in content
+        assert "lookup_docs_underused" in content
 
     def test_low_uses_consider_language(self) -> None:
         content = generate_python_quality_rule("low")


### PR DESCRIPTION
## Summary
- Ships **lookup-first** discipline through init/upgrade templates (Cursor pipeline + python-quality rules, Claude python-quality rule, post-edit hooks, session nudges, finish-task skill).
- Adds **`check_lookup_docs_discipline`** to doctor so stale consumer scaffolding fails until `tapps-mcp upgrade --force`.
- Extends pipeline enforcement recommendations when 7d `lookup_docs_to_edit_ratio` is below 20%.

Closes the recurring `lookup_docs_underused` telemetry gap at the source: agents are told to call `tapps_lookup_docs` **before the first edit** on external library APIs, not after.

## Test plan
- [x] `pytest` on doctor, hint consistency, python-quality rule, finish-task skill tests (55 passed)
- [x] Pre-commit gate on staged Python files
- [ ] After merge + release: `tapps-mcp upgrade --force --host auto` in ReportLab and verify `.cursor/rules/tapps-python-quality.mdc` contains `before the first edit` and `lookup_docs_underused`
- [ ] `tapps-mcp doctor --quick` reports lookup-docs discipline OK


Made with [Cursor](https://cursor.com)