### PR TITLE
feat(review): add blast-radius caveat from call-graph health (TAP-4528)

### DIFF
--- a/docs/CALL_GRAPH.md
+++ b/docs/CALL_GRAPH.md
@@ -48,6 +48,36 @@ raising. Rebuild via `tapps_call_graph` or `tapps_diff_impact(force_rebuild=true
 then re-review. This is distinct from the flat, cross-change-set `affected_tests`
 block: `diff_impact` is keyed **per symbol** and adds each symbol's callers.
 
+### `blast_radius_caveat` — incomplete-impact trust signal (TAP-4528)
+
+When a reviewed change lands in a region where the call graph is **materially
+incomplete**, the review verdict carries a top-level `blast_radius_caveat` so
+agents know the impact analysis (callers / affected tests) may be partial:
+
+```json
+"blast_radius_caveat": {
+  "degraded": true,
+  "in_repo_gap_rate": 0.42,
+  "parse_failures": 0,
+  "reason": "high_in_repo_gap_rate",
+  "note": "In-repo call-graph gap rate is 42% (threshold 10%) — many in-repo references are unresolved, so this change's blast radius may be incomplete."
+}
+```
+
+- **`reason`** is one of `cache_not_ready` (cache missing / stale / unreadable —
+  impact could not be computed), `parse_failures` (≥ 1 file failed to parse), or
+  `high_in_repo_gap_rate` (in-repo gap rate `>=` the 10% threshold).
+- The caveat is **derived from `summarize_call_graph_cache` output** — it is a
+  read of the same health metrics below, not a new analysis pass (deterministic,
+  ADR-0004: no LLM / no network).
+- **Healthy / low-gap regions produce no caveat** — the field is absent, so
+  clean reviews stay clean (no false alarms). A handful of stray unresolved
+  external references (below the 10% in-repo threshold, zero parse failures) is
+  normal and does **not** trip it.
+
+The field sits beside `diff_impact` on `tapps_validate_changed` output when
+`include_impact=true` and source (non-test) Python files are in the change set.
+
 ---
 
 ## Local cache (not in git)

--- a/packages/tapps-mcp/src/tapps_mcp/project/diff_impact.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/diff_impact.py
@@ -14,6 +14,12 @@ from tapps_mcp.project.test_linker import build_test_edges, edges_for_symbols
 DEFAULT_AFFECTED_TESTS_LIMIT = 20
 DEFAULT_DOC_DRIFT_CALLER_THRESHOLD = 5
 
+# Blast-radius caveat: in-repo gap rate at or above this fraction of edges means
+# the impact analysis is materially incomplete and the review verdict should say so.
+# Below the threshold (a handful of stray unresolved refs) is normal and must NOT
+# raise a caveat — otherwise every healthy review gets a false alarm (TAP-4528).
+BLAST_RADIUS_GAP_RATE_THRESHOLD = 0.10
+
 
 @dataclass
 class RankedTest:
@@ -97,7 +103,9 @@ def analyze_diff_impact(
 
     ranked: dict[str, RankedTest] = {}
 
-    def bump(test_file: str, score: float, reason: str, test_sym: str = "", code_sym: str = "") -> None:
+    def bump(
+        test_file: str, score: float, reason: str, test_sym: str = "", code_sym: str = ""
+    ) -> None:
         entry = ranked.get(test_file)
         if entry is None:
             entry = RankedTest(test_file, 0.0, [], [], [])
@@ -255,10 +263,7 @@ def build_diff_impact_enrichment(
         for sym in sorted(_symbols_in_file(index, rel.replace("\\", "/"))):
             if sym in symbols_out:
                 continue
-            callers = [
-                edge.caller
-                for edge in index.callers_of(sym)[:max_callers]
-            ]
+            callers = [edge.caller for edge in index.callers_of(sym)[:max_callers]]
             tests = get_tests_for_symbol(test_edges, sym, index=index)[:max_tests]
             symbols_out[sym] = {
                 "callers": callers,
@@ -284,6 +289,100 @@ def build_diff_impact_enrichment(
             f"{len(index.parse_failures)} parse failure(s) — some callers/tests may be missing."
         )
     return payload
+
+
+def caveat_from_call_graph_summary(
+    summary: dict[str, object],
+    *,
+    gap_rate_threshold: float = BLAST_RADIUS_GAP_RATE_THRESHOLD,
+) -> dict[str, object] | None:
+    """Map a ``summarize_call_graph_cache`` summary → optional blast-radius caveat.
+
+    Deterministic (ADR-0004): consumes the already-computed cache summary — no
+    new analysis pass, no index rebuild, no network / LLM. Returns ``None`` for a
+    healthy / low-gap region (no false alarms, TAP-4528 AC2) and a caveat dict
+    when the call graph is materially incomplete::
+
+        {
+            "degraded": True,
+            "in_repo_gap_rate": 0.42,
+            "parse_failures": 2,
+            "reason": "parse_failures" | "high_in_repo_gap_rate" | "cache_not_ready",
+            "note": "<human-readable caveat>",
+        }
+
+    A caveat is raised when ANY of:
+      * the cache is not ready (missing / stale / unreadable) — impact analysis
+        could not run at all, so the blast radius is unknown;
+      * one or more files failed to parse (``parse_failures > 0``);
+      * the in-repo gap rate meets ``gap_rate_threshold`` — enough unresolved
+        in-repo references that callers/tests are likely missing.
+    """
+    status = str(summary.get("status", "missing"))
+    raw_parse_failures = summary.get("parse_failures", 0) or 0
+    raw_gap_rate = summary.get("in_repo_gap_rate", 0.0) or 0.0
+    parse_failures = int(raw_parse_failures) if isinstance(raw_parse_failures, (int, float)) else 0
+    in_repo_gap_rate = float(raw_gap_rate) if isinstance(raw_gap_rate, (int, float)) else 0.0
+
+    if status != "ready":
+        note = str(
+            summary.get("hint")
+            or "Call-graph cache is not ready — the reviewed change's blast radius "
+            "could not be computed, so impact analysis may be partial. Run "
+            "tapps_call_graph or tapps_diff_impact(force_rebuild=True) to rebuild it."
+        )
+        return {
+            "degraded": True,
+            "in_repo_gap_rate": in_repo_gap_rate,
+            "parse_failures": parse_failures,
+            "reason": "cache_not_ready",
+            "note": note,
+        }
+
+    if parse_failures > 0:
+        return {
+            "degraded": True,
+            "in_repo_gap_rate": in_repo_gap_rate,
+            "parse_failures": parse_failures,
+            "reason": "parse_failures",
+            "note": (
+                f"{parse_failures} file(s) failed to parse — the call graph is "
+                "incomplete for those modules, so this change's blast radius "
+                "(callers / affected tests) may be partial."
+            ),
+        }
+
+    if in_repo_gap_rate >= gap_rate_threshold:
+        return {
+            "degraded": True,
+            "in_repo_gap_rate": in_repo_gap_rate,
+            "parse_failures": parse_failures,
+            "reason": "high_in_repo_gap_rate",
+            "note": (
+                f"In-repo call-graph gap rate is {in_repo_gap_rate:.0%} "
+                f"(threshold {gap_rate_threshold:.0%}) — many in-repo references "
+                "are unresolved, so this change's blast radius may be incomplete."
+            ),
+        }
+
+    return None
+
+
+def build_blast_radius_caveat(
+    project_root: Path,
+    *,
+    gap_rate_threshold: float = BLAST_RADIUS_GAP_RATE_THRESHOLD,
+) -> dict[str, object] | None:
+    """Load the call-graph cache summary and derive a blast-radius caveat (TAP-4528).
+
+    Thin convenience over :func:`caveat_from_call_graph_summary` for callers that
+    do not already hold a summary. Deterministic: reuses
+    ``summarize_call_graph_cache`` output only. Returns ``None`` when healthy.
+    """
+    from tapps_mcp.project.call_graph_cache import summarize_call_graph_cache
+
+    summary = summarize_call_graph_cache(project_root)
+    return caveat_from_call_graph_summary(summary, gap_rate_threshold=gap_rate_threshold)
 
 
 def export_test_map(

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed.py
@@ -69,12 +69,14 @@ from tapps_mcp.tools.validate_changed_output import (
     _build_response_data,
     _build_structured_validation_output,
     _build_validation_summary,
+    _compute_blast_radius_caveat,
     _compute_diff_impact,
     _handle_no_changed_files,
     _resolve_security_depth,
     _run_judges,
     apply_judge_payload,
     attach_affected_tests,
+    attach_blast_radius_caveat,
     attach_diff_impact,
 )
 from tapps_mcp.tools.validation_progress import (
@@ -215,6 +217,7 @@ class _BatchOutcome:
     impact_data: dict[str, Any] | None
     affected_tests_data: dict[str, Any] | None
     diff_impact_data: dict[str, Any] | None
+    blast_radius_caveat: dict[str, Any] | None
     timeout_info: _TimedOutInfo
 
 
@@ -282,9 +285,7 @@ async def _execute_validation_batch(
     _maybe_warm_dependency_cache(bc.settings, bc.quick)
 
     sem = asyncio.Semaphore(_VALIDATE_CONCURRENCY)
-    do_security_full = _resolve_security_depth(
-        bc.security_depth, bc.include_security, bc.quick
-    )
+    do_security_full = _resolve_security_depth(bc.security_depth, bc.include_security, bc.quick)
 
     tasks = [
         asyncio.create_task(
@@ -344,6 +345,11 @@ def _finalize_outcome(
         if bc.include_impact and bc.paths
         else None
     )
+    blast_radius_caveat = (
+        _compute_blast_radius_caveat(bc.paths, bc.settings.project_root)
+        if bc.include_impact and bc.paths
+        else None
+    )
 
     if not all_passed:
         _record_call("tapps_validate_changed", success=False)
@@ -357,6 +363,7 @@ def _finalize_outcome(
         impact_data=impact_data,
         affected_tests_data=affected_tests_data,
         diff_impact_data=diff_impact_data,
+        blast_radius_caveat=blast_radius_caveat,
         timeout_info=timeout_info,
     )
 
@@ -405,9 +412,7 @@ async def _assemble_response(
     """Build the final response dict from batch context + outcome."""
     from tapps_mcp.server import _with_nudges
 
-    summary = _build_validation_summary(
-        outcome.results, bc.quick, bc.capped, bc.extra_count
-    )
+    summary = _build_validation_summary(outcome.results, bc.quick, bc.capped, bc.extra_count)
     per_file_results, summary_rows = _build_per_file_results(outcome.results)
     elapsed_ms = (time.perf_counter_ns() - bc.start) // 1_000_000
     bc.tracker.finalize(outcome.all_passed, summary, elapsed_ms)
@@ -423,6 +428,7 @@ async def _assemble_response(
     )
     attach_affected_tests(resp_data, outcome.affected_tests_data)
     attach_diff_impact(resp_data, outcome.diff_impact_data)
+    attach_blast_radius_caveat(resp_data, outcome.blast_radius_caveat)
     _attach_optional_payload(
         resp_data,
         paths=bc.paths,

--- a/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/validate_changed_output.py
@@ -92,9 +92,7 @@ def _compute_affected_tests(
     from tapps_mcp.project.impact_analyzer import _is_test_file
 
     py_sources = [
-        p
-        for p in paths
-        if p.suffix in {".py", ".pyi"} and p.exists() and not _is_test_file(p)
+        p for p in paths if p.suffix in {".py", ".pyi"} and p.exists() and not _is_test_file(p)
     ]
     if not py_sources:
         return None
@@ -126,9 +124,7 @@ def _compute_diff_impact(
     from tapps_mcp.project.impact_analyzer import _is_test_file
 
     py_sources = [
-        p
-        for p in paths
-        if p.suffix in {".py", ".pyi"} and p.exists() and not _is_test_file(p)
+        p for p in paths if p.suffix in {".py", ".pyi"} and p.exists() and not _is_test_file(p)
     ]
     if not py_sources:
         return None
@@ -141,6 +137,46 @@ def _compute_diff_impact(
             "note": "diff-impact enrichment failed",
             "symbols": {},
         }
+
+
+def _compute_blast_radius_caveat(
+    paths: list[Path],
+    project_root: Path,
+) -> dict[str, Any] | None:
+    """Derive an incomplete-blast-radius caveat from call-graph health (TAP-4528).
+
+    Deterministic reuse of ``summarize_call_graph_cache`` — no new analysis pass,
+    no network / LLM (ADR-0004). Returns ``None`` for a healthy / low-gap region
+    (no false alarms) and a machine-readable caveat dict (with a human-readable
+    ``note``) when the call graph is materially incomplete. Only relevant when
+    source (non-test) Python files are in the change set.
+    """
+    from tapps_mcp.project.diff_impact import build_blast_radius_caveat
+    from tapps_mcp.project.impact_analyzer import _is_test_file
+
+    py_sources = [
+        p for p in paths if p.suffix in {".py", ".pyi"} and p.exists() and not _is_test_file(p)
+    ]
+    if not py_sources:
+        return None
+    try:
+        return build_blast_radius_caveat(project_root)
+    except Exception:
+        _logger.debug("blast_radius_caveat_failed", exc_info=True)
+        return None
+
+
+def attach_blast_radius_caveat(
+    resp_data: dict[str, Any],
+    caveat: dict[str, Any] | None,
+) -> None:
+    """Attach a top-level ``blast_radius_caveat`` when the call graph is degraded.
+
+    Absent when healthy (``caveat is None``) so low-gap reviews stay clean
+    (TAP-4528). Sits beside ``diff_impact`` on the review verdict.
+    """
+    if caveat is not None:
+        resp_data["blast_radius_caveat"] = caveat
 
 
 def _build_structured_validation_output(
@@ -344,8 +380,8 @@ async def _handle_no_changed_files(
             )
             resp_data["next_steps"] = [
                 "FALLBACK: Use tapps_quick_check on individual files with the same project_root.",
-                f"Example: tapps_validate_changed(file_paths=\"packages/foo/src/bar.py\", "
-                f"project_root=\"{settings.project_root}\")",
+                f'Example: tapps_validate_changed(file_paths="packages/foo/src/bar.py", '
+                f'project_root="{settings.project_root}")',
             ]
         else:
             resp_data["path_hint"] = (
@@ -436,9 +472,7 @@ def _append_judge_summary(summary: str, judge_results: list[dict[str, Any]]) -> 
         return summary
     passed = sum(1 for r in judge_results if r.get("result") == "pass")
     failed = sum(
-        1
-        for r in judge_results
-        if r.get("result") in {"fail", "error"} and r.get("blocking")
+        1 for r in judge_results if r.get("result") in {"fail", "error"} and r.get("blocking")
     )
     skipped = sum(1 for r in judge_results if r.get("result") == "skipped")
     suffix = f" | judges: {passed} passed"
@@ -531,11 +565,13 @@ __all__ = [
     "_build_response_data",
     "_build_structured_validation_output",
     "_build_validation_summary",
-    "_compute_impact_analysis",
     "_compute_affected_tests",
+    "_compute_blast_radius_caveat",
+    "_compute_impact_analysis",
     "_handle_no_changed_files",
     "_resolve_security_depth",
     "_run_judges",
     "apply_judge_payload",
     "attach_affected_tests",
+    "attach_blast_radius_caveat",
 ]

--- a/packages/tapps-mcp/tests/unit/test_diff_impact.py
+++ b/packages/tapps-mcp/tests/unit/test_diff_impact.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from tapps_mcp.project.diff_impact import (
+    BLAST_RADIUS_GAP_RATE_THRESHOLD,
     analyze_diff_impact,
+    build_blast_radius_caveat,
     build_diff_impact_enrichment,
+    caveat_from_call_graph_summary,
 )
 
 
@@ -140,9 +143,7 @@ def test_compute():
         key = next(k for k in symbols if k.endswith("compute"))
         entry = symbols[key]
         assert any("do_work" in c for c in entry["callers"])
-        assert any(
-            "tests/test_core.py" in t["test_file"] for t in entry["affected_tests"]
-        )
+        assert any("tests/test_core.py" in t["test_file"] for t in entry["affected_tests"])
 
     def test_degrades_when_cache_missing(self, tmp_path: Path) -> None:
         _write(
@@ -161,3 +162,97 @@ def compute():
         assert result["cache_status"] == "missing"
         assert result["symbols"] == {}
         assert result["note"]
+
+
+class TestBlastRadiusCaveat:
+    """Call-graph health → review-verdict caveat (TAP-4528)."""
+
+    def test_healthy_low_gap_region_has_no_caveat(self) -> None:
+        """A ready cache with a low gap rate and no parse failures = no caveat."""
+        summary = {
+            "status": "ready",
+            "ready": True,
+            "stale": False,
+            "degraded": False,
+            "in_repo_gap_rate": 0.01,
+            "parse_failures": 0,
+        }
+        assert caveat_from_call_graph_summary(summary) is None
+
+    def test_high_gap_rate_region_raises_caveat(self) -> None:
+        """High in-repo gap rate = machine-readable caveat + human-readable note."""
+        summary = {
+            "status": "ready",
+            "ready": True,
+            "stale": False,
+            "degraded": True,
+            "in_repo_gap_rate": 0.42,
+            "parse_failures": 0,
+        }
+        caveat = caveat_from_call_graph_summary(summary)
+        assert caveat is not None
+        assert caveat["degraded"] is True
+        assert caveat["reason"] == "high_in_repo_gap_rate"
+        assert caveat["in_repo_gap_rate"] == 0.42
+        assert isinstance(caveat["note"], str) and caveat["note"]
+
+    def test_parse_failures_raise_caveat_even_at_low_gap(self) -> None:
+        """Any parse failure trips the caveat regardless of gap rate."""
+        summary = {
+            "status": "ready",
+            "in_repo_gap_rate": 0.0,
+            "parse_failures": 2,
+        }
+        caveat = caveat_from_call_graph_summary(summary)
+        assert caveat is not None
+        assert caveat["reason"] == "parse_failures"
+        assert caveat["parse_failures"] == 2
+
+    def test_not_ready_cache_raises_cache_not_ready_caveat(self) -> None:
+        """A missing / stale cache means the blast radius is unknown → caveat."""
+        summary = {"status": "missing", "hint": "run tapps_call_graph"}
+        caveat = caveat_from_call_graph_summary(summary)
+        assert caveat is not None
+        assert caveat["reason"] == "cache_not_ready"
+        assert caveat["note"] == "run tapps_call_graph"
+
+    def test_threshold_boundary_is_inclusive(self) -> None:
+        """Gap rate exactly at the threshold raises a caveat; just under does not."""
+        at = {"status": "ready", "in_repo_gap_rate": BLAST_RADIUS_GAP_RATE_THRESHOLD}
+        under = {
+            "status": "ready",
+            "in_repo_gap_rate": BLAST_RADIUS_GAP_RATE_THRESHOLD - 0.001,
+        }
+        assert caveat_from_call_graph_summary(at) is not None
+        assert caveat_from_call_graph_summary(under) is None
+
+    def test_build_blast_radius_caveat_missing_cache(self, tmp_path: Path) -> None:
+        """End-to-end: no warmed cache → cache_not_ready caveat (no rebuild)."""
+        caveat = build_blast_radius_caveat(tmp_path)
+        assert caveat is not None
+        assert caveat["reason"] == "cache_not_ready"
+
+    def test_build_blast_radius_caveat_healthy_repo(self, tmp_path: Path) -> None:
+        """End-to-end: a clean warmed cache produces no caveat (no false alarm)."""
+        _write(
+            tmp_path,
+            "app/core.py",
+            """
+def compute():
+    return 42
+""",
+        )
+        _write(
+            tmp_path,
+            "tests/test_core.py",
+            """
+from app.core import compute
+
+def test_compute():
+    assert compute() == 42
+""",
+        )
+        changed = tmp_path / "app/core.py"
+        # Warm the cache with a clean, fully-resolvable graph.
+        analyze_diff_impact([changed], tmp_path)
+        assert build_blast_radius_caveat(tmp_path) is None

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_event_emit.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_event_emit.py
@@ -37,6 +37,7 @@ def _make_outcome(
         impact_data=None,
         affected_tests_data=None,
         diff_impact_data=None,
+        blast_radius_caveat=None,
         timeout_info=_TimedOutInfo(timed_out=False, files_remaining=[]),
     )
 
@@ -70,9 +71,7 @@ class TestFireValidateEvents:
 
         with (
             patch_kg_emit(bridge=mock_bridge),
-            patch(
-                "tapps_mcp.tools.validate_changed.asyncio.create_task"
-            ) as mock_task,
+            patch("tapps_mcp.tools.validate_changed.asyncio.create_task") as mock_task,
         ):
             _fire_validate_events(_make_paths(), _make_outcome(), elapsed_ms=42)
 
@@ -96,7 +95,9 @@ class TestFireValidateEvents:
             ),
         ):
             paths = _make_paths(["/project/src/a.py", "/project/src/b.py"])
-            _fire_validate_events(paths, _make_outcome(file_paths=[str(p) for p in paths]), elapsed_ms=100)
+            _fire_validate_events(
+                paths, _make_outcome(file_paths=[str(p) for p in paths]), elapsed_ms=100
+            )
 
             assert len(captured) == 1
             await captured[0]

--- a/packages/tapps-mcp/tests/unit/test_validate_changed_p0.py
+++ b/packages/tapps-mcp/tests/unit/test_validate_changed_p0.py
@@ -229,9 +229,7 @@ class TestValidateChangedP0:
         assert affected["affected_tests"][0]["test_file"]
 
     @pytest.mark.asyncio
-    async def test_include_impact_returns_diff_impact_enrichment(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_include_impact_returns_diff_impact_enrichment(self, tmp_path: Path) -> None:
         """include_impact=True attaches per-symbol diff_impact enrichment (TAP-4526)."""
         from tapps_mcp.project.call_graph import build_call_graph_index
         from tapps_mcp.server_pipeline_tools import tapps_validate_changed
@@ -288,10 +286,71 @@ class TestValidateChangedP0:
         symbols = diff_impact["symbols"]
         key = next(k for k in symbols if k.endswith("compute"))
         assert any("do_work" in c for c in symbols[key]["callers"])
-        assert any(
-            "tests/test_core.py" in t["test_file"]
-            for t in symbols[key]["affected_tests"]
-        )
+        assert any("tests/test_core.py" in t["test_file"] for t in symbols[key]["affected_tests"])
+        # Healthy graph → no blast-radius caveat (no false alarm, TAP-4528 AC2).
+        assert result["data"].get("blast_radius_caveat") is None
+
+    @pytest.mark.asyncio
+    async def test_include_impact_attaches_blast_radius_caveat_when_degraded(
+        self, tmp_path: Path
+    ) -> None:
+        """A degraded call graph attaches a top-level blast_radius_caveat (TAP-4528).
+
+        The validate pipeline warms a clean cache, so a real gap can't be forced
+        deterministically here — patch the (unit-tested) caveat helper and assert
+        the wiring surfaces its result on the review verdict.
+        """
+        from tapps_mcp.server_pipeline_tools import tapps_validate_changed
+
+        src = tmp_path / "app" / "core.py"
+        src.parent.mkdir(parents=True)
+        src.write_text("def compute():\n    return 42\n", encoding="utf-8")
+
+        scorer = _mock_scorer()
+        mock_gate = MagicMock(passed=True, failures=[])
+        mock_report = _mock_impact_report(str(src), severity="low")
+        degraded_caveat = {
+            "degraded": True,
+            "in_repo_gap_rate": 0.42,
+            "parse_failures": 0,
+            "reason": "high_in_repo_gap_rate",
+            "note": "In-repo call-graph gap rate is 42% — blast radius may be incomplete.",
+        }
+
+        with (
+            patch("tapps_mcp.server_pipeline_tools.load_settings") as mock_settings,
+            patch("tapps_mcp.server._validate_file_path", side_effect=Path),
+            patch("tapps_mcp.scoring.scorer.CodeScorer", return_value=scorer),
+            patch("tapps_mcp.gates.evaluator.evaluate_gate", return_value=mock_gate),
+            patch(
+                "tapps_mcp.project.impact_analyzer.build_import_graph",
+                return_value={},
+            ),
+            patch(
+                "tapps_mcp.project.impact_analyzer.analyze_impact",
+                return_value=mock_report,
+            ),
+            patch(
+                "tapps_mcp.project.diff_impact.build_blast_radius_caveat",
+                return_value=degraded_caveat,
+            ),
+        ):
+            mock_settings.return_value.project_root = tmp_path
+            mock_settings.return_value.tool_timeout = 30
+            mock_settings.return_value.dependency_scan_enabled = False
+
+            result = await tapps_validate_changed(
+                file_paths=str(src),
+                quick=True,
+                include_impact=True,
+            )
+
+        assert result["success"] is True
+        caveat = result["data"].get("blast_radius_caveat")
+        assert caveat is not None
+        assert caveat["degraded"] is True
+        assert caveat["reason"] == "high_in_repo_gap_rate"
+        assert caveat["note"]
 
     @pytest.mark.asyncio
     async def test_include_impact_false_no_summary(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes TAP-4528 (Tier 1 of TAP-4525). Builds on TAP-4526 (#172).

## What
Promotes the call graph's `in_repo_gap_rate` / parse-failure signal to a first-class `blast_radius_caveat` on the `tapps_validate_changed` review verdict, so a review touching a dynamic-dispatch (high-gap) region carries an explicit "impact analysis may be incomplete" note. Deterministic (ADR-0004) — reuses the existing `summarize_call_graph_cache` output, no new analysis pass.

## Design
- Fires on: cache-not-ready, `parse_failures > 0`, or `in_repo_gap_rate >= 0.10`. Keyed off real health metrics rather than the raw `degraded` boolean (which trips on a single stray gap and would false-alarm). Healthy/low-gap regions produce no caveat (AC2).
- Home: the review/`validate_changed` output, beside `diff_impact`. Not added to `tapps_quality_gate` (single-file path, no blast radius) — shared helper available if ever needed.

## Tests
168 passed in the touched slice. Both branches covered (`TestBlastRadiusCaveat`: healthy→None, high-gap/parse-fail/not-ready→caveat, threshold boundary). New code clean under ruff+mypy; pre-existing master debt left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)