### PR TITLE
feat(review): attach diff-impact blast radius to review output (TAP-4526)

### DIFF
--- a/docs/CALL_GRAPH.md
+++ b/docs/CALL_GRAPH.md
@@ -16,6 +16,40 @@ Module-level import impact remains `tapps_impact_analysis` without `symbol`. Cal
 
 ---
 
+## Review path: `diff_impact` blast radius (TAP-4526)
+
+`tapps_validate_changed(include_impact=true)` — the reviewer's batch entry point —
+attaches a `diff_impact` block to its response. For each changed Python **symbol**
+it reports, reusing the existing call graph (no new analysis, no LLM, no network,
+per [ADR-0004](adr/0004-deterministic-tools-only-contract.md)):
+
+- `callers` — in-repo functions/methods that call the symbol (from static CALLS edges).
+- `affected_tests` — ranked `{test_file, test_symbol}` pairs that exercise it (TESTS edges).
+
+Shape:
+
+```json
+"diff_impact": {
+  "cache_status": "ready",
+  "degraded": false,
+  "symbols": {
+    "pkg.mod.changed_fn": {
+      "callers": ["pkg.mod.caller_a", "pkg.other.caller_b"],
+      "affected_tests": [{"test_file": "tests/test_mod.py", "test_symbol": "test_changed_fn"}]
+    }
+  },
+  "changed_files": ["pkg/mod.py"]
+}
+```
+
+**Graceful degradation:** when the call-graph cache is missing or stale, the block
+is still present with `degraded: true` and a `note` (empty `symbols`) rather than
+raising. Rebuild via `tapps_call_graph` or `tapps_diff_impact(force_rebuild=true)`,
+then re-review. This is distinct from the flat, cross-change-set `affected_tests`
+block: `diff_impact` is keyed **per symbol** and adds each symbol's callers.
+
+---
+
 ## Local cache (not in git)
 
 The index is written to:

--- a/packages/tapps-mcp/src/tapps_mcp/project/diff_impact.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/diff_impact.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from tapps_mcp.pipeline.agent_contract import CALL_GRAPH_STALE_HINT
 from tapps_mcp.project.call_graph import build_call_graph_index
 from tapps_mcp.project.call_graph_queries import resolve_symbol_name
 from tapps_mcp.project.impact_analyzer import analyze_impact, build_import_graph
@@ -175,6 +176,113 @@ def analyze_diff_impact(
     }
     if doc_drift_hints:
         payload["doc_drift_hints"] = doc_drift_hints
+    return payload
+
+
+def build_diff_impact_enrichment(
+    changed_files: list[Path],
+    project_root: Path,
+    *,
+    max_callers: int = 10,
+    max_tests: int = 10,
+) -> dict[str, object]:
+    """Per-changed-symbol callers + ranked affected tests for the review path (TAP-4526).
+
+    Deterministic (ADR-0004): reuses the cached call-graph index and TESTS edges.
+    Never rebuilds the index and never hits the network / an LLM. When the
+    call-graph cache is missing or stale, returns a ``degraded`` block with a
+    ``note`` and empty ``symbols`` — the caller must not crash.
+
+    Returns a dict shaped::
+
+        {
+            "degraded": bool,
+            "note": str,                # present only when degraded
+            "cache_status": str,        # missing | unreadable | stale | ready
+            "symbols": {
+                "<qualified_name>": {
+                    "callers": ["<qualified caller>", ...],   # in-repo only
+                    "affected_tests": [{"test_file", "test_symbol"}, ...],
+                },
+                ...,
+            },
+            "changed_files": ["...", ...],
+        }
+    """
+    from tapps_mcp.project.call_graph_cache import (
+        load_call_graph_index,
+        summarize_call_graph_cache,
+    )
+
+    changed_paths = [str(p) for p in changed_files]
+
+    cache = summarize_call_graph_cache(project_root)
+    status = str(cache.get("status", "missing"))
+    if status != "ready":
+        note = str(
+            cache.get("hint")
+            or "Call-graph cache is missing or stale — run tapps_call_graph or "
+            "tapps_diff_impact(force_rebuild=True) to enable diff-impact enrichment."
+        )
+        return {
+            "degraded": True,
+            "note": note,
+            "cache_status": status,
+            "symbols": {},
+            "changed_files": changed_paths,
+        }
+
+    index = load_call_graph_index(project_root)
+    if index is None:
+        return {
+            "degraded": True,
+            "note": CALL_GRAPH_STALE_HINT,
+            "cache_status": "unreadable",
+            "symbols": {},
+            "changed_files": changed_paths,
+        }
+
+    from tapps_mcp.project.test_linker import build_test_edges, get_tests_for_symbol
+
+    test_edges = build_test_edges(index, project_root=project_root)
+
+    symbols_out: dict[str, dict[str, object]] = {}
+    for changed in changed_files:
+        try:
+            rel = str(changed.resolve().relative_to(project_root.resolve()))
+        except ValueError:
+            rel = str(changed)
+        for sym in sorted(_symbols_in_file(index, rel.replace("\\", "/"))):
+            if sym in symbols_out:
+                continue
+            callers = [
+                edge.caller
+                for edge in index.callers_of(sym)[:max_callers]
+            ]
+            tests = get_tests_for_symbol(test_edges, sym, index=index)[:max_tests]
+            symbols_out[sym] = {
+                "callers": callers,
+                "affected_tests": [
+                    {
+                        "test_file": str(t.get("test_file", "")),
+                        "test_symbol": str(t.get("test_symbol", "")),
+                    }
+                    for t in tests
+                ],
+            }
+
+    degraded = bool(index.resolution_gaps or index.parse_failures)
+    payload: dict[str, object] = {
+        "degraded": degraded,
+        "cache_status": status,
+        "symbols": symbols_out,
+        "changed_files": changed_paths,
+    }
+    if degraded:
+        payload["note"] = (
+            f"Call graph has {len(index.resolution_gaps)} unresolved reference(s) and "
+            f"{len(index.parse_failures)} parse failure(s) — some callers/tests may be missing."
+        )
     return payload
 
 

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
@@ -69,11 +69,13 @@ from tapps_mcp.tools.validate_changed_output import (
     _build_response_data,
     _build_structured_validation_output,
     _build_validation_summary,
+    _compute_diff_impact,
     _handle_no_changed_files,
     _resolve_security_depth,
     _run_judges,
     apply_judge_payload,
     attach_affected_tests,
+    attach_diff_impact,
 )
 from tapps_mcp.tools.validation_progress import (
     _PROGRESS_HEARTBEAT_INTERVAL,
@@ -212,6 +214,7 @@ class _BatchOutcome:
     total_sec: int
     impact_data: dict[str, Any] | None
     affected_tests_data: dict[str, Any] | None
+    diff_impact_data: dict[str, Any] | None
     timeout_info: _TimedOutInfo
 
 
@@ -336,6 +339,11 @@ def _finalize_outcome(
         if bc.include_impact and bc.paths
         else None
     )
+    diff_impact_data = (
+        _compute_diff_impact(bc.paths, bc.settings.project_root)
+        if bc.include_impact and bc.paths
+        else None
+    )
 
     if not all_passed:
         _record_call("tapps_validate_changed", success=False)
@@ -348,6 +356,7 @@ def _finalize_outcome(
         total_sec=total_sec,
         impact_data=impact_data,
         affected_tests_data=affected_tests_data,
+        diff_impact_data=diff_impact_data,
         timeout_info=timeout_info,
     )
 
@@ -413,6 +422,7 @@ async def _assemble_response(
         outcome.impact_data,
     )
     attach_affected_tests(resp_data, outcome.affected_tests_data)
+    attach_diff_impact(resp_data, outcome.diff_impact_data)
     _attach_optional_payload(
         resp_data,
         paths=bc.paths,

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
@@ -112,6 +112,37 @@ def _compute_affected_tests(
         return {"error": "affected tests analysis failed"}
 
 
+def _compute_diff_impact(
+    paths: list[Path],
+    project_root: Path,
+) -> dict[str, Any] | None:
+    """Per-changed-symbol callers + ranked affected tests (TAP-4526).
+
+    Deterministic reuse of the cached call graph. Degrades gracefully (a
+    ``degraded`` block with a ``note``) when the cache is missing or stale —
+    never raises. Only source (non-test) Python files are enriched.
+    """
+    from tapps_mcp.project.diff_impact import build_diff_impact_enrichment
+    from tapps_mcp.project.impact_analyzer import _is_test_file
+
+    py_sources = [
+        p
+        for p in paths
+        if p.suffix in {".py", ".pyi"} and p.exists() and not _is_test_file(p)
+    ]
+    if not py_sources:
+        return None
+    try:
+        return build_diff_impact_enrichment(py_sources, project_root)
+    except Exception:
+        _logger.debug("diff_impact_enrichment_failed", exc_info=True)
+        return {
+            "degraded": True,
+            "note": "diff-impact enrichment failed",
+            "symbols": {},
+        }
+
+
 def _build_structured_validation_output(
     results: list[dict[str, Any]],
     all_passed: bool,
@@ -372,6 +403,15 @@ def attach_affected_tests(
     """Add optional affected_tests block when diff-impact ranking is available."""
     if affected_tests_data is not None:
         resp_data["affected_tests"] = affected_tests_data
+
+
+def attach_diff_impact(
+    resp_data: dict[str, Any],
+    diff_impact_data: dict[str, Any] | None,
+) -> None:
+    """Add optional per-symbol diff_impact block (callers + affected tests, TAP-4526)."""
+    if diff_impact_data is not None:
+        resp_data["diff_impact"] = diff_impact_data
 
 
 def _build_judge_summary_rows(judge_results: list[dict[str, Any]]) -> list[str]:

--- a/packages/tapps-mcp/tests/unit/test_diff_impact.py
+++ b/packages/tapps-mcp/tests/unit/test_diff_impact.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tapps_mcp.project.diff_impact import analyze_diff_impact
+from tapps_mcp.project.diff_impact import (
+    analyze_diff_impact,
+    build_diff_impact_enrichment,
+)
 
 
 def _write(root: Path, rel: str, source: str) -> None:
@@ -90,3 +93,71 @@ def compute():
         assert len(hints) >= 1
         assert hints[0]["direct_callers"] >= 5
         assert hints[0]["suggested_doc_paths"]
+
+
+class TestDiffImpactEnrichment:
+    """Per-changed-symbol callers + affected tests for the review path (TAP-4526)."""
+
+    def test_enrichment_reports_callers_and_tests(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/core.py",
+            """
+def compute():
+    return 42
+""",
+        )
+        _write(
+            tmp_path,
+            "app/caller.py",
+            """
+def do_work():
+    from app.core import compute
+    return compute()
+""",
+        )
+        _write(
+            tmp_path,
+            "tests/test_core.py",
+            """
+from app.core import compute
+
+def test_compute():
+    assert compute() == 42
+""",
+        )
+        changed = tmp_path / "app/core.py"
+        # Warm the cache first so the enrichment has a ready index to read.
+        analyze_diff_impact([changed], tmp_path)
+
+        result = build_diff_impact_enrichment([changed], tmp_path)
+
+        assert result["degraded"] is False
+        assert result["cache_status"] == "ready"
+        symbols = result["symbols"]
+        assert isinstance(symbols, dict)
+        # The changed symbol is keyed by its qualified name.
+        key = next(k for k in symbols if k.endswith("compute"))
+        entry = symbols[key]
+        assert any("do_work" in c for c in entry["callers"])
+        assert any(
+            "tests/test_core.py" in t["test_file"] for t in entry["affected_tests"]
+        )
+
+    def test_degrades_when_cache_missing(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/core.py",
+            """
+def compute():
+    return 42
+""",
+        )
+        changed = tmp_path / "app/core.py"
+        # No cache warmed — enrichment must degrade gracefully, not raise.
+        result = build_diff_impact_enrichment([changed], tmp_path)
+
+        assert result["degraded"] is True
+        assert result["cache_status"] == "missing"
+        assert result["symbols"] == {}
+        assert result["note"]

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_event_emit.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_event_emit.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
-from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -36,6 +36,7 @@ def _make_outcome(
         total_sec=total_sec,
         impact_data=None,
         affected_tests_data=None,
+        diff_impact_data=None,
         timeout_info=_TimedOutInfo(timed_out=False, files_remaining=[]),
     )
 

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_p0.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_p0.py
@@ -229,6 +229,71 @@ class TestValidateChangedP0:
         assert affected["affected_tests"][0]["test_file"]
 
     @pytest.mark.asyncio
+    async def test_include_impact_returns_diff_impact_enrichment(
+        self, tmp_path: Path
+    ) -> None:
+        """include_impact=True attaches per-symbol diff_impact enrichment (TAP-4526)."""
+        from tapps_mcp.project.call_graph import build_call_graph_index
+        from tapps_mcp.server_pipeline_tools import tapps_validate_changed
+
+        src = tmp_path / "app" / "core.py"
+        src.parent.mkdir(parents=True)
+        src.write_text("def compute():\n    return 42\n", encoding="utf-8")
+        caller = tmp_path / "app" / "caller.py"
+        caller.write_text(
+            "def do_work():\n    from app.core import compute\n    return compute()\n",
+            encoding="utf-8",
+        )
+        test_file = tmp_path / "tests" / "test_core.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            "from app.core import compute\n\ndef test_compute():\n    assert compute() == 42\n",
+            encoding="utf-8",
+        )
+        # Warm the call-graph cache so the enrichment has a ready index.
+        build_call_graph_index(tmp_path, force_rebuild=True)
+
+        scorer = _mock_scorer()
+        mock_gate = MagicMock(passed=True, failures=[])
+        mock_report = _mock_impact_report(str(src), severity="low")
+
+        with (
+            patch("tapps_mcp.server_pipeline_tools.load_settings") as mock_settings,
+            patch("tapps_mcp.server._validate_file_path", side_effect=Path),
+            patch("tapps_mcp.scoring.scorer.CodeScorer", return_value=scorer),
+            patch("tapps_mcp.gates.evaluator.evaluate_gate", return_value=mock_gate),
+            patch(
+                "tapps_mcp.project.impact_analyzer.build_import_graph",
+                return_value={},
+            ),
+            patch(
+                "tapps_mcp.project.impact_analyzer.analyze_impact",
+                return_value=mock_report,
+            ),
+        ):
+            mock_settings.return_value.project_root = tmp_path
+            mock_settings.return_value.tool_timeout = 30
+            mock_settings.return_value.dependency_scan_enabled = False
+
+            result = await tapps_validate_changed(
+                file_paths=str(src),
+                quick=True,
+                include_impact=True,
+            )
+
+        assert result["success"] is True
+        diff_impact = result["data"].get("diff_impact")
+        assert diff_impact is not None
+        assert diff_impact["degraded"] is False
+        symbols = diff_impact["symbols"]
+        key = next(k for k in symbols if k.endswith("compute"))
+        assert any("do_work" in c for c in symbols[key]["callers"])
+        assert any(
+            "tests/test_core.py" in t["test_file"]
+            for t in symbols[key]["affected_tests"]
+        )
+
+    @pytest.mark.asyncio
     async def test_include_impact_false_no_summary(self, tmp_path: Path) -> None:
         """include_impact=False should NOT include impact_summary."""
         from tapps_mcp.server_pipeline_tools import tapps_validate_changed


### PR DESCRIPTION
Closes TAP-4526 (Tier 1 of TAP-4525).

## What
Wires the existing Python call graph + `tapps_diff_impact` into the review path (`tapps_validate_changed`), so a change-set review reports, per changed symbol, its in-repo callers and ranked affected tests — reusing the cached index, no rebuild, no LLM (ADR-0004).

## Changes
- New `project/diff_impact.py` — deterministic `build_diff_impact_enrichment` over `load_call_graph_index` + TESTS edges.
- `tools/validate_changed.py` / `validate_changed_output.py` — attach a `diff_impact` block; graceful `degraded` note when the cache is missing/stale.
- 3 new tests (25 passed in the touched suites); `docs/CALL_GRAPH.md` documents the block.

Note: `.claude/agents/tapps-reviewer.md` is write-protected by a repo hook, so reviewer-facing behavior is documented in `docs/CALL_GRAPH.md` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)