### PR TITLE
chore(release): 3.12.48

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- tapps-agents-version: 3.12.46 -->
+<!-- tapps-agents-version: 3.12.48 -->
 # TappsMCP - instructions for AI assistants
 
 When the **TappsMCP** MCP server is configured, you have access to tools for **code quality, doc lookup, and domain expert advice**. Use them to avoid hallucinated APIs, missed quality steps, and inconsistent output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.12.48] - 2026-06-24
+
+Patch: support-layer hygiene from the Linear cache-gate review — fail-closed
+destructive guard, retired-hook migration, and full removal of the no-op
+memory-capture subsystem.
+
+### Removed
+
+- **`tapps_init(memory_capture=)` opt-in subsystem** (TAP-1999). The
+  memory-capture Stop hook has been a no-op since session capture went
+  brain-native (`memory_index_session`). Removed the public `tapps_init`
+  param + pass-through chain, `generate_memory_capture_hook()`, the sh/ps1
+  templates, the `MEMORY_CAPTURE_HOOKS_CONFIG` dicts, and the canonical-manifest
+  entry. Canonical generation no longer ships the file (script counts 16 → 15).
+  No CLI flag exposed the param; the default was `False`.
+
+### Added
+
+- **Retired-hook migration in `tapps_upgrade`** — settings `hooks` entries are
+  merge-only, so existing projects kept running superseded hooks. Upgrade now
+  renames the fail-**open** `tapps-pre-tooluse.sh` wiring in place to the
+  fail-**closed** `tapps-pre-bash.sh` (guard upgraded, never dropped), unwires
+  and deletes the no-op `tapps-memory-capture.sh`.
+- **`check_retired_hooks` (doctor)** — flags a wired memory-capture hook or a
+  present `tapps-pre-tooluse.sh` as drift, with `tapps-mcp upgrade` remediation.
+- **Cross-language cache-key parity guard** — test that the bash Linear
+  cache-key derivation matches the authoritative Python `_resolve_cache_key`,
+  so drift becomes a CI failure instead of a silent cache miss.
+- **`tapps-tool-reference` skill** now lists previously-unbound tools
+  (`tapps_decompose`, `tapps_pipeline`, `tapps_audit_campaign`, `tapps_usage`,
+  `tapps_dashboard`, `tapps_stats`).
+
+### Fixed
+
+- **Destructive-command guard fail-open → fail-closed.** The deployed
+  `settings.json` wired the retired `tapps-pre-tooluse.sh`, which had no
+  `[ -z "$PYBIN" ]` guard — a missing interpreter let `rm -rf` through (exit 0).
+  Rewired to the fail-closed `tapps-pre-bash.sh` (TAP-1785).
+- **Linear routing precedence** — the `linear-standards` rule now states the
+  generic plugin `linear` skill does not satisfy the validate/cache gates; use
+  `linear-issue` / `linear-read`.
+
 ## [3.12.47] - 2026-06-22
 
 Patch: enforce lookup-first discipline in init/upgrade scaffolding and doctor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- tapps-claude-version: 3.12.46 -->
+<!-- tapps-claude-version: 3.12.48 -->
 # CLAUDE.md
 
 This file provides guidance to Claude Code when working with code in this repository.

--- a/npm-docs-mcp/package.json
+++ b/npm-docs-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-mcp",
-  "version": "3.12.46",
+  "version": "3.12.48",
   "description": "MCP server for automated documentation generation, validation, and maintenance - npm wrapper for the Python docs-mcp package",
   "bin": {
     "docs-mcp": "./bin/docs-mcp.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapps-mcp",
-  "version": "3.12.46",
+  "version": "3.12.48",
   "description": "MCP server providing code quality tools - npm wrapper for the Python tapps-mcp package",
   "bin": {
     "tapps-mcp": "./bin/tapps-mcp.js"

--- a/packages/docs-mcp/pyproject.toml
+++ b/packages/docs-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docs-mcp"
-version = "3.12.46"
+version = "3.12.48"
 description = "MCP server for automated documentation generation, validation, and maintenance"
 readme = "docs/README.md"
 license = "MIT"

--- a/packages/tapps-core/pyproject.toml
+++ b/packages/tapps-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-core"
-version = "3.12.46"
+version = "3.12.48"
 description = "Shared infrastructure library for Tapps platform (config, security, logging, knowledge, memory, metrics)"
 license = "MIT"
 requires-python = ">=3.12"

--- a/packages/tapps-mcp/pyproject.toml
+++ b/packages/tapps-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-mcp"
-version = "3.12.47"
+version = "3.12.48"
 description = "MCP server providing deterministic code quality tools for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "docs-mcp"
-version = "3.12.46"
+version = "3.12.48"
 source = { editable = "packages/docs-mcp" }
 dependencies = [
     { name = "click" },
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "tapps-core"
-version = "3.12.46"
+version = "3.12.48"
 source = { editable = "packages/tapps-core" }
 dependencies = [
     { name = "httpx" },
@@ -2792,7 +2792,7 @@ provides-extras = ["vector", "reranker"]
 
 [[package]]
 name = "tapps-mcp"
-version = "3.12.46"
+version = "3.12.48"
 source = { editable = "packages/tapps-mcp" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Ships the cache-gate-review support-layer hygiene (#161–164) as **3.12.48**.

Unified bump reconciles the prior split (tapps-mcp was 3.12.47, other packages 3.12.46) → **3.12.48** across all packages + AGENTS.md/CLAUDE.md stamps + uv.lock. CHANGELOG entry added.

## Included since 3.12.47
- **Removed** the no-op `memory-capture` subsystem, incl. the public `tapps_init(memory_capture=)` param (#164, TAP-1999).
- **Added** the retired-hook upgrade migration (fail-open→fail-closed guard rename, dead-hook strip/delete), `check_retired_hooks` doctor check, the cross-language cache-key parity guard, and tool-reference additions (#161–164).
- **Fixed** the destructive-guard fail-open and linear-skill precedence (#162).

`bump-versions.py --check` confirms all derived files in sync at 3.12.48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)