### PR TITLE
docs(skills): surface unbound tools in tapps-tool-reference (review items #4-6)

### DIFF
--- a/.claude/skills/tapps-tool-reference/SKILL.md
+++ b/.claude/skills/tapps-tool-reference/SKILL.md
@@ -64,4 +64,14 @@ provide the full tool reference from this skill.
 | **tapps_doctor** | Diagnose configuration issues |
 | **tapps_set_engagement_level** | Change enforcement intensity (high/medium/low) |
 
+## Planning, metrics & audit
+| Tool | When to use it |
+|------|----------------|
+| **tapps_decompose** | Break a vague task into ordered, verifiable TAPPS tool-call steps before starting |
+| **tapps_pipeline** | Show TAPPS pipeline stage progress and the next recommended tool call |
+| **tapps_audit_campaign** | Plan, dispatch, or convert a file-scope audit campaign to a fix plan |
+| **tapps_usage** | Session gap report: tools called vs pipeline expectations (edits without validation, libraries used without lookup_docs) |
+| **tapps_dashboard** | Metrics dashboard: usage, gate pass rate, and trends |
+| **tapps_stats** | Per-tool usage statistics: call counts, success rates, latency percentiles |
+
 For function-level refactors use `/tapps-refactor`. Call `tapps_server_info` for the latest recommended workflow string.

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
@@ -459,6 +459,16 @@ provide the full tool reference from this skill.
 | **tapps_doctor** | Diagnose configuration issues |
 | **tapps_set_engagement_level** | Change enforcement intensity (high/medium/low) |
 
+## Planning, metrics & audit
+| Tool | When to use it |
+|------|----------------|
+| **tapps_decompose** | Break a vague task into ordered, verifiable TAPPS tool-call steps before starting |
+| **tapps_pipeline** | Show TAPPS pipeline stage progress and the next recommended tool call |
+| **tapps_audit_campaign** | Plan, dispatch, or convert a file-scope audit campaign to a fix plan |
+| **tapps_usage** | Session gap report: tools called vs pipeline expectations (edits without validation, libraries used without lookup_docs) |
+| **tapps_dashboard** | Metrics dashboard: usage, gate pass rate, and trends |
+| **tapps_stats** | Per-tool usage statistics: call counts, success rates, latency percentiles |
+
 For function-level refactors use `/tapps-refactor`. Call `tapps_server_info` for the latest recommended workflow string.
 """,
     "tapps-init": """\
@@ -1363,6 +1373,16 @@ tapps_validate_changed (before complete, always pass file_paths), tapps_checklis
 | **tapps_dead_code** | Find unused code during refactoring |
 | **tapps_dependency_scan** | Check for CVEs before releases |
 | **tapps_dependency_graph** | Understand module dependencies, circular imports |
+
+## Planning, metrics & audit
+| Tool | When to use it |
+|------|----------------|
+| **tapps_decompose** | Break a vague task into ordered, verifiable TAPPS tool-call steps before starting |
+| **tapps_pipeline** | Show TAPPS pipeline stage progress and the next recommended tool call |
+| **tapps_audit_campaign** | Plan, dispatch, or convert a file-scope audit campaign to a fix plan |
+| **tapps_usage** | Session gap report: tools called vs pipeline expectations (edits without validation, libraries used without lookup_docs) |
+| **tapps_dashboard** | Metrics dashboard: usage, gate pass rate, and trends |
+| **tapps_stats** | Per-tool usage statistics: call counts, success rates, latency percentiles |
 
 For function-level refactors use `/tapps-refactor`. Call `tapps_server_info` for the latest recommended workflow string.
 """,


### PR DESCRIPTION
Closes the remaining cache-gate review items #4–6. Two of the three were **non-issues on verification** — only #4 warranted a change.

## #4 — Unbound tools (fixed here)
`tapps_decompose`, `tapps_pipeline`, `tapps_audit_campaign`, `tapps_usage`, `tapps_dashboard`, `tapps_stats` were documented in AGENTS.md / their MCP descriptions but absent from the `tapps-tool-reference` skill — the per-tool "which tool do I call" discovery surface. Added a "Planning, metrics & audit" section with their canonical one-line descriptions (sourced verbatim from `tool_descriptions.py`). Edits both generator variants (claude + cursor) so it propagates on upgrade, plus this repo's deployed `SKILL.md`. Additive, doc-only.

## #5 — lookup_docs gating: ALREADY IMPLEMENTED (no change)
The review claimed lookup_docs is "documented but never gated." Verified false: `compute_gaps` (usage.py) detects external library imports in edited files and, when no `tapps_lookup_docs` ran, emits `library_uses_without_lookup_docs` / `lookup_docs_underused`. These are **inlined in `tapps_checklist`** (server.py:1616-1634 → `usage_gaps.libraries_without_lookup`), plus `tapps_session_start`, `tapps_doctor`, and standalone `tapps_usage`. Adding more gating would duplicate server-enforced state (anti-pattern per integration-hygiene). No change.

## #6 — radon dual path: INTENTIONAL (no change)
The two radon code paths are deliberate and documented (scorer.py docstring): `scorer.py` uses in-process direct radon (`_radon_cc_direct`) for the sync quick path (no subprocess latency); `parallel.py` uses subprocess radon for the async full-scan run in parallel with ruff/mypy/bandit. Both are live and serve different execution contexts — not dead code, not a bug. A unification would risk the scoring hot path for zero gain. No change.

## Verification
- `test_platform_skills` (150) + skills-generation suites green for my change; ruff/gate pass (platform_skills.py score 90 from pre-existing lint).
- Two pre-existing failures confirmed identical on clean master (untouched here): `test_result_dict_tracks_created` (stale 16-vs-17 skill-count assertion) and 2 pre-existing `platform_skills.py` ruff findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)