### PR TITLE
feat(playbooks): light domain playbooks and tapps_domain_playbook (ADR-0025)

### DIFF
--- a/.claude/agents/tapps-frontend-reviewer.md
+++ b/.claude/agents/tapps-frontend-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: tapps-frontend-reviewer
+description: >-
+  Review UI/UX and frontend changes using domain playbooks and TAPPS quality
+  gates. Use for React, CSS, accessibility, or layout work.
+tools: Read, Glob, Grep, Write, Edit
+model: claude-sonnet-4-6
+maxTurns: 20
+permissionMode: acceptEdits
+memory: project
+skills:
+  - tapps-domain-frontend
+  - tapps-finish-task
+mcpServers:
+  tapps-mcp: {}
+---
+
+You are a TappsMCP frontend reviewer. When invoked:
+
+1. Call `mcp__tapps-mcp__tapps_domain_playbook` with `domain="user-experience"` (or alias `frontend`)
+2. Call `mcp__tapps-mcp__tapps_lookup_docs` for the UI library in use (React, Next.js, etc.)
+3. Review changed files against the playbook checklist (a11y, layout, UX)
+4. Call `mcp__tapps-mcp__tapps_quick_check` on any changed Python/TS files
+5. Summarize findings and recommend `/tapps-finish-task` before declaring done
+
+Optional persona voice: agency-agents Frontend Developer — TappsMCP owns all gates.
+
+## Project scope (do not break out of this repo/project)
+
+You were deployed into THIS repo by `tapps_init` / `tapps_upgrade`. Stay in scope:
+
+- You MAY read across projects (docs lookups, browsing other repos, fetching references).
+- You MUST NOT write outside this repo or this project. Specifically:
+  - Do not create, update, comment on, or move Linear (or other tracker) issues
+    that belong to a different project than this repo.
+  - Do not modify files, branches, or pull requests in any other repository.
+  - Do not push, merge, or release on behalf of another project.
+- Pull team / project / repo identity from local config (`.tapps-mcp.yaml`,
+  the current git remote) — never infer it from search results or memory hits
+  that point at unrelated workspaces.
+- If a task seems to require a write outside this repo/project, stop and ask
+  the user instead of doing it.

--- a/.claude/skills/tapps-domain-frontend/SKILL.md
+++ b/.claude/skills/tapps-domain-frontend/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: tapps-domain-frontend
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  Frontend/UX TAPPS workflow: playbook, UI library docs, and quality gate on scored files. Use when building UI components, accessibility fixes, or client-side routing changes.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_domain_playbook mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist mcp__nlt-build__tapps_score_file
+argument-hint: "[file-path or scope]"
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+1. **Session bootstrap.** Call `tapps_session_start()` if not already called this session.
+2. **Load playbook.** Call `tapps_domain_playbook(domain="user-experience")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `tapps_lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `tapps_quick_check(file_path=...)`.
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type=frontend. Do not declare done without validate + checklist.
+

--- a/.claude/skills/tapps-domain-security/SKILL.md
+++ b/.claude/skills/tapps-domain-security/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: tapps-domain-security
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  Security-focused TAPPS workflow: playbook, library docs, security scan, and CVE check. Use when implementing auth, secrets, input validation, or pre-release security passes.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_domain_playbook mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist mcp__nlt-build__tapps_security_scan mcp__nlt-build__tapps_dependency_scan
+argument-hint: "[file-path or scope]"
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+1. **Session bootstrap.** Call `tapps_session_start()` if not already called this session.
+2. **Load playbook.** Call `tapps_domain_playbook(domain="security")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `tapps_lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `tapps_quick_check(file_path=...)`.
+4b. Run `tapps_security_scan` on sensitive changed files.
+4c. Run `tapps_dependency_scan` when lockfiles or dependencies changed.
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type=security. Do not declare done without validate + checklist.
+

--- a/.claude/skills/tapps-domain-testing/SKILL.md
+++ b/.claude/skills/tapps-domain-testing/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: tapps-domain-testing
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  Testing-focused TAPPS workflow: playbook, pytest docs, diff impact, and validation. Use when adding tests, fixing test gaps, or validating affected tests after refactors.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_domain_playbook mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist mcp__nlt-build__tapps_diff_impact mcp__nlt-build__tapps_call_graph
+argument-hint: "[file-path or scope]"
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+1. **Session bootstrap.** Call `tapps_session_start()` if not already called this session.
+2. **Load playbook.** Call `tapps_domain_playbook(domain="testing-strategies")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `tapps_lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `tapps_quick_check(file_path=...)`.
+4b. Call `tapps_diff_impact(file_paths=...)` to rank affected tests.
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type=qa. Do not declare done without validate + checklist.
+

--- a/.claude/skills/tapps-flow-develop/SKILL.md
+++ b/.claude/skills/tapps-flow-develop/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: tapps-flow-develop
+user-invocable: true
+model: claude-haiku-4-5-20251001
+description: >-
+  Standard feature/bugfix development flow via the shared TAPPS pipeline.
+  Use when starting daily implementation work and you want session start,
+  lookup docs, quick_check loop, and finish-task without a domain specialist.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist Bash
+argument-hint: "[task_type: feature|bugfix]"
+---
+
+1. `tapps_session_start()`
+2. `tapps_lookup_docs` before each external library API
+3. Edit loop: `tapps_quick_check` after Python edits
+4. `/tapps-finish-task` with `task_type=feature` or `bugfix`

--- a/.claude/skills/tapps-flow-frontend/SKILL.md
+++ b/.claude/skills/tapps-flow-frontend/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: tapps-flow-frontend
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  Frontend work flow combining UX playbook and standard finish pipeline.
+  Use when the task is primarily UI/UX implementation or accessibility.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_domain_playbook mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist
+---
+
+1. Invoke `/tapps-domain-frontend` steps 1–5, **or** run this shortcut:
+   - `tapps_domain_playbook(domain="user-experience")`
+   - `tapps_lookup_docs` for UI libraries in scope
+2. `/tapps-finish-task` with `task_type=frontend`
+3. Optional persona: agency-agents Frontend Developer (voice only; TappsMCP owns gates)

--- a/.claude/skills/tapps-flow-review/SKILL.md
+++ b/.claude/skills/tapps-flow-review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: tapps-flow-review
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  QA/review flow: parallel review pipeline or single-file review ending in checklist.
+  Use when reviewing PRs, audit findings, or validating another agent's changes.
+allowed-tools: mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist mcp__nlt-build__tapps_security_scan
+argument-hint: "[file paths]"
+---
+
+Prefer `/tapps-review-pipeline` for multiple Python files. Otherwise:
+
+1. `tapps_security_scan` + `tapps_quick_check` on targets
+2. `/tapps-finish-task` with `task_type=review` or `qa`

--- a/.cursor/agents/tapps-frontend-reviewer.md
+++ b/.cursor/agents/tapps-frontend-reviewer.md
@@ -1,0 +1,39 @@
+---
+name: tapps-frontend-reviewer
+description: >-
+  Review UI/UX and frontend changes using domain playbooks and TAPPS quality
+  gates. Use for React, CSS, accessibility, or layout work.
+model: sonnet
+readonly: false
+is_background: false
+tools:
+  - code_search
+  - read_file
+  - edit_file
+---
+
+You are a TappsMCP frontend reviewer. When invoked:
+
+1. Call `tapps_domain_playbook` with `domain="user-experience"` (or alias `frontend`)
+2. Call `tapps_lookup_docs` for the UI library in use (React, Next.js, etc.)
+3. Review changed files against the playbook checklist (a11y, layout, UX)
+4. Call `tapps_quick_check` on any changed Python/TS files
+5. Summarize findings and recommend `/tapps-finish-task` before declaring done
+
+Optional persona voice: agency-agents Frontend Developer — TappsMCP owns all gates.
+
+## Project scope (do not break out of this repo/project)
+
+You were deployed into THIS repo by `tapps_init` / `tapps_upgrade`. Stay in scope:
+
+- You MAY read across projects (docs lookups, browsing other repos, fetching references).
+- You MUST NOT write outside this repo or this project. Specifically:
+  - Do not create, update, comment on, or move Linear (or other tracker) issues
+    that belong to a different project than this repo.
+  - Do not modify files, branches, or pull requests in any other repository.
+  - Do not push, merge, or release on behalf of another project.
+- Pull team / project / repo identity from local config (`.tapps-mcp.yaml`,
+  the current git remote) — never infer it from search results or memory hits
+  that point at unrelated workspaces.
+- If a task seems to require a write outside this repo/project, stop and ask
+  the user instead of doing it.

--- a/.cursor/skills/tapps-domain-frontend/SKILL.md
+++ b/.cursor/skills/tapps-domain-frontend/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: tapps-domain-frontend
+description: >-
+  Frontend/UX TAPPS workflow: playbook, UI library docs, and quality gate on scored files. Use when building UI components, accessibility fixes, or client-side routing changes.
+mcp_tools:
+  - tapps_session_start
+  - tapps_domain_playbook
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+  - tapps_score_file
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+1. **Session bootstrap.** Call `session_start()` if not already called this session.
+2. **Load playbook.** Call `domain_playbook(domain="user-experience")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `quick_check(file_path=...)`.
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type=frontend. Do not declare done without validate + checklist.
+

--- a/.cursor/skills/tapps-domain-security/SKILL.md
+++ b/.cursor/skills/tapps-domain-security/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: tapps-domain-security
+description: >-
+  Security-focused TAPPS workflow: playbook, library docs, security scan, and CVE check. Use when implementing auth, secrets, input validation, or pre-release security passes.
+mcp_tools:
+  - tapps_session_start
+  - tapps_domain_playbook
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+  - tapps_security_scan
+  - tapps_dependency_scan
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+1. **Session bootstrap.** Call `session_start()` if not already called this session.
+2. **Load playbook.** Call `domain_playbook(domain="security")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `quick_check(file_path=...)`.
+4b. Run `security_scan` on sensitive changed files.
+4c. Run `dependency_scan` when lockfiles or dependencies changed.
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type=security. Do not declare done without validate + checklist.
+

--- a/.cursor/skills/tapps-domain-testing/SKILL.md
+++ b/.cursor/skills/tapps-domain-testing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: tapps-domain-testing
+description: >-
+  Testing-focused TAPPS workflow: playbook, pytest docs, diff impact, and validation. Use when adding tests, fixing test gaps, or validating affected tests after refactors.
+mcp_tools:
+  - tapps_session_start
+  - tapps_domain_playbook
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+  - tapps_diff_impact
+  - tapps_call_graph
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+1. **Session bootstrap.** Call `session_start()` if not already called this session.
+2. **Load playbook.** Call `domain_playbook(domain="testing-strategies")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `quick_check(file_path=...)`.
+4b. Call `diff_impact(file_paths=...)` to rank affected tests.
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type=qa. Do not declare done without validate + checklist.
+

--- a/.cursor/skills/tapps-flow-develop/SKILL.md
+++ b/.cursor/skills/tapps-flow-develop/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: tapps-flow-develop
+description: >-
+  Standard feature/bugfix development flow via the shared TAPPS pipeline.
+  Use when starting daily implementation work and you want session start,
+  lookup docs, quick_check loop, and finish-task without a domain specialist.
+mcp_tools:
+  - tapps_session_start
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+---
+
+1. `tapps_session_start()`
+2. `tapps_lookup_docs` before each external library API
+3. Edit loop: `tapps_quick_check` after Python edits
+4. `/tapps-finish-task` with `task_type=feature` or `bugfix`

--- a/.cursor/skills/tapps-flow-frontend/SKILL.md
+++ b/.cursor/skills/tapps-flow-frontend/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: tapps-flow-frontend
+description: >-
+  Frontend work flow combining UX playbook and standard finish pipeline.
+  Use when the task is primarily UI/UX implementation or accessibility.
+mcp_tools:
+  - tapps_session_start
+  - tapps_domain_playbook
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+---
+
+1. Invoke `/tapps-domain-frontend` steps 1–5, **or** run this shortcut:
+   - `tapps_domain_playbook(domain="user-experience")`
+   - `tapps_lookup_docs` for UI libraries in scope
+2. `/tapps-finish-task` with `task_type=frontend`
+3. Optional persona: agency-agents Frontend Developer (voice only; TappsMCP owns gates)

--- a/.cursor/skills/tapps-flow-review/SKILL.md
+++ b/.cursor/skills/tapps-flow-review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: tapps-flow-review
+description: >-
+  QA/review flow: parallel review pipeline or single-file review ending in checklist.
+  Use when reviewing PRs, audit findings, or validating another agent's changes.
+mcp_tools:
+  - tapps_validate_changed
+  - tapps_checklist
+  - tapps_security_scan
+---
+
+Prefer `/tapps-review-pipeline` for multiple Python files. Otherwise:
+
+1. `tapps_security_scan` + `tapps_quick_check` on targets
+2. `/tapps-finish-task` with `task_type=review` or `qa`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Seven rules every agent in this project should follow.
 | **tapps_usage** | When you want to see what you missed this session - per-session `gaps` + concrete `recommendations`. Inlined as `usage_gaps` on every `tapps_checklist` response. |
 | **tapps_quality_gate** | Before declaring work complete - ensures file passes preset |
 
-**For full tool reference** (42 tools with per-tool guidance), invoke the **tapps-tool-reference** skill when the user asks "what tools does TappsMCP have?", "when do I use tapps_score_file?", etc.
+**For full tool reference** (43 tools with per-tool guidance), invoke the **tapps-tool-reference** skill when the user asks "what tools does TappsMCP have?", "when do I use tapps_score_file?", etc.
 
 ---
 
@@ -99,6 +99,7 @@ See [ADR-0017](docs/adr/0017-function-level-call-graph-python-first.md).
 | **tapps_release_update** | Source release body from CHANGELOG/git, generate + validate via docs-mcp, return for Linear post via `linear-release-update` skill |
 | **tapps_pipeline** | Show TAPPS pipeline stage progress and next-step hint for the current session |
 | **tapps_decompose** | Decompose a high-level task into TappsMCP tool call steps for the current pipeline stage |
+| **tapps_domain_playbook** | Load a bundled domain checklist (testing, security, UX, etc.) and suggested TAPPS tool order — deterministic, not RAG |
 | **tapps_linear_snapshot_get / _put / _invalidate** | Cache-first Linear list reads (TAP-1224); orchestrated by the `linear-read` skill — never call directly without snapshot_get first |
 | **tapps_linear_count** | Count Linear issues for a `(team, project, state, label)` slice; backs the cache gate violation telemetry |
 | **tapps_server_info** | Lightweight server discovery (version, checkers, config) — prefer `tapps_session_start` which returns the same info plus session bootstrap |
@@ -182,9 +183,9 @@ The checklist uses this to decide which tools are required vs recommended vs opt
 
 `tapps_init` generates hooks, agents, skills, and rules for Claude Code and Cursor. See the generated files in `.claude/` and `.cursor/` directories.
 
-**Subagents:** tapps-reviewer (sonnet), tapps-researcher (haiku), tapps-validator (sonnet), tapps-review-fixer (sonnet + worktree).
+**Subagents:** tapps-reviewer (sonnet), tapps-researcher (haiku), tapps-validator (sonnet), tapps-review-fixer (sonnet + worktree), tapps-frontend-reviewer (sonnet).
 
-**Skills:** tapps-finish-task, tapps-handoff-session, tapps-continue-session, tapps-review-pipeline, tapps-research, tapps-security, tapps-memory, tapps-tool-reference, tapps-init, tapps-engagement, tapps-upgrade, tapps-apply-files.
+**Skills:** tapps-finish-task, tapps-handoff-session, tapps-continue-session, tapps-review-pipeline, tapps-research, tapps-security, tapps-memory, tapps-tool-reference, tapps-init, tapps-engagement, tapps-upgrade, tapps-apply-files, tapps-domain-* (security/testing/frontend), tapps-flow-* (develop/review/frontend).
 
 ## Agent ecosystem (using TappsMCP with other agent libraries)
 
@@ -313,7 +314,7 @@ For direct stdio connections you can expose only a subset of tools to keep the a
 - **disabled_tools** (deny list): tools to exclude from the full set. Applied when `enabled_tools` is not set. Env: `TAPPS_MCP_DISABLED_TOOLS`.
 - **tool_preset**: `full` (all tools), `core` (7 Tier-1 tools), `pipeline` (Tier 1 + Tier 2), or role presets: `reviewer`, `planner`, `frontend`, `developer` (Epic 79.5). NLT profiles: `nlt-build`, `nlt-memory`, `nlt-setup` (legacy: `nlt-code-quality`, `nlt-platform-admin`). Env: `TAPPS_MCP_TOOL_PRESET=nlt-build`.
 
-Empty or missing = all 42 tools (default, backward compatible). Invalid tool names in `enabled_tools` are ignored and logged. Recommended subsets by task/role and Docker tool filtering: see [docs/architecture/tool-budget.md](docs/architecture/tool-budget.md).
+Empty or missing = all 43 tools (default, backward compatible). Invalid tool names in `enabled_tools` are ignored and logged. Recommended subsets by task/role and Docker tool filtering: see [docs/architecture/tool-budget.md](docs/architecture/tool-budget.md).
 
 ---
 ## tapps_session_start vs tapps_init
@@ -370,11 +371,12 @@ Run `tapps-mcp doctor` to list wired matchers.
 
 ### Subagents (auto-generated)
 
-Four agent definitions per platform in `.claude/agents/` or `.cursor/agents/`:
+Four core quality subagents plus one domain reviewer per platform in `.claude/agents/` or `.cursor/agents/`:
 - **tapps-reviewer** (sonnet) - Reviews code quality and runs security scans after edits
 - **tapps-researcher** (sonnet) - Looks up documentation and researches best practices
 - **tapps-validator** (haiku) - Runs pre-completion validation on all changed files
 - **tapps-review-fixer** (sonnet, isolated worktree) - Combined score-fix-validate pass; designed for parallel multi-file pipelines
+- **tapps-frontend-reviewer** (sonnet) - UI/UX review via `tapps_domain_playbook` + lookup docs; closes with `/tapps-finish-task`
 
 ### Skills (auto-generated)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- tapps-agents-version: 3.12.48 -->
+<!-- tapps-agents-version: 3.12.49 -->
 # TappsMCP - instructions for AI assistants
 
 When the **TappsMCP** MCP server is configured, you have access to tools for **code quality, doc lookup, and domain expert advice**. Use them to avoid hallucinated APIs, missed quality steps, and inconsistent output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.12.48] - 2026-06-24
+## [3.12.49] - 2026-06-26
+
+Feature: light domain playbooks ([ADR-0025](docs/adr/0025-light-domain-playbooks-not-rag-experts.md)) — static checklists and skills instead of EPIC-94 RAG experts.
+
+### Added
+
+- **`tapps_core.playbooks`** — bundled markdown playbooks (testing, security, UX, performance, API design, architecture) with registry and loader.
+- **`tapps_domain_playbook`** MCP tool (43 tools total; +1 deferred on `nlt-build`).
+- **Skills** — `tapps-domain-*` (security, testing, frontend) and `tapps-flow-*` (develop, review, frontend).
+- **Checklist task types** — `qa` and `frontend` policy variants.
+- **DocsMCP enrichment** — epic/story `expert_guidance` from static playbook excerpts.
+- **`tapps-frontend-reviewer`** subagent for UI/UX review workflows.
+
+### Changed
+
+- `tapps_init` agency-agents hint now references pairing with `tapps-domain-*` skills.
+- Docker `tapps-frontend` profile documents `tapps_domain_playbook` instead of removed `consult_expert`.
+
 
 Patch: support-layer hygiene from the Linear cache-gate review — fail-closed
 destructive guard, retired-hook migration, and full removal of the no-op

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 ## What is TappsMCP?
 
-TappsMCP is an **MCP server** providing deterministic code quality tools to LLMs and AI coding assistants. It scores Python files, runs security scans, enforces quality gates, looks up library docs, and validates configs -- all via structured MCP tool calls (42 tools). Any MCP-capable client (Claude Code, Cursor, VS Code Copilot) can use it. If you are a consuming project, see [AGENTS.md](AGENTS.md) instead.
+TappsMCP is an **MCP server** providing deterministic code quality tools to LLMs and AI coding assistants. It scores Python files, runs security scans, enforces quality gates, looks up library docs, and validates configs -- all via structured MCP tool calls (43 tools). Any MCP-capable client (Claude Code, Cursor, VS Code Copilot) can use it. If you are a consuming project, see [AGENTS.md](AGENTS.md) instead.
 
 ## Repository structure
 
@@ -15,7 +15,7 @@ This is a **uv workspace monorepo** with three packages plus an external depende
 |---|---|---|
 | **tapps-brain** | [github.com/wtthornton/tapps-brain](https://github.com/wtthornton/tapps-brain) | Shared memory service (Docker + Postgres, HTTP at `localhost:8080`). Accessed from tapps-mcp via `BrainBridge` (`uv run tapps-mcp memory` CLI; optional `tapps_memory` MCP on `nlt-memory`, TAP-3895). See the [tapps-brain repo](https://github.com/wtthornton/tapps-brain) for storage internals. |
 | **tapps-core** | `packages/tapps-core/` | Shared infrastructure library (config, security, logging, knowledge, metrics, adaptive) |
-| **tapps-mcp** | `packages/tapps-mcp/` | Code quality MCP server (42 tools) |
+| **tapps-mcp** | `packages/tapps-mcp/` | Code quality MCP server (43 tools) |
 | **docs-mcp** | `packages/docs-mcp/` | Documentation MCP server (42 tools) |
 
 tapps-core no longer ships a `memory/` package — the re-export shims that previously delegated to tapps-brain were removed in [TAP-1995](https://linear.app/tappscodingagents/issue/TAP-1995). Callers now import from `tapps_brain` directly. The `BrainBridge` adapter lives at `tapps_core.brain_bridge` (single module, replacing the old `tapps_core.memory.*` layout). tapps-mcp re-exports from tapps-core for backward compatibility (`from tapps_mcp.config import load_settings` still works).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-**Tapps Platform** ships two MCP servers for AI-assisted development: **TappsMCP** (code quality, security, shared memory) and **DocsMCP** (documentation generation and maintenance). Together they expose **84 tools** (42 per package) with structured, deterministic outputs suitable for Claude Code, Cursor, VS Code, and any MCP host.
+**Tapps Platform** ships two MCP servers for AI-assisted development: **TappsMCP** (code quality, security, shared memory) and **DocsMCP** (documentation generation and maintenance). Together they expose **85 tools** (43 TappsMCP + 42 DocsMCP) with structured, deterministic outputs suitable for Claude Code, Cursor, VS Code, and any MCP host.
+
+### What's new in v3.12.49
+
+- **Light domain playbooks** ([ADR-0025](docs/adr/0025-light-domain-playbooks-not-rag-experts.md)) — `tapps_domain_playbook`, six bundled checklists, `tapps-domain-*` / `tapps-flow-*` skills, `qa`/`frontend` checklist types, DocsMCP epic enrichment. Replaces EPIC-94 RAG experts without reviving vector consultation.
 
 ### What's new in v3.12
 
@@ -37,15 +41,15 @@ See [CHANGELOG.md](CHANGELOG.md) for the full history.
 |---|---|---|
 | **tapps-brain** | Shared memory service (Docker + Postgres, HTTP at `localhost:8080`). External repo — see [tapps-brain](https://github.com/wtthornton/tapps-brain) for the canonical storage/retrieval/federation docs. | 0 (library; brain_* MCP tools ship in the service) |
 | **tapps-core** | Shared infrastructure (config, security, logging, knowledge, metrics, adaptive) | 0 (library) |
-| **tapps-mcp** | Code quality MCP server (scoring, gates, tools, validation) | 42 |
+| **tapps-mcp** | Code quality MCP server (scoring, gates, tools, validation) | 43 |
 | **docs-mcp** | Documentation generation and maintenance MCP server | 42 |
 
 Install is from the local checkout (`uv tool install -e packages/tapps-mcp`); the packages are not published to PyPI. See [Install](#install).
 
 ```
-tapps-brain (standalone)  <──  tapps-core (shared infra)  <──  tapps-mcp (42 tools)
+tapps-brain (standalone)  <──  tapps-core (shared infra)  <──  tapps-mcp (43 tools)
                                                           <──  docs-mcp  (42 tools)
-                                                                      = 84 MCP tools
+                                                                      = 85 MCP tools
 ```
 
 ### Key highlights

--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -43,7 +43,7 @@
 - **SBOM** - Supply chain security
 
 ## Architecture
-- **3-package monorepo**: tapps-core (library), tapps-mcp (42 tools), docs-mcp (42 tools) — see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for module map and data flow
+- **3-package monorepo**: tapps-core (library), tapps-mcp (43 tools), docs-mcp (42 tools) — see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for module map and data flow
 - **MCP Protocol**: 2025-11-25 (latest stable)
 - **7-category scoring**: complexity, security, maintainability, test coverage, performance, structure, devex — see [docs/CHECKLIST.md](docs/CHECKLIST.md) for category weights and [README.md](README.md) for scoring tool reference
 - **Memory subsystem**: see [docs/MEMORY_REFERENCE.md](docs/MEMORY_REFERENCE.md) for the 42 brain memory actions (`uv run tapps-mcp memory` CLI; `nlt-memory` MCP profile for recall/save/handoff); [tapps-brain repo](https://github.com/wtthornton/tapps-brain) for retrieval, decay, consolidation, and federation internals

--- a/docker-mcp/profiles/tapps-frontend.yaml
+++ b/docker-mcp/profiles/tapps-frontend.yaml
@@ -1,6 +1,6 @@
 # Role profile: Frontend / UX work (Epic 79.6 Phase 1).
-# Use with tools.yaml to expose only frontend tools (~7 TappsMCP). See docker-mcp/README.md.
+# Use with tools.yaml to expose only frontend tools (~8 TappsMCP). See docker-mcp/README.md.
 name: tapps-frontend
-description: "Frontend / UX — quick_check, score_file, lookup_docs, consult_expert, quality_gate, project_profile"
+description: "Frontend / UX — quick_check, score_file, lookup_docs, domain_playbook, quality_gate"
 servers:
   - catalog://tapps-mcp

--- a/docker-mcp/tapps-mcp/readme.md
+++ b/docker-mcp/tapps-mcp/readme.md
@@ -1,6 +1,6 @@
 # TappsMCP
 
-Deterministic code quality MCP server providing 42 tools for AI coding assistants.
+Deterministic code quality MCP server providing 43 tools for AI coding assistants.
 
 ## Features
 

--- a/docker-mcp/tapps-mcp/server.yaml
+++ b/docker-mcp/tapps-mcp/server.yaml
@@ -14,7 +14,7 @@ about:
     Deterministic code quality MCP server. Scores Python files across 7
     categories, runs security scans, enforces quality gates, looks up
     library docs (Context7-backed), and validates infra configs.
-    42 tools, zero LLM calls in the tool chain.
+    43 tools, zero LLM calls in the tool chain.
   icon: https://raw.githubusercontent.com/wtthornton/TappsMCP/master/docs/icon.png
 source:
   project: https://github.com/wtthornton/TappsMCP

--- a/docs/adr/0025-light-domain-playbooks-not-rag-experts.md
+++ b/docs/adr/0025-light-domain-playbooks-not-rag-experts.md
@@ -1,0 +1,39 @@
+# 25. Light domain playbooks (not RAG experts)
+
+Date: 2026-06-26
+
+## Status
+
+Accepted
+
+## Context
+
+EPIC-94 removed the RAG-backed expert consultation system (`tapps_consult_expert`, vector indices, business experts). Agents lost domain-shaped workflows (testing, security, frontend) without losing the shared TAPPS quality pipeline. [ADR-0014](0014-brain-central-doc-rag-big-bang.md) explicitly excludes reviving EPIC-94 expert consultation. Industry practice (2026) favors **skills + static playbooks + deterministic tools** over vector personas for code work.
+
+## Decision
+
+Ship a **light playbook layer**:
+
+1. **Bundled markdown playbooks** in `tapps_core.playbooks.data` with a registry in `tapps_core.playbooks.registry`.
+2. **MCP tool** `tapps_domain_playbook(domain)` — deterministic file lookup + metadata (deferred on `nlt-build`).
+3. **Skills** `tapps-domain-*` and `tapps-flow-*` orchestrating existing TAPPS tools; all close with `/tapps-finish-task`.
+4. **Checklist task types** `qa` and `frontend` for policy variants.
+5. **DocsMCP enrichment** via static playbook excerpts (no network in sync path).
+
+Persona voice remains optional via [agency-agents](https://github.com/msitarzewski/agency-agents) — not forked into `tapps_init`.
+
+## Consequences
+
+**Positive:** Domain routing restored; ADR-0004 preserved; no per-repo vector indices; epic/story enrichment useful again.
+
+**Negative:** Playbook content must be maintained manually; no LLM-synthesized “expert answers.”
+
+**Neutral:** Tool count 42 → 43; `nlt-build` deferred tools +1.
+
+## Alternatives considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Full EPIC-94 RAG revival | Violates ADR-0004/0014; stale indices; duplicates Context7 |
+| 112 personas in tapps_init | Maintenance fork of agency-agents |
+| Role-specific quality gates | Agents bypass shared pipeline |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ CLAUDE.md and per-package CLAUDE.md files point at ADRs by number rather than em
 | [0021](0021-usage-gap-doc-lookup-telemetry-and-import-cache-aliases.md) | Usage-gap doc lookup: import/cache aliases + cross-channel telemetry | Accepted |
 | [0022](0022-agent-hint-contract-lookup-and-validation-semantics.md) | Agent hint contract — lookup timing and validation semantics | Accepted |
 | [0024](0024-shared-http-mcp-fleet.md) | Shared HTTP MCP fleet for multi-window Cursor | Accepted |
+| [0025](0025-light-domain-playbooks-not-rag-experts.md) | Light domain playbooks (not RAG experts) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/architecture/nlt-mcp-plugin-spec.yaml
+++ b/docs/architecture/nlt-mcp-plugin-spec.yaml
@@ -146,16 +146,19 @@ servers:
     serve_args: ["serve", "--profile", "nlt-build"]
     legacy_profile_alias: nlt-code-quality
     default_enabled: true
-    tool_count: 18
+    tool_count: 19
     eager_count: 9
     skills:
       - tapps-finish-task
       - tapps-review-pipeline
+      - tapps-domain-security
+      - tapps-domain-testing
+      - tapps-domain-frontend
+      - tapps-flow-develop
+      - tapps-flow-review
+      - tapps-flow-frontend
       - tapps-security
       - tapps-research
-      - tapps-score
-      - tapps-gate
-      - tapps-validate
     hooks:
       - tapps-after-edit # Cursor: remind quick_check
       - tapps-post-edit # Claude: remind quick_check
@@ -180,6 +183,7 @@ servers:
         - tapps_audit_campaign
         - tapps_call_graph
         - tapps_diff_impact
+        - tapps_domain_playbook
 
   nlt-memory:
     display_name: "Memory"

--- a/docs/architecture/tool-budget.md
+++ b/docs/architecture/tool-budget.md
@@ -41,7 +41,7 @@ Eager tapps-mcp tools (full `tapps-mcp serve`): `tapps_session_start`, `tapps_va
 
 | Server | Mode | Eager tools | Deferred tools | Total |
 |---|---|---|---|---|
-| `tapps-mcp` | full (no `--mode`) | 10 | 32 | 42 |
+| `tapps-mcp` | full (no `--mode`) | 10 | 33 | 43 |
 | `tapps-quality` | `--mode quality` | 9 | 6 | 15 |
 | `tapps-admin` | `--mode admin` | 1 | 12 | 13 |
 | `docs-mcp` | full `docsmcp serve` | 7 | 35 | 42 |
@@ -52,8 +52,8 @@ Eager docs-mcp tools (full serve): `docs_generate_changelog`, `docs_generate_epi
 `docs_save_linear_issue`, `docs_release_gate` (7 total). The `nlt-project-docs` profile
 registers 29 tools with **all** `defer_loading=True` (loaded via Tool Search).
 
-> **Note:** Full-catalog sizes are `ALL_TOOL_NAMES` / `ALL_DOCS_TOOL_NAMES` (42 each, 84
-> combined). NLT profiles expose subsets — e.g. `nlt-build` (18 tools, 9 eager),
+> **Note:** Full-catalog sizes are `ALL_TOOL_NAMES` / `ALL_DOCS_TOOL_NAMES` (43 / 42, 85
+> combined). NLT profiles expose subsets — e.g. `nlt-build` (19 tools, 9 eager),
 > `nlt-memory` (4 tools), `nlt-project-docs` (29 tools, 0 eager).
 
 ## Updating the budget
@@ -65,7 +65,7 @@ Set `doctor_tool_budget_limit` in `.tapps-mcp.yaml`:
 doctor_tool_budget_limit: 30
 ```
 
-If you intentionally run tapps-mcp in full mode (42 tools, 10 eager) and accept the context cost,
+If you intentionally run tapps-mcp in full mode (43 tools, 10 eager) and accept the context cost,
 raise the budget to 10 (or higher) to silence the WARN. If you want a stricter check, lower it to 15
 to enforce quality-preset-level discipline.
 

--- a/packages/docs-mcp/pyproject.toml
+++ b/packages/docs-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docs-mcp"
-version = "3.12.48"
+version = "3.12.49"
 description = "MCP server for automated documentation generation, validation, and maintenance"
 readme = "docs/README.md"
 license = "MIT"

--- a/packages/docs-mcp/src/docs_mcp/generators/domain_enrichment.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/domain_enrichment.py
@@ -1,0 +1,69 @@
+"""Deterministic domain enrichment for DocsMCP generators (ADR-0025)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tapps_core.playbooks.loader import load_playbook_markdown
+from tapps_core.playbooks.registry import get_playbook, suggest_domains_for_text
+
+
+def _playbook_excerpt(markdown: str, *, max_length: int = 400) -> str:
+    lines = [line.strip() for line in markdown.splitlines() if line.strip()]
+    body: list[str] = []
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        body.append(line)
+        if len(" ".join(body)) >= max_length:
+            break
+    text = " ".join(body).strip()
+    if len(text) > max_length:
+        return text[: max_length - 3].rsplit(" ", 1)[0] + "..."
+    return text
+
+
+def build_domain_guidance(
+    context: str,
+    *,
+    limit: int = 3,
+    max_excerpt_chars: int = 400,
+) -> list[dict[str, str]]:
+    """Return expert_guidance-shaped entries from bundled playbooks."""
+    guidance: list[dict[str, str]] = []
+    for domain_id in suggest_domains_for_text(context, limit=limit):
+        meta = get_playbook(domain_id)
+        if meta is None:
+            continue
+        try:
+            markdown = load_playbook_markdown(meta)
+        except FileNotFoundError:
+            continue
+        advice = _playbook_excerpt(markdown, max_length=max_excerpt_chars)
+        if not advice:
+            continue
+        guidance.append(
+            {
+                "domain": meta.display_name,
+                "expert": meta.display_name,
+                "advice": advice,
+                "confidence": "100%",
+                "source": "domain_playbook",
+            }
+        )
+    return guidance
+
+
+def enrich_expert_guidance(
+    config_text: str,
+    enrichment: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> None:
+    """Populate ``enrichment['expert_guidance']`` from static domain playbooks."""
+    existing: list[dict[str, str]] = enrichment.get("expert_guidance", [])
+    if existing:
+        return
+    guidance = build_domain_guidance(config_text, limit=limit)
+    if guidance:
+        enrichment["expert_guidance"] = guidance

--- a/packages/docs-mcp/src/docs_mcp/generators/epics.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/epics.py
@@ -1404,11 +1404,16 @@ class EpicGenerator:
 
     @staticmethod
     def _enrich_experts(config: EpicConfig, enrichment: dict[str, Any]) -> None:
-        """No-op — expert system removed (EPIC-94).
+        """Enrich epics with bundled domain playbook excerpts (ADR-0025)."""
+        from docs_mcp.generators.domain_enrichment import enrich_expert_guidance
 
-        Previously enriched epics with TappsMCP domain expert guidance.
-        Retained as a no-op to preserve the enrichment pipeline interface.
-        """
+        context_parts = [
+            config.title or "",
+            config.purpose_and_intent or "",
+            config.goal or "",
+            " ".join(s.title for s in config.stories) if config.stories else "",
+        ]
+        enrich_expert_guidance("\n".join(context_parts), enrichment)
 
     # -- expert filtering (Epic 18.3) ---------------------------------------
 

--- a/packages/docs-mcp/src/docs_mcp/generators/stories.py
+++ b/packages/docs-mcp/src/docs_mcp/generators/stories.py
@@ -1031,11 +1031,15 @@ class StoryGenerator:
 
     @staticmethod
     def _enrich_experts(config: StoryConfig, enrichment: dict[str, Any]) -> None:
-        """No-op — expert system removed (EPIC-94).
+        """Enrich stories with bundled domain playbook excerpts (ADR-0025)."""
+        from docs_mcp.generators.domain_enrichment import enrich_expert_guidance
 
-        Previously enriched stories with TappsMCP domain expert guidance.
-        Retained as a no-op to preserve the enrichment pipeline interface.
-        """
+        context_parts = [
+            config.title or "",
+            config.purpose_and_intent or "",
+            " ".join(config.acceptance_criteria) if config.acceptance_criteria else "",
+        ]
+        enrich_expert_guidance("\n".join(context_parts), enrichment, limit=2)
 
     # -- helpers -----------------------------------------------------------
 

--- a/packages/docs-mcp/tests/unit/test_domain_enrichment.py
+++ b/packages/docs-mcp/tests/unit/test_domain_enrichment.py
@@ -1,0 +1,27 @@
+"""Tests for DocsMCP domain playbook enrichment."""
+
+from __future__ import annotations
+
+from docs_mcp.generators.domain_enrichment import build_domain_guidance, enrich_expert_guidance
+
+
+class TestDomainEnrichment:
+    def test_build_guidance_for_security_epic(self) -> None:
+        guidance = build_domain_guidance("OAuth security hardening for API endpoints")
+        assert guidance
+        domains = {item["domain"] for item in guidance}
+        assert "Application security" in domains
+
+    def test_enrich_populates_expert_guidance(self) -> None:
+        enrichment: dict[str, object] = {}
+        enrich_expert_guidance("Improve pytest coverage for checkout flow", enrichment)
+        assert "expert_guidance" in enrichment
+        items = enrichment["expert_guidance"]
+        assert isinstance(items, list)
+        assert items
+        assert items[0]["source"] == "domain_playbook"
+
+    def test_enrich_skips_when_existing(self) -> None:
+        enrichment = {"expert_guidance": [{"domain": "X", "advice": "keep", "confidence": "100%"}]}
+        enrich_expert_guidance("security auth", enrichment)
+        assert enrichment["expert_guidance"] == [{"domain": "X", "advice": "keep", "confidence": "100%"}]

--- a/packages/docs-mcp/tests/unit/test_epics.py
+++ b/packages/docs-mcp/tests/unit/test_epics.py
@@ -813,21 +813,29 @@ class TestEpicGeneratorAutoPopulate:
 # ---------------------------------------------------------------------------
 
 
-class TestEpicExpertEnrichmentNoOp:
-    """Issue #82: _enrich_experts is a no-op after EPIC-94 removal."""
+class TestEpicExpertEnrichmentPlaybooks:
+    """ADR-0025: _enrich_experts uses bundled domain playbooks."""
 
-    def test_enrich_experts_is_noop(self) -> None:
+    def test_enrich_experts_adds_security_guidance(self) -> None:
         from docs_mcp.generators.epics import EpicConfig, EpicGenerator
 
-        config = EpicConfig(number=1, title="Test")
+        config = EpicConfig(
+            number=1,
+            title="API security hardening",
+            purpose_and_intent="We are doing this so that auth endpoints resist abuse.",
+        )
+        enrichment: dict[str, Any] = {}
+        EpicGenerator._enrich_experts(config, enrichment)
+        assert "expert_guidance" in enrichment
+        assert enrichment["expert_guidance"][0]["source"] == "domain_playbook"
+
+    def test_enrich_experts_no_match_leaves_empty(self) -> None:
+        from docs_mcp.generators.epics import EpicConfig, EpicGenerator
+
+        config = EpicConfig(number=2, title="Rename internal variable")
         enrichment: dict[str, Any] = {}
         EpicGenerator._enrich_experts(config, enrichment)
         assert "expert_guidance" not in enrichment
-
-
-# Note: TestEpicGeneratorExpertEnrichment was removed when the expert
-# enrichment system was deleted (EPIC-94). The dead test class has been
-# removed entirely rather than kept as commented-out code.
 
 
 # ---------------------------------------------------------------------------

--- a/packages/docs-mcp/tests/unit/test_stories.py
+++ b/packages/docs-mcp/tests/unit/test_stories.py
@@ -533,21 +533,28 @@ class TestStoryGeneratorAutoPopulate:
 # ---------------------------------------------------------------------------
 
 
-class TestStoryExpertEnrichmentNoOp:
-    """Issue #82: _enrich_experts is a no-op after EPIC-94 removal."""
+class TestStoryExpertEnrichmentPlaybooks:
+    """ADR-0025: _enrich_experts uses bundled domain playbooks."""
 
-    def test_enrich_experts_is_noop(self) -> None:
+    def test_enrich_experts_adds_testing_guidance(self) -> None:
         from docs_mcp.generators.stories import StoryConfig, StoryGenerator
 
-        config = StoryConfig(epic_number=1, story_number=1, title="Test")
+        config = StoryConfig(
+            epic_number=1,
+            story_number=1,
+            title="Add pytest coverage for checkout",
+        )
+        enrichment: dict[str, Any] = {}
+        StoryGenerator._enrich_experts(config, enrichment)
+        assert "expert_guidance" in enrichment
+
+    def test_enrich_experts_no_match_leaves_empty(self) -> None:
+        from docs_mcp.generators.stories import StoryConfig, StoryGenerator
+
+        config = StoryConfig(epic_number=1, story_number=2, title="Rename variable")
         enrichment: dict[str, Any] = {}
         StoryGenerator._enrich_experts(config, enrichment)
         assert "expert_guidance" not in enrichment
-
-
-# Note: TestStoryGeneratorExpertEnrichment was removed when the expert
-# enrichment system was deleted (EPIC-94). The dead test class has been
-# removed entirely rather than kept as commented-out code.
 
 
 # ---------------------------------------------------------------------------

--- a/packages/tapps-core/pyproject.toml
+++ b/packages/tapps-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-core"
-version = "3.12.48"
+version = "3.12.49"
 description = "Shared infrastructure library for Tapps platform (config, security, logging, knowledge, memory, metrics)"
 license = "MIT"
 requires-python = ">=3.12"
@@ -47,3 +47,6 @@ include = ["src/tapps_core/"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tapps_core"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/tapps_core/playbooks/data" = "tapps_core/playbooks/data"

--- a/packages/tapps-core/src/tapps_core/playbooks/__init__.py
+++ b/packages/tapps-core/src/tapps_core/playbooks/__init__.py
@@ -1,0 +1,27 @@
+"""Static domain playbooks (ADR-0025) — deterministic guidance, not RAG experts."""
+
+from tapps_core.playbooks.loader import load_playbook_markdown, load_playbook_markdown_by_domain
+from tapps_core.playbooks.models import DomainPlaybook, LookupHint
+from tapps_core.playbooks.registry import (
+    DOMAIN_ALIASES,
+    DOMAIN_PLAYBOOKS,
+    did_you_mean_domain,
+    get_playbook,
+    list_domain_ids,
+    resolve_domain_id,
+    suggest_domains_for_text,
+)
+
+__all__ = [
+    "DOMAIN_ALIASES",
+    "DOMAIN_PLAYBOOKS",
+    "DomainPlaybook",
+    "LookupHint",
+    "did_you_mean_domain",
+    "get_playbook",
+    "list_domain_ids",
+    "load_playbook_markdown",
+    "load_playbook_markdown_by_domain",
+    "resolve_domain_id",
+    "suggest_domains_for_text",
+]

--- a/packages/tapps-core/src/tapps_core/playbooks/data/__init__.py
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled playbook markdown assets."""

--- a/packages/tapps-core/src/tapps_core/playbooks/data/api-design-integration.md
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/api-design-integration.md
@@ -1,0 +1,23 @@
+# API design playbook
+
+## When to use
+
+New endpoints, request/response models, versioning, or public API changes.
+
+## Workflow
+
+1. Call `tapps_lookup_docs` for the web framework in use (e.g. FastAPI routing, Pydantic models).
+2. Run `tapps_impact_analysis(file_path="...")` before changing public module APIs.
+3. Edit loop with `tapps_quick_check`.
+4. Close with `/tapps-finish-task` and `task_type=feature`.
+
+## Checklist
+
+- [ ] Request/response schemas explicit and validated.
+- [ ] Error responses consistent and documented.
+- [ ] Breaking changes flagged for consumers.
+- [ ] Importers of changed modules identified via impact analysis.
+
+## Exit criteria
+
+Gate pass on changed files; impact analysis when public API touched.

--- a/packages/tapps-core/src/tapps_core/playbooks/data/performance-optimization.md
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/performance-optimization.md
@@ -1,0 +1,23 @@
+# Performance optimization playbook
+
+## When to use
+
+Latency regressions, hot paths, N+1 queries, or large refactor blast-radius review.
+
+## Workflow
+
+1. Call `tapps_session_start()` and read `data.call_graph` staleness hint.
+2. Use `tapps_call_graph(symbol="...", query="callers")` before changing hot functions.
+3. Use `tapps_impact_analysis` for module-level blast radius.
+4. Iterate with `tapps_quick_check` after edits.
+5. Close with `/tapps-finish-task` and `task_type=refactor`.
+
+## Checklist
+
+- [ ] Measure before optimizing (profile or benchmark when possible).
+- [ ] Callers of changed symbols reviewed via call graph.
+- [ ] No premature micro-optimizations without evidence.
+
+## Exit criteria
+
+Changed code passes gate; call graph consulted when symbols changed.

--- a/packages/tapps-core/src/tapps_core/playbooks/data/security.md
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/security.md
@@ -1,0 +1,24 @@
+# Security playbook
+
+## When to use
+
+Auth changes, secrets handling, new endpoints, dependency upgrades, or pre-release audits.
+
+## Workflow
+
+1. Call `tapps_session_start()` if not already called.
+2. Call `tapps_lookup_docs(library="python-security", topic="input validation")` for patterns.
+3. Run `tapps_security_scan(file_path="...")` on every changed sensitive module.
+4. Run `tapps_dependency_scan()` before release or when lockfiles change.
+5. Close with `/tapps-finish-task` and `task_type=security`.
+
+## Checklist
+
+- [ ] No secrets, tokens, or credentials in source or logs.
+- [ ] User input validated at trust boundaries.
+- [ ] Dependencies scanned for known CVEs.
+- [ ] Security gate findings triaged by severity before merge.
+
+## Exit criteria
+
+Security scan and quality gate pass on changed files; CVE scan run when dependencies changed.

--- a/packages/tapps-core/src/tapps_core/playbooks/data/software-architecture.md
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/software-architecture.md
@@ -1,0 +1,22 @@
+# Software architecture playbook
+
+## When to use
+
+Cross-module refactors, new packages, boundary moves, or deleting modules.
+
+## Workflow
+
+1. Call `tapps_impact_analysis(file_path="...", granularity="both")` when symbols matter.
+2. Use `tapps_dependency_graph` to detect circular imports before large moves.
+3. Use `tapps_call_graph` for function-level refactors.
+4. Close with `/tapps-finish-task` and `task_type=refactor`.
+
+## Checklist
+
+- [ ] Blast radius documented before edits.
+- [ ] Circular dependencies resolved or explicitly accepted.
+- [ ] Public vs internal module boundaries respected.
+
+## Exit criteria
+
+Impact/call graph tools used when API or symbol signatures change; gate pass on edits.

--- a/packages/tapps-core/src/tapps_core/playbooks/data/testing-strategies.md
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/testing-strategies.md
@@ -1,0 +1,24 @@
+# Testing strategies playbook
+
+## When to use
+
+Before adding or changing tests, or when fixing regressions without a failing test.
+
+## Workflow
+
+1. Call `tapps_session_start()` if not already called this session.
+2. Call `tapps_lookup_docs(library="pytest", topic="fixtures and parametrize")` before writing test code.
+3. After code edits, run `tapps_diff_impact(file_paths="...")` to rank affected tests.
+4. Use `tapps_quick_check(file_path="...")` on each changed Python test module.
+5. Close with `/tapps-finish-task` and `task_type=qa`.
+
+## Checklist
+
+- [ ] New behavior has a test that fails before the fix and passes after.
+- [ ] Tests are deterministic (no time/network flakiness without explicit mocks).
+- [ ] Fixtures live in conftest when shared across modules.
+- [ ] Async tests use the project's async pytest plugin conventions.
+
+## Exit criteria
+
+All changed Python files pass `tapps_validate_changed`; affected tests identified via diff impact when available.

--- a/packages/tapps-core/src/tapps_core/playbooks/data/user-experience.md
+++ b/packages/tapps-core/src/tapps_core/playbooks/data/user-experience.md
@@ -1,0 +1,27 @@
+# Frontend / UX playbook
+
+## When to use
+
+UI components, styling, routing, accessibility, or client-side performance work.
+
+## Workflow
+
+1. Call `tapps_session_start()` if not already called.
+2. Call `tapps_lookup_docs` for the UI library in use (e.g. `react` + `accessibility`).
+3. Score changed files with `tapps_score_file` / `tapps_quick_check` (Python backend) or manual review for TS/CSS.
+4. Close with `/tapps-finish-task` and `task_type=frontend`.
+
+## Checklist
+
+- [ ] Keyboard navigation and focus order considered.
+- [ ] Color contrast and semantic HTML where applicable.
+- [ ] No hard-coded secrets in client bundles.
+- [ ] Loading and error states handled for async UI.
+
+## Persona (optional)
+
+For implementation voice and UX craft, install [agency-agents](https://github.com/msitarzewski/agency-agents) Frontend Developer — TappsMCP owns enforcement, not persona.
+
+## Exit criteria
+
+Lookup docs called for external UI libraries; quality gate pass on scored files.

--- a/packages/tapps-core/src/tapps_core/playbooks/loader.py
+++ b/packages/tapps-core/src/tapps_core/playbooks/loader.py
@@ -1,0 +1,33 @@
+"""Load bundled domain playbook markdown from package data."""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tapps_core.playbooks.models import DomainPlaybook
+
+_PLAYBOOKS_PACKAGE = "tapps_core.playbooks.data"
+
+
+def load_playbook_markdown(meta: DomainPlaybook) -> str:
+    """Return playbook markdown for *meta*; raises FileNotFoundError if missing."""
+    filename = meta.playbook_file
+    traversable = resources.files(_PLAYBOOKS_PACKAGE)
+    path = traversable.joinpath(filename)
+    if not path.is_file():
+        msg = f"Playbook file not found: {filename}"
+        raise FileNotFoundError(msg)
+    return path.read_text(encoding="utf-8")
+
+
+def load_playbook_markdown_by_domain(domain: str) -> tuple[DomainPlaybook, str]:
+    """Resolve *domain* and return (metadata, markdown body)."""
+    from tapps_core.playbooks.registry import get_playbook
+
+    meta = get_playbook(domain)
+    if meta is None:
+        msg = f"Unknown domain playbook: {domain}"
+        raise KeyError(msg)
+    return meta, load_playbook_markdown(meta)

--- a/packages/tapps-core/src/tapps_core/playbooks/models.py
+++ b/packages/tapps-core/src/tapps_core/playbooks/models.py
@@ -1,0 +1,24 @@
+"""Domain playbook models (ADR-0025)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class LookupHint(BaseModel):
+    """Library documentation lookup suggestion for a domain playbook."""
+
+    library: str
+    topic: str = ""
+
+
+class DomainPlaybook(BaseModel):
+    """Static domain playbook metadata — deterministic, no RAG."""
+
+    domain_id: str
+    display_name: str
+    playbook_file: str
+    lookup_hints: list[LookupHint] = Field(default_factory=list)
+    recommended_tools: list[str] = Field(default_factory=list)
+    checklist_task_type: str = "feature"
+    epic_keywords: list[str] = Field(default_factory=list)

--- a/packages/tapps-core/src/tapps_core/playbooks/registry.py
+++ b/packages/tapps-core/src/tapps_core/playbooks/registry.py
@@ -1,0 +1,157 @@
+"""Canonical domain playbook registry (ADR-0025).
+
+Replaces EPIC-94 vector experts with static playbooks + lookup hints.
+"""
+
+from __future__ import annotations
+
+from tapps_core.playbooks.models import DomainPlaybook, LookupHint
+
+DOMAIN_PLAYBOOKS: dict[str, DomainPlaybook] = {
+    "testing-strategies": DomainPlaybook(
+        domain_id="testing-strategies",
+        display_name="Testing strategies",
+        playbook_file="testing-strategies.md",
+        lookup_hints=[
+            LookupHint(library="pytest", topic="fixtures and parametrize"),
+            LookupHint(library="pytest", topic="async tests"),
+        ],
+        recommended_tools=[
+            "tapps_lookup_docs",
+            "tapps_diff_impact",
+            "tapps_quick_check",
+            "tapps_validate_changed",
+        ],
+        checklist_task_type="qa",
+        epic_keywords=["test", "testing", "pytest", "coverage", "e2e", "fixture"],
+    ),
+    "security": DomainPlaybook(
+        domain_id="security",
+        display_name="Application security",
+        playbook_file="security.md",
+        lookup_hints=[
+            LookupHint(library="python-security", topic="input validation"),
+            LookupHint(library="bandit", topic="configuration"),
+        ],
+        recommended_tools=[
+            "tapps_lookup_docs",
+            "tapps_security_scan",
+            "tapps_dependency_scan",
+            "tapps_validate_changed",
+        ],
+        checklist_task_type="security",
+        epic_keywords=["security", "auth", "cve", "vulnerability", "owasp", "secret"],
+    ),
+    "user-experience": DomainPlaybook(
+        domain_id="user-experience",
+        display_name="Frontend / UX",
+        playbook_file="user-experience.md",
+        lookup_hints=[
+            LookupHint(library="react", topic="accessibility"),
+            LookupHint(library="nextjs", topic="routing"),
+        ],
+        recommended_tools=[
+            "tapps_lookup_docs",
+            "tapps_score_file",
+            "tapps_quick_check",
+            "tapps_validate_changed",
+        ],
+        checklist_task_type="frontend",
+        epic_keywords=["ui", "frontend", "react", "vue", "accessibility", "a11y", "css"],
+    ),
+    "performance-optimization": DomainPlaybook(
+        domain_id="performance-optimization",
+        display_name="Performance optimization",
+        playbook_file="performance-optimization.md",
+        lookup_hints=[
+            LookupHint(library="python", topic="profiling"),
+        ],
+        recommended_tools=[
+            "tapps_call_graph",
+            "tapps_impact_analysis",
+            "tapps_quick_check",
+        ],
+        checklist_task_type="refactor",
+        epic_keywords=["performance", "latency", "benchmark", "slow", "optimize"],
+    ),
+    "api-design-integration": DomainPlaybook(
+        domain_id="api-design-integration",
+        display_name="API design",
+        playbook_file="api-design-integration.md",
+        lookup_hints=[
+            LookupHint(library="fastapi", topic="routing best practices"),
+            LookupHint(library="pydantic", topic="models"),
+        ],
+        recommended_tools=[
+            "tapps_lookup_docs",
+            "tapps_impact_analysis",
+            "tapps_quick_check",
+        ],
+        checklist_task_type="feature",
+        epic_keywords=["api", "rest", "endpoint", "graphql", "openapi"],
+    ),
+    "software-architecture": DomainPlaybook(
+        domain_id="software-architecture",
+        display_name="Software architecture",
+        playbook_file="software-architecture.md",
+        lookup_hints=[],
+        recommended_tools=[
+            "tapps_impact_analysis",
+            "tapps_call_graph",
+            "tapps_dependency_graph",
+        ],
+        checklist_task_type="refactor",
+        epic_keywords=["architecture", "refactor", "module", "boundary", "monolith"],
+    ),
+}
+
+DOMAIN_ALIASES: dict[str, str] = {
+    "testing": "testing-strategies",
+    "frontend": "user-experience",
+    "ux": "user-experience",
+    "perf": "performance-optimization",
+    "performance": "performance-optimization",
+    "api": "api-design-integration",
+    "architecture": "software-architecture",
+}
+
+
+def list_domain_ids() -> list[str]:
+    """Return sorted canonical domain ids."""
+    return sorted(DOMAIN_PLAYBOOKS.keys())
+
+
+def resolve_domain_id(domain: str) -> str | None:
+    """Resolve a domain id or alias to a canonical id."""
+    key = domain.strip().lower()
+    if key in DOMAIN_PLAYBOOKS:
+        return key
+    return DOMAIN_ALIASES.get(key)
+
+
+def get_playbook(domain: str) -> DomainPlaybook | None:
+    """Return playbook metadata for *domain* (id or alias), or None."""
+    resolved = resolve_domain_id(domain)
+    if resolved is None:
+        return None
+    return DOMAIN_PLAYBOOKS[resolved]
+
+
+def suggest_domains_for_text(text: str, *, limit: int = 3) -> list[str]:
+    """Rank domains by keyword hits in *text* (deterministic)."""
+    lowered = text.lower()
+    scores: list[tuple[int, str]] = []
+    for domain_id, meta in DOMAIN_PLAYBOOKS.items():
+        hits = sum(1 for kw in meta.epic_keywords if kw in lowered)
+        if hits:
+            scores.append((hits, domain_id))
+    scores.sort(key=lambda item: (-item[0], item[1]))
+    return [domain_id for _, domain_id in scores[:limit]]
+
+
+def did_you_mean_domain(domain: str, *, limit: int = 3) -> list[str]:
+    """Simple prefix/substring suggestions for unknown domain ids."""
+    key = domain.strip().lower()
+    options = list_domain_ids() + list(DOMAIN_ALIASES.keys())
+    matches = [opt for opt in options if key in opt or opt.startswith(key)]
+    return sorted(set(matches))[:limit]

--- a/packages/tapps-core/tests/unit/test_playbook_registry.py
+++ b/packages/tapps-core/tests/unit/test_playbook_registry.py
@@ -1,0 +1,54 @@
+"""Tests for domain playbook registry and loader."""
+
+from __future__ import annotations
+
+import pytest
+
+from tapps_core.playbooks import (
+    get_playbook,
+    list_domain_ids,
+    load_playbook_markdown,
+    load_playbook_markdown_by_domain,
+    resolve_domain_id,
+    suggest_domains_for_text,
+)
+
+
+class TestPlaybookRegistry:
+    def test_list_domain_ids_stable(self) -> None:
+        ids = list_domain_ids()
+        assert "testing-strategies" in ids
+        assert "security" in ids
+        assert ids == sorted(ids)
+
+    def test_resolve_aliases(self) -> None:
+        assert resolve_domain_id("frontend") == "user-experience"
+        assert resolve_domain_id("testing") == "testing-strategies"
+
+    def test_unknown_domain(self) -> None:
+        assert get_playbook("not-a-domain") is None
+
+    def test_suggest_domains_from_title(self) -> None:
+        domains = suggest_domains_for_text("Add pytest coverage for auth security epic")
+        assert "testing-strategies" in domains
+        assert "security" in domains
+
+
+class TestPlaybookLoader:
+    def test_load_testing_playbook(self) -> None:
+        meta = get_playbook("testing-strategies")
+        assert meta is not None
+        text = load_playbook_markdown(meta)
+        assert "pytest" in text.lower()
+
+    def test_load_by_domain_alias(self) -> None:
+        meta, text = load_playbook_markdown_by_domain("security")
+        assert meta.domain_id == "security"
+        assert "tapps_security_scan" in text
+
+    def test_missing_file_raises(self) -> None:
+        meta = get_playbook("testing-strategies")
+        assert meta is not None
+        broken = meta.model_copy(update={"playbook_file": "missing.md"})
+        with pytest.raises(FileNotFoundError):
+            load_playbook_markdown(broken)

--- a/packages/tapps-mcp/pyproject.toml
+++ b/packages/tapps-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapps-mcp"
-version = "3.12.48"
+version = "3.12.49"
 description = "MCP server providing deterministic code quality tools for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/packages/tapps-mcp/src/tapps_mcp/common/developer_workflow.py
+++ b/packages/tapps-mcp/src/tapps_mcp/common/developer_workflow.py
@@ -81,7 +81,7 @@ def render_workflow_md() -> str:
     lines.extend(
         [
             "",
-            "Use `task_type` in tapps_checklist: feature, bugfix, refactor, security, review, or epic.",
+            "Use `task_type` in tapps_checklist: feature, bugfix, refactor, security, review, qa, frontend, or epic.",
             "",
             "## When to use other tools",
             "",

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_domain_skills.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_domain_skills.py
@@ -1,0 +1,270 @@
+"""Domain and role-flow skill templates (ADR-0025)."""
+
+from __future__ import annotations
+
+_DOMAIN_FINISH = """\
+6. **Close out.** Invoke `/tapps-finish-task` with the task_type from the playbook response. Do not declare done without validate + checklist.
+"""
+
+_DOMAIN_STEP_PLAYBOOK = """\
+1. **Session bootstrap.** Call `tapps_session_start()` if not already called this session.
+2. **Load playbook.** Call `tapps_domain_playbook(domain="{domain}")` (or read bundled checklist from the response). Follow its workflow and checklist.
+3. **Library docs.** For each entry in `lookup_hints`, call `tapps_lookup_docs(library=..., topic=...)` before using those APIs.
+4. **Domain tools.** Run the tools listed in `recommended_tools` on changed files in scope.
+5. **Edit loop.** After each Python file change, call `tapps_quick_check(file_path=...)`.
+"""
+
+_CLAUDE_DOMAIN_TOOLS = (
+    "mcp__nlt-build__tapps_session_start "
+    "mcp__nlt-build__tapps_domain_playbook "
+    "mcp__nlt-build__tapps_lookup_docs "
+    "mcp__nlt-build__tapps_quick_check "
+    "mcp__nlt-build__tapps_validate_changed "
+    "mcp__nlt-build__tapps_checklist"
+)
+
+_CURSOR_DOMAIN_TOOLS = [
+    "tapps_session_start",
+    "tapps_domain_playbook",
+    "tapps_lookup_docs",
+    "tapps_quick_check",
+    "tapps_validate_changed",
+    "tapps_checklist",
+]
+
+
+def _claude_domain_skill(
+    name: str,
+    description: str,
+    domain: str,
+    extra_tools: str = "",
+    extra_steps: str = "",
+    task_type: str = "feature",
+) -> str:
+    tools = _CLAUDE_DOMAIN_TOOLS + (f" {extra_tools}" if extra_tools else "")
+    body = _DOMAIN_STEP_PLAYBOOK.format(domain=domain) + extra_steps + _DOMAIN_FINISH
+    body = body.replace(
+        "task_type from the playbook response",
+        f"task_type={task_type}",
+    )
+    return f"""\
+---
+name: {name}
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  {description}
+allowed-tools: {tools}
+argument-hint: "[file-path or scope]"
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+{body}
+"""
+
+
+def _cursor_domain_skill(
+    name: str,
+    description: str,
+    domain: str,
+    extra_tools: list[str] | None = None,
+    extra_steps: str = "",
+    task_type: str = "feature",
+) -> str:
+    tools = _CURSOR_DOMAIN_TOOLS + (extra_tools or [])
+    tools_yaml = "\n".join(f"  - {t}" for t in tools)
+    body = _DOMAIN_STEP_PLAYBOOK.format(domain=domain) + extra_steps + _DOMAIN_FINISH
+    body = body.replace(
+        "task_type from the playbook response",
+        f"task_type={task_type}",
+    )
+    body = body.replace("`tapps_", "`").replace("mcp__nlt-build__", "")
+    return f"""\
+---
+name: {name}
+description: >-
+  {description}
+mcp_tools:
+{tools_yaml}
+---
+
+Domain playbook workflow — same quality gate as the standard TAPPS pipeline.
+
+{body}
+"""
+
+
+CLAUDE_DOMAIN_SKILLS: dict[str, str] = {
+    "tapps-domain-security": _claude_domain_skill(
+        "tapps-domain-security",
+        "Security-focused TAPPS workflow: playbook, library docs, security scan, and CVE check. "
+        "Use when implementing auth, secrets, input validation, or pre-release security passes.",
+        "security",
+        extra_tools="mcp__nlt-build__tapps_security_scan mcp__nlt-build__tapps_dependency_scan",
+        extra_steps=(
+            "4b. Run `tapps_security_scan` on sensitive changed files.\n"
+            "4c. Run `tapps_dependency_scan` when lockfiles or dependencies changed.\n"
+        ),
+        task_type="security",
+    ),
+    "tapps-domain-testing": _claude_domain_skill(
+        "tapps-domain-testing",
+        "Testing-focused TAPPS workflow: playbook, pytest docs, diff impact, and validation. "
+        "Use when adding tests, fixing test gaps, or validating affected tests after refactors.",
+        "testing-strategies",
+        extra_tools="mcp__nlt-build__tapps_diff_impact mcp__nlt-build__tapps_call_graph",
+        extra_steps="4b. Call `tapps_diff_impact(file_paths=...)` to rank affected tests.\n",
+        task_type="qa",
+    ),
+    "tapps-domain-frontend": _claude_domain_skill(
+        "tapps-domain-frontend",
+        "Frontend/UX TAPPS workflow: playbook, UI library docs, and quality gate on scored files. "
+        "Use when building UI components, accessibility fixes, or client-side routing changes.",
+        "user-experience",
+        extra_tools="mcp__nlt-build__tapps_score_file",
+        task_type="frontend",
+    ),
+    "tapps-flow-develop": """\
+---
+name: tapps-flow-develop
+user-invocable: true
+model: claude-haiku-4-5-20251001
+description: >-
+  Standard feature/bugfix development flow via the shared TAPPS pipeline.
+  Use when starting daily implementation work and you want session start,
+  lookup docs, quick_check loop, and finish-task without a domain specialist.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist Bash
+argument-hint: "[task_type: feature|bugfix]"
+---
+
+1. `tapps_session_start()`
+2. `tapps_lookup_docs` before each external library API
+3. Edit loop: `tapps_quick_check` after Python edits
+4. `/tapps-finish-task` with `task_type=feature` or `bugfix`
+""",
+    "tapps-flow-review": """\
+---
+name: tapps-flow-review
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  QA/review flow: parallel review pipeline or single-file review ending in checklist.
+  Use when reviewing PRs, audit findings, or validating another agent's changes.
+allowed-tools: mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist mcp__nlt-build__tapps_security_scan
+argument-hint: "[file paths]"
+---
+
+Prefer `/tapps-review-pipeline` for multiple Python files. Otherwise:
+
+1. `tapps_security_scan` + `tapps_quick_check` on targets
+2. `/tapps-finish-task` with `task_type=review` or `qa`
+""",
+    "tapps-flow-frontend": """\
+---
+name: tapps-flow-frontend
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  Frontend work flow combining UX playbook and standard finish pipeline.
+  Use when the task is primarily UI/UX implementation or accessibility.
+allowed-tools: mcp__nlt-build__tapps_session_start mcp__nlt-build__tapps_domain_playbook mcp__nlt-build__tapps_lookup_docs mcp__nlt-build__tapps_quick_check mcp__nlt-build__tapps_validate_changed mcp__nlt-build__tapps_checklist
+---
+
+1. Invoke `/tapps-domain-frontend` steps 1–5, **or** run this shortcut:
+   - `tapps_domain_playbook(domain="user-experience")`
+   - `tapps_lookup_docs` for UI libraries in scope
+2. `/tapps-finish-task` with `task_type=frontend`
+3. Optional persona: agency-agents Frontend Developer (voice only; TappsMCP owns gates)
+""",
+}
+
+CURSOR_DOMAIN_SKILLS: dict[str, str] = {
+    "tapps-domain-security": _cursor_domain_skill(
+        "tapps-domain-security",
+        "Security-focused TAPPS workflow: playbook, library docs, security scan, and CVE check. "
+        "Use when implementing auth, secrets, input validation, or pre-release security passes.",
+        "security",
+        extra_tools=["tapps_security_scan", "tapps_dependency_scan"],
+        extra_steps=(
+            "4b. Run `tapps_security_scan` on sensitive changed files.\n"
+            "4c. Run `tapps_dependency_scan` when lockfiles or dependencies changed.\n"
+        ),
+        task_type="security",
+    ),
+    "tapps-domain-testing": _cursor_domain_skill(
+        "tapps-domain-testing",
+        "Testing-focused TAPPS workflow: playbook, pytest docs, diff impact, and validation. "
+        "Use when adding tests, fixing test gaps, or validating affected tests after refactors.",
+        "testing-strategies",
+        extra_tools=["tapps_diff_impact", "tapps_call_graph"],
+        extra_steps="4b. Call `tapps_diff_impact(file_paths=...)` to rank affected tests.\n",
+        task_type="qa",
+    ),
+    "tapps-domain-frontend": _cursor_domain_skill(
+        "tapps-domain-frontend",
+        "Frontend/UX TAPPS workflow: playbook, UI library docs, and quality gate on scored files. "
+        "Use when building UI components, accessibility fixes, or client-side routing changes.",
+        "user-experience",
+        extra_tools=["tapps_score_file"],
+        task_type="frontend",
+    ),
+    "tapps-flow-develop": """\
+---
+name: tapps-flow-develop
+description: >-
+  Standard feature/bugfix development flow via the shared TAPPS pipeline.
+  Use when starting daily implementation work and you want session start,
+  lookup docs, quick_check loop, and finish-task without a domain specialist.
+mcp_tools:
+  - tapps_session_start
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+---
+
+1. `tapps_session_start()`
+2. `tapps_lookup_docs` before each external library API
+3. Edit loop: `tapps_quick_check` after Python edits
+4. `/tapps-finish-task` with `task_type=feature` or `bugfix`
+""",
+    "tapps-flow-review": """\
+---
+name: tapps-flow-review
+description: >-
+  QA/review flow: parallel review pipeline or single-file review ending in checklist.
+  Use when reviewing PRs, audit findings, or validating another agent's changes.
+mcp_tools:
+  - tapps_validate_changed
+  - tapps_checklist
+  - tapps_security_scan
+---
+
+Prefer `/tapps-review-pipeline` for multiple Python files. Otherwise:
+
+1. `tapps_security_scan` + `tapps_quick_check` on targets
+2. `/tapps-finish-task` with `task_type=review` or `qa`
+""",
+    "tapps-flow-frontend": """\
+---
+name: tapps-flow-frontend
+description: >-
+  Frontend work flow combining UX playbook and standard finish pipeline.
+  Use when the task is primarily UI/UX implementation or accessibility.
+mcp_tools:
+  - tapps_session_start
+  - tapps_domain_playbook
+  - tapps_lookup_docs
+  - tapps_quick_check
+  - tapps_validate_changed
+  - tapps_checklist
+---
+
+1. Invoke `/tapps-domain-frontend` steps 1–5, **or** run this shortcut:
+   - `tapps_domain_playbook(domain="user-experience")`
+   - `tapps_lookup_docs` for UI libraries in scope
+2. `/tapps-finish-task` with `task_type=frontend`
+3. Optional persona: agency-agents Frontend Developer (voice only; TappsMCP owns gates)
+""",
+}

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
@@ -1726,6 +1726,14 @@ Post a structured Linear project update document when a new version is released.
 """,
 }
 
+from tapps_mcp.pipeline.platform_domain_skills import (  # noqa: E402
+    CLAUDE_DOMAIN_SKILLS,
+    CURSOR_DOMAIN_SKILLS,
+)
+
+CLAUDE_SKILLS.update(CLAUDE_DOMAIN_SKILLS)
+CURSOR_SKILLS.update(CURSOR_DOMAIN_SKILLS)
+
 
 def generate_skills(
     project_root: Path,

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_subagents.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_subagents.py
@@ -152,6 +152,34 @@ You are a TappsMCP review-fixer agent. For each file assigned to you:
 Be thorough but minimal - only change what is needed to pass the quality gate.
 Do not refactor beyond what the issues require.
 """,
+    "tapps-frontend-reviewer.md": """\
+---
+name: tapps-frontend-reviewer
+description: >-
+  Review UI/UX and frontend changes using domain playbooks and TAPPS quality
+  gates. Use for React, CSS, accessibility, or layout work.
+tools: Read, Glob, Grep, Write, Edit
+model: claude-sonnet-4-6
+maxTurns: 20
+permissionMode: acceptEdits
+memory: project
+skills:
+  - tapps-domain-frontend
+  - tapps-finish-task
+mcpServers:
+  tapps-mcp: {}
+---
+
+You are a TappsMCP frontend reviewer. When invoked:
+
+1. Call `mcp__tapps-mcp__tapps_domain_playbook` with `domain="user-experience"` (or alias `frontend`)
+2. Call `mcp__tapps-mcp__tapps_lookup_docs` for the UI library in use (React, Next.js, etc.)
+3. Review changed files against the playbook checklist (a11y, layout, UX)
+4. Call `mcp__tapps-mcp__tapps_quick_check` on any changed Python/TS files
+5. Summarize findings and recommend `/tapps-finish-task` before declaring done
+
+Optional persona voice: agency-agents Frontend Developer — TappsMCP owns all gates.
+""",
 }
 
 CURSOR_AGENTS: dict[str, str] = {
@@ -255,6 +283,31 @@ You are a TappsMCP review-fixer agent. For each file assigned to you:
 Be thorough but minimal - only change what is needed to pass the quality gate.
 Do not refactor beyond what the issues require.
 """,
+    "tapps-frontend-reviewer.md": """\
+---
+name: tapps-frontend-reviewer
+description: >-
+  Review UI/UX and frontend changes using domain playbooks and TAPPS quality
+  gates. Use for React, CSS, accessibility, or layout work.
+model: sonnet
+readonly: false
+is_background: false
+tools:
+  - code_search
+  - read_file
+  - edit_file
+---
+
+You are a TappsMCP frontend reviewer. When invoked:
+
+1. Call `tapps_domain_playbook` with `domain="user-experience"` (or alias `frontend`)
+2. Call `tapps_lookup_docs` for the UI library in use (React, Next.js, etc.)
+3. Review changed files against the playbook checklist (a11y, layout, UX)
+4. Call `tapps_quick_check` on any changed Python/TS files
+5. Summarize findings and recommend `/tapps-finish-task` before declaring done
+
+Optional persona voice: agency-agents Frontend Developer — TappsMCP owns all gates.
+""",
 }
 
 
@@ -275,7 +328,7 @@ def generate_subagent_definitions(
 ) -> dict[str, Any]:
     """Generate subagent definition files for the given platform.
 
-    Creates 4 agent ``.md`` files in ``.claude/agents/`` or ``.cursor/agents/``
+    Creates 5 agent ``.md`` files in ``.claude/agents/`` or ``.cursor/agents/``
     depending on the platform. Existing files are skipped to preserve
     user customizations unless *overwrite* is ``True`` (used by the
     upgrade path to refresh corrected frontmatter).

--- a/packages/tapps-mcp/src/tapps_mcp/server.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server.py
@@ -252,6 +252,8 @@ ALL_TOOL_NAMES: frozenset[str] = frozenset(
         "tapps_audit_close_coverage",
         # TAP-3895: slim tapps_memory facade on nlt-memory profile only
         "tapps_memory",
+        # ADR-0025: deterministic domain playbooks (deferred on nlt-build)
+        "tapps_domain_playbook",
     }
 )
 
@@ -388,6 +390,7 @@ TOOL_PROFILE_NLT_BUILD: frozenset[str] = frozenset(
         "tapps_dependency_scan",
         "tapps_report",
         "tapps_audit_campaign",
+        "tapps_domain_playbook",
     }
 )
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -1693,3 +1693,12 @@ def register(mcp_instance: FastMCP, allowed_tools: frozenset[str]) -> None:
             annotations=_ANNOTATIONS_READ_ONLY,
             meta=_META_DEFERRED,
         )
+    if "tapps_domain_playbook" in allowed_tools:
+        from tapps_mcp.tools.domain_playbook import tapps_domain_playbook
+
+        register_tool(
+            mcp_instance,
+            tapps_domain_playbook,
+            annotations=_ANNOTATIONS_READ_ONLY,
+            meta=_META_DEFERRED,
+        )

--- a/packages/tapps-mcp/src/tapps_mcp/tool_descriptions.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tool_descriptions.py
@@ -106,6 +106,9 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "tapps_decompose": (
         "Break a vague task into ordered, verifiable TAPPS tool-call steps."
     ),
+    "tapps_domain_playbook": (
+        "Return a bundled domain checklist and suggested TAPPS tool order (deterministic)."
+    ),
     "tapps_linear_snapshot_get": (
         "Cache-first Linear read: return cached issues or signal a cache miss."
     ),

--- a/packages/tapps-mcp/src/tapps_mcp/tools/checklist.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/checklist.py
@@ -217,6 +217,16 @@ TASK_TOOL_MAP: dict[str, dict[str, list[str]]] = {
         "recommended": ["tapps_checklist"],
         "optional": ["tapps_lookup_docs"],
     },
+    "qa": {
+        "required": ["tapps_validate_changed", "tapps_security_scan", "tapps_quality_gate"],
+        "recommended": ["tapps_diff_impact", "tapps_checklist"],
+        "optional": ["tapps_score_file"],
+    },
+    "frontend": {
+        "required": ["tapps_lookup_docs", "tapps_quality_gate"],
+        "recommended": ["tapps_score_file", "tapps_validate_changed", "tapps_checklist"],
+        "optional": ["tapps_quick_check"],
+    },
 }
 
 # High engagement: more tools required (stricter)
@@ -283,6 +293,21 @@ TASK_TOOL_MAP_HIGH: dict[str, dict[str, list[str]]] = {
         "recommended": [],
         "optional": ["tapps_lookup_docs"],
     },
+    "qa": {
+        "required": [
+            "tapps_validate_changed",
+            "tapps_security_scan",
+            "tapps_quality_gate",
+            "tapps_checklist",
+        ],
+        "recommended": ["tapps_diff_impact", "tapps_score_file"],
+        "optional": [],
+    },
+    "frontend": {
+        "required": ["tapps_lookup_docs", "tapps_quality_gate", "tapps_validate_changed"],
+        "recommended": ["tapps_score_file", "tapps_checklist"],
+        "optional": ["tapps_quick_check"],
+    },
 }
 
 # Low engagement: fewer tools required (lighter)
@@ -332,6 +357,16 @@ TASK_TOOL_MAP_LOW: dict[str, dict[str, list[str]]] = {
         "recommended": [],
         "optional": ["tapps_checklist", "tapps_lookup_docs"],
     },
+    "qa": {
+        "required": ["tapps_quality_gate", "tapps_security_scan"],
+        "recommended": ["tapps_validate_changed", "tapps_checklist"],
+        "optional": ["tapps_diff_impact"],
+    },
+    "frontend": {
+        "required": ["tapps_lookup_docs"],
+        "recommended": ["tapps_quality_gate", "tapps_quick_check"],
+        "optional": ["tapps_checklist"],
+    },
 }
 
 # Alias for medium (same as TASK_TOOL_MAP)
@@ -355,6 +390,14 @@ TASK_TYPE_REASONS: dict[str, str] = {
         "Project documentation work: invoke /tapps-docs-bootstrap or /tapps-docs-refresh "
         "skills (nlt-project-docs). Finish with /tapps-docs-finish-task for drift, links, "
         "and completeness checks."
+    ),
+    "qa": (
+        "QA and test-validation work: use /tapps-domain-testing or task_type=qa; "
+        "require validate_changed, security_scan, and diff_impact when tests are in scope."
+    ),
+    "frontend": (
+        "Frontend/UX work: use /tapps-domain-frontend or /tapps-flow-frontend; "
+        "lookup_docs for UI libraries before implementation."
     ),
 }
 

--- a/packages/tapps-mcp/src/tapps_mcp/tools/domain_playbook.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/domain_playbook.py
@@ -1,0 +1,113 @@
+"""Domain playbook MCP tool handler (ADR-0025)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from tapps_core.playbooks.loader import load_playbook_markdown_by_domain
+from tapps_core.playbooks.registry import (
+    did_you_mean_domain,
+    list_domain_ids,
+    resolve_domain_id,
+)
+
+
+def build_domain_playbook_payload(
+    domain: str,
+    *,
+    include_tool_sequence: bool = True,
+) -> dict[str, Any]:
+    """Return deterministic playbook payload for *domain*."""
+    resolved = resolve_domain_id(domain)
+    if resolved is None:
+        suggestions = did_you_mean_domain(domain)
+        return {
+            "ok": False,
+            "domain": domain,
+            "error": "unknown_domain",
+            "available_domains": list_domain_ids(),
+            "did_you_mean": suggestions,
+        }
+
+    meta, markdown = load_playbook_markdown_by_domain(resolved)
+    payload: dict[str, Any] = {
+        "ok": True,
+        "domain": meta.domain_id,
+        "display_name": meta.display_name,
+        "playbook_markdown": markdown,
+        "lookup_hints": [hint.model_dump() for hint in meta.lookup_hints],
+        "checklist_task_type": meta.checklist_task_type,
+        "source": "bundled",
+    }
+    if include_tool_sequence:
+        payload["recommended_tools"] = list(meta.recommended_tools)
+        payload["tool_sequence"] = [
+            "tapps_session_start",
+            *meta.recommended_tools,
+            "tapps_validate_changed",
+            "tapps_checklist",
+        ]
+    return payload
+
+
+async def run_tapps_domain_playbook(
+    domain: str,
+    include_tool_sequence: bool = True,
+) -> dict[str, Any]:
+    """Async wrapper for MCP registration."""
+    return build_domain_playbook_payload(
+        domain,
+        include_tool_sequence=include_tool_sequence,
+    )
+
+
+async def tapps_domain_playbook(
+    domain: str,
+    include_tool_sequence: bool = True,
+) -> dict[str, Any]:
+    """Return a bundled domain checklist and suggested TAPPS tool order.
+
+    Deterministic: same domain input returns the same playbook markdown.
+    Use before domain-specific work (testing, security, frontend) when a skill
+    is not loaded. Does not call external APIs or LLMs.
+
+    Args:
+        domain: Domain id or alias (e.g. ``testing-strategies``, ``security``,
+            ``frontend``, ``ux``).
+        include_tool_sequence: When true (default), include ``recommended_tools``
+            and a suggested ``tool_sequence`` list.
+    """
+    from tapps_mcp.server_helpers import error_response, success_response
+
+    start = time.perf_counter_ns()
+    from tapps_mcp.server import _record_call, _record_execution
+
+    _record_call("tapps_domain_playbook")
+
+    domain = domain.strip()
+    if not domain:
+        elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
+        _record_execution("tapps_domain_playbook", start)
+        return error_response(
+            "tapps_domain_playbook",
+            "MISSING_DOMAIN",
+            "domain is required",
+        )
+
+    data = await run_tapps_domain_playbook(
+        domain,
+        include_tool_sequence=include_tool_sequence,
+    )
+    elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
+    _record_execution("tapps_domain_playbook", start)
+
+    if not data.get("ok"):
+        return error_response(
+            "tapps_domain_playbook",
+            "UNKNOWN_DOMAIN",
+            f"Unknown domain playbook: {domain}",
+            extra={"details": data},
+        )
+
+    return success_response("tapps_domain_playbook", elapsed_ms, data)

--- a/packages/tapps-mcp/src/tapps_mcp/tools/pipeline_init_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/pipeline_init_helpers.py
@@ -279,8 +279,10 @@ def enrich_init_result_hints(
             "YouTube, Sentry, and other MCPs alongside TappsMCP."
         )
     result["agency_agents_hint"] = (
-        "Optional: For more specialized agents (e.g. Frontend Developer, Reality Checker), "
-        "see https://github.com/msitarzewski/agency-agents and run their install script for your platform."
+        "Optional: For persona voice (e.g. Frontend Developer), install "
+        "https://github.com/msitarzewski/agency-agents and pair with TappsMCP "
+        "domain skills (`/tapps-domain-frontend`, `/tapps-flow-frontend`). "
+        "TappsMCP owns quality gates; agency-agents owns tone only."
     )
     result["consumer_requirements"] = (
         "For a full checklist of what you need to use most tools "

--- a/packages/tapps-mcp/tests/unit/test_agent_contract.py
+++ b/packages/tapps-mcp/tests/unit/test_agent_contract.py
@@ -28,8 +28,10 @@ class TestAgentContractConstants:
         assert tapps_mcp_tool_count() == len(ALL_TOOL_NAMES)
 
     def test_post_edit_lookup_messages_unified(self) -> None:
-        assert "before using those APIs" in POST_EDIT_IMPORT_LOOKUP_MSG
-        assert "before using those APIs" in POST_EDIT_IMPORT_LOOKUP_BASH
+        assert "before editing" in POST_EDIT_IMPORT_LOOKUP_MSG
+        assert "code that uses those APIs" in POST_EDIT_IMPORT_LOOKUP_MSG
+        assert "before editing" in POST_EDIT_IMPORT_LOOKUP_BASH
+        assert "code that uses those APIs" in POST_EDIT_IMPORT_LOOKUP_BASH
         assert "before declaring complete" not in POST_EDIT_IMPORT_LOOKUP_BASH
         assert "before writing more code" not in POST_EDIT_IMPORT_LOOKUP_BASH
 

--- a/packages/tapps-mcp/tests/unit/test_domain_playbook.py
+++ b/packages/tapps-mcp/tests/unit/test_domain_playbook.py
@@ -1,0 +1,35 @@
+"""Tests for tapps_domain_playbook MCP tool."""
+
+from __future__ import annotations
+
+import pytest
+
+from tapps_mcp.tools.domain_playbook import build_domain_playbook_payload
+
+
+class TestDomainPlaybookPayload:
+    def test_known_domain_deterministic(self) -> None:
+        first = build_domain_playbook_payload("testing-strategies")
+        second = build_domain_playbook_payload("testing-strategies")
+        assert first == second
+        assert first["ok"] is True
+        assert first["domain"] == "testing-strategies"
+        assert "pytest" in first["playbook_markdown"].lower()
+        assert first["checklist_task_type"] == "qa"
+        assert "tapps_diff_impact" in first["recommended_tools"]
+
+    def test_alias_frontend(self) -> None:
+        payload = build_domain_playbook_payload("frontend")
+        assert payload["ok"] is True
+        assert payload["domain"] == "user-experience"
+
+    def test_unknown_domain(self) -> None:
+        payload = build_domain_playbook_payload("nope")
+        assert payload["ok"] is False
+        assert payload["error"] == "unknown_domain"
+        assert payload["did_you_mean"] == [] or isinstance(payload["did_you_mean"], list)
+
+    def test_without_tool_sequence(self) -> None:
+        payload = build_domain_playbook_payload("security", include_tool_sequence=False)
+        assert "recommended_tools" not in payload
+        assert "tool_sequence" not in payload

--- a/packages/tapps-mcp/tests/unit/test_enabled_tools_config.py
+++ b/packages/tapps-mcp/tests/unit/test_enabled_tools_config.py
@@ -151,7 +151,8 @@ class TestResolveAllowedTools:
         settings.tool_preset = "nlt-build"
         allowed = _resolve_allowed_tools(settings)
         assert allowed == TOOL_PROFILE_NLT_BUILD
-        assert len(allowed) == 18
+        assert len(allowed) == 19
+        assert "tapps_domain_playbook" in allowed
         assert "tapps_dependency_scan" in allowed
 
     def test_preset_nlt_memory(self) -> None:
@@ -287,4 +288,4 @@ class TestToolPresetConstants:
         # + 1 tapps_linear_list_issues (TAP-2010) + 1 tapps_finding_to_story (TAP-2717)
         # + 1 tapps_audit_close_coverage (TAP-2798) + 1 tapps_handoff_save (TAP-3792)
         # + 2 Epic 114 tools (tapps_call_graph, tapps_diff_impact) = 42.
-        assert len(ALL_TOOL_NAMES) == 42
+        assert len(ALL_TOOL_NAMES) == 43

--- a/packages/tapps-mcp/tests/unit/test_platform_domain_skills.py
+++ b/packages/tapps-mcp/tests/unit/test_platform_domain_skills.py
@@ -1,0 +1,21 @@
+"""Tests for domain/flow skill templates."""
+
+from __future__ import annotations
+
+from tapps_mcp.pipeline.platform_domain_skills import CLAUDE_DOMAIN_SKILLS, CURSOR_DOMAIN_SKILLS
+from tapps_mcp.pipeline.platform_skills import CLAUDE_SKILLS, CURSOR_SKILLS
+
+
+class TestPlatformDomainSkills:
+    def test_merged_into_platform_skills(self) -> None:
+        for key in CLAUDE_DOMAIN_SKILLS:
+            assert key in CLAUDE_SKILLS
+        for key in CURSOR_DOMAIN_SKILLS:
+            assert key in CURSOR_SKILLS
+
+    def test_descriptions_have_use_when(self) -> None:
+        for body in CLAUDE_DOMAIN_SKILLS.values():
+            assert "Use when" in body
+
+    def test_domain_testing_mentions_playbook_tool(self) -> None:
+        assert "tapps_domain_playbook" in CLAUDE_DOMAIN_SKILLS["tapps-domain-testing"]

--- a/packages/tapps-mcp/tests/unit/test_platform_generators.py
+++ b/packages/tapps-mcp/tests/unit/test_platform_generators.py
@@ -138,7 +138,7 @@ class TestSubagentTemplates:
     """Verify subagent template dicts."""
 
     def test_claude_agents_count(self) -> None:
-        assert len(CLAUDE_AGENTS) == 4
+        assert len(CLAUDE_AGENTS) == 5
 
     def test_cursor_agents_count(self) -> None:
         assert len(CURSOR_AGENTS) == 4

--- a/packages/tapps-mcp/tests/unit/test_plugin_builder.py
+++ b/packages/tapps-mcp/tests/unit/test_plugin_builder.py
@@ -87,7 +87,7 @@ class TestPluginAgents:
         agents_dir = plugin_dir / "agents"
         assert agents_dir.exists()
         agent_files = list(agents_dir.glob("*.md"))
-        assert len(agent_files) == 4
+        assert len(agent_files) == 5
 
     def test_agent_names(self, plugin_dir: Path) -> None:
         builder = PluginBuilder(output_dir=plugin_dir)

--- a/packages/tapps-mcp/tests/unit/test_subagent_generation.py
+++ b/packages/tapps-mcp/tests/unit/test_subagent_generation.py
@@ -1,6 +1,6 @@
 """Tests for subagent definition generation (Story 12.6).
 
-Verifies that generate_subagent_definitions() creates 4 agent .md files per
+Verifies that generate_subagent_definitions() creates 5 agent .md files per
 platform with correct YAML frontmatter format differences between Claude Code
 and Cursor.
 """
@@ -20,6 +20,7 @@ class TestClaudeAgents:
         assert (agents_dir / "tapps-researcher.md").exists()
         assert (agents_dir / "tapps-validator.md").exists()
         assert (agents_dir / "tapps-review-fixer.md").exists()
+        assert (agents_dir / "tapps-frontend-reviewer.md").exists()
 
     def test_reviewer_has_comma_separated_tools(self, tmp_path):
         generate_subagent_definitions(tmp_path, "claude")
@@ -230,6 +231,7 @@ class TestCursorAgents:
         assert (agents_dir / "tapps-researcher.md").exists()
         assert (agents_dir / "tapps-validator.md").exists()
         assert (agents_dir / "tapps-review-fixer.md").exists()
+        assert (agents_dir / "tapps-frontend-reviewer.md").exists()
 
     def test_review_fixer_has_edit_tools(self, tmp_path):
         generate_subagent_definitions(tmp_path, "cursor")

--- a/packages/tapps-mcp/tests/unit/test_tool_annotations.py
+++ b/packages/tapps-mcp/tests/unit/test_tool_annotations.py
@@ -172,9 +172,9 @@ class TestAnnotationCategories:
         # + 1 tapps_linear_count (TAP-1847) + 1 tapps_audit_campaign (TAP-2036)
         # + 1 tapps_usage (v3.11.0) + 1 tapps_linear_list_issues (TAP-2010)
         # + 1 tapps_finding_to_story (TAP-2717) + 1 tapps_memory (TAP-3895)
-        # + 2 Epic 114 read-only tools = 30
-        assert len(read_only) == 30, (
-            f"Expected 28 read-only tools, got {len(read_only)}"
+        # + 2 Epic 114 read-only tools + 1 tapps_domain_playbook (ADR-0025) = 31
+        assert len(read_only) == 31, (
+            f"Expected 31 read-only tools, got {len(read_only)}"
         )
 
     def test_side_effect_count(self) -> None:
@@ -215,9 +215,9 @@ class TestAnnotationCategories:
         # + 1 tapps_usage (v3.11.0) + 1 tapps_linear_list_issues (TAP-2010)
         # + 1 tapps_finding_to_story (TAP-2717)
         # + 1 tapps_audit_close_coverage (TAP-2798) + 1 tapps_handoff_save (TAP-3792)
-        # + 1 tapps_memory (TAP-3895) + 2 Epic 114 tools = 37
-        assert len(idempotent) == 37, (
-            f"Expected 35 idempotent tools, got {len(idempotent)}: {sorted(idempotent)}"
+        # + 1 tapps_memory (TAP-3895) + 2 Epic 114 tools + 1 tapps_domain_playbook = 38
+        assert len(idempotent) == 38, (
+            f"Expected 38 idempotent tools, got {len(idempotent)}: {sorted(idempotent)}"
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "docs-mcp"
-version = "3.12.48"
+version = "3.12.49"
 source = { editable = "packages/docs-mcp" }
 dependencies = [
     { name = "click" },
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "tapps-core"
-version = "3.12.48"
+version = "3.12.49"
 source = { editable = "packages/tapps-core" }
 dependencies = [
     { name = "httpx" },
@@ -2792,7 +2792,7 @@ provides-extras = ["vector", "reranker"]
 
 [[package]]
 name = "tapps-mcp"
-version = "3.12.48"
+version = "3.12.49"
 source = { editable = "packages/tapps-mcp" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Adds **light domain playbooks** ([ADR-0025](docs/adr/0025-light-domain-playbooks-not-rag-experts.md)): bundled markdown checklists in `tapps_core.playbooks`, deterministic `tapps_domain_playbook` MCP tool (43 tools), and six new skills (`tapps-domain-*`, `tapps-flow-*`).
- Restores **DocsMCP epic/story enrichment** via static playbook excerpts (replaces EPIC-94 no-op).
- Adds **`qa` / `frontend` checklist task types**, **`tapps-frontend-reviewer`** subagent, and updated agency-agents pairing hint in `tapps_init`.
- Bumps version to **3.12.49**.

## Test plan

- [x] `pytest packages/tapps-core/tests/unit/test_playbook_registry.py`
- [x] `pytest packages/tapps-mcp/tests/unit/test_domain_playbook.py packages/tapps-mcp/tests/unit/test_platform_domain_skills.py packages/tapps-mcp/tests/unit/test_enabled_tools_config.py packages/tapps-mcp/tests/unit/test_tool_annotations.py packages/tapps-mcp/tests/unit/test_subagent_generation.py`
- [x] `pytest packages/docs-mcp/tests/unit/test_domain_enrichment.py` + epic/story enrichment tests
- [x] Pre-commit validate-changed on staged Python files (29/29 pass)
- [x] `tapps-mcp deploy-local --skip-gate` → release `3.12.49-*` flipped to `~/.tapps-mcp/current`
- [ ] Reload MCP in Cursor and call `tapps_domain_playbook(domain="security")`
- [ ] Try `/tapps-domain-testing` or `/tapps-flow-develop` on a real task


Made with [Cursor](https://cursor.com)