### PR TITLE
feat(scoring): add semgrep as a deterministic offline security checker (TAP-4529)

### DIFF
--- a/packages/tapps-core/src/tapps_core/common/models.py
+++ b/packages/tapps-core/src/tapps_core/common/models.py
@@ -57,6 +57,10 @@ class SecurityIssue(BaseModel):
     severity: str = Field(default="medium", description="critical | high | medium | low | info.")
     confidence: str = Field(default="medium", description="high | medium | low.")
     owasp: str | None = Field(default=None, description="OWASP category if mapped.")
+    source: str = Field(
+        default="bandit",
+        description="Provenance of the finding: 'bandit', 'semgrep', or 'heuristic'.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/tapps-core/src/tapps_core/config/settings.py
+++ b/packages/tapps-core/src/tapps_core/config/settings.py
@@ -922,6 +922,16 @@ class TappsMCPSettings(BaseSettings):
         description="File name patterns to exclude from dead code findings (fnmatch).",
     )
 
+    # Semgrep security scanning (TAP-4529) — deterministic, offline, pinned ruleset
+    semgrep_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable semgrep static security scanning in scoring. Runs against a "
+            "pinned in-repo ruleset with no network fetch; degrades gracefully "
+            "when the semgrep binary is absent."
+        ),
+    )
+
     # Dependency vulnerability scanning
     dependency_scan_enabled: bool = Field(
         default=True,

--- a/packages/tapps-mcp/pyproject.toml
+++ b/packages/tapps-mcp/pyproject.toml
@@ -36,6 +36,13 @@ dependencies = [
     "httpx>=0.28.1,<1",
     "filelock>=3.29.4,<4",
     "bandit>=1.8",
+    # NOTE (TAP-4529): semgrep is an OPTIONAL checker, deliberately NOT pinned
+    # here. Its transitive pins (click<8.2, tomli<2.1) conflict irreconcilably
+    # with this workspace's click>=8.4.1 and pip-audit's tomli>=2.2.1, so a hard
+    # dependency would make `uv sync` unresolvable. The scoring path degrades
+    # gracefully when semgrep is absent (records a skipped-checker note). To
+    # enable it, install the binary out-of-band, e.g. `pipx install semgrep` or
+    # `uv pip install semgrep`, and it is auto-detected via shutil.which.
     "defusedxml>=0.7.1,<1",
     "radon>=6.0",
     "vulture>=2.14",

--- a/packages/tapps-mcp/src/tapps_mcp/scoring/dependency_security.py
+++ b/packages/tapps-mcp/src/tapps_mcp/scoring/dependency_security.py
@@ -5,7 +5,69 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from tapps_core.common.models import SecurityIssue
     from tapps_mcp.tools.pip_audit import VulnerabilityFinding
+
+
+# ---------------------------------------------------------------------------
+# Cross-checker security-finding assembly (TAP-4529)
+# ---------------------------------------------------------------------------
+
+# Semantic categories shared across checkers, so a bandit finding and a semgrep
+# finding for the SAME issue (e.g. subprocess shell=True) collapse to one and
+# are not double-counted. Keyed off the checker's rule code.
+_SHELL_INJECTION_BANDIT = {"B602", "B603", "B604", "B605", "B606", "B607", "B609"}
+_EVAL_EXEC_BANDIT = {"B102", "B307"}
+_PICKLE_BANDIT = {"B301", "B403"}
+_YAML_BANDIT = {"B506"}
+_WEAK_HASH_BANDIT = {"B303", "B324"}
+
+
+def _category_of(issue: SecurityIssue) -> str:
+    """Map a finding to a coarse semantic category for cross-checker dedupe.
+
+    Falls back to the raw rule code so distinct issues never collapse; only
+    KNOWN equivalences (a bandit code and a semgrep rule for the same class of
+    bug) share a category and therefore dedupe.
+    """
+    code = issue.code
+    if code in _SHELL_INJECTION_BANDIT or "dangerous-subprocess-shell-true" in code:
+        return "shell-injection"
+    if code in _EVAL_EXEC_BANDIT or "dangerous-eval-exec" in code:
+        return "eval-exec"
+    if code in _PICKLE_BANDIT or "insecure-pickle-load" in code:
+        return "insecure-pickle"
+    if code in _YAML_BANDIT or "yaml-unsafe-load" in code:
+        return "yaml-unsafe-load"
+    if code in _WEAK_HASH_BANDIT or "weak-hash-md5-sha1" in code:
+        return "weak-hash"
+    return f"code:{code}"
+
+
+def merge_security_findings(
+    bandit_issues: list[SecurityIssue],
+    semgrep_issues: list[SecurityIssue],
+) -> list[SecurityIssue]:
+    """Merge bandit + semgrep findings, deduping cross-checker overlaps.
+
+    Dedupe key is ``(semantic-category, file, line)``. When both checkers flag
+    the same issue at the same location, bandit wins (it is the established
+    checker and its ``B###`` codes map to OWASP), so the finding is counted
+    once with ``source="bandit"``. Semgrep findings with no bandit twin survive
+    with ``source="semgrep"``. Ordering is deterministic: all bandit findings
+    first (input order), then surviving semgrep findings (input order).
+    """
+    merged: list[SecurityIssue] = list(bandit_issues)
+    seen: set[tuple[str, str, int]] = {
+        (_category_of(i), i.file, i.line) for i in bandit_issues
+    }
+    for issue in semgrep_issues:
+        key = (_category_of(issue), issue.file, issue.line)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(issue)
+    return merged
 
 # ---------------------------------------------------------------------------
 # Penalty constants per severity level

--- a/packages/tapps-mcp/src/tapps_mcp/scoring/models.py
+++ b/packages/tapps-mcp/src/tapps_mcp/scoring/models.py
@@ -64,6 +64,14 @@ class ScoreResult(BaseModel):
     missing_tools: list[str] = Field(
         default_factory=list, description="Names of unavailable external tools."
     )
+    skipped_tools: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional checkers that were skipped without failing the score "
+            "(e.g. 'semgrep' when the binary is absent). Informational only — "
+            "does not by itself set degraded."
+        ),
+    )
     tool_errors: dict[str, str] = Field(
         default_factory=dict, description="Per-tool error reasons when tools fail."
     )

--- a/packages/tapps-mcp/src/tapps_mcp/scoring/scorer.py
+++ b/packages/tapps-mcp/src/tapps_mcp/scoring/scorer.py
@@ -312,6 +312,7 @@ class CodeScorer(ScorerBase):
             cwd=cwd,
             timeout=timeout,
             run_vulture=self._settings.dead_code_enabled,
+            run_semgrep=self._settings.semgrep_enabled,
             vulture_whitelist_patterns=self._settings.dead_code_whitelist_patterns,
             mode=mode,
         )
@@ -339,6 +340,7 @@ class CodeScorer(ScorerBase):
             dependency_vuln_count=dep_vuln_count,
             degraded=parallel.degraded or bool(degraded_cats),
             missing_tools=parallel.missing_tools,
+            skipped_tools=parallel.skipped_tools,
             tool_errors=parallel.tool_errors,
             degraded_categories=degraded_cats,
         )
@@ -399,6 +401,13 @@ class CodeScorer(ScorerBase):
         """
         w = self._weights
         details: dict[str, object] = {"issue_count": len(parallel.security_issues)}
+        # Provenance breakdown so semgrep findings are visible next to bandit's.
+        if parallel.semgrep_issues:
+            details["semgrep_issue_count"] = sum(
+                1 for i in parallel.security_issues if i.source == "semgrep"
+            )
+        if "semgrep" in parallel.skipped_tools:
+            details["semgrep_skipped"] = True
         # Use the real bandit result unless: (a) bandit is missing/unavailable, or
         # (b) bandit ran but its output was empty/unparseable (parse failure).
         bandit_parse_failed = "bandit" in parallel.tool_parse_failures

--- a/packages/tapps-mcp/src/tapps_mcp/scoring/semgrep_rules/tapps-security.yml
+++ b/packages/tapps-mcp/src/tapps_mcp/scoring/semgrep_rules/tapps-security.yml
@@ -1,0 +1,104 @@
+# tapps-mcp curated, PINNED, OFFLINE semgrep ruleset (TAP-4529).
+#
+# This file is the ONLY config semgrep is ever pointed at during scoring
+# (`--config <this-file>`). It must never trigger a network fetch: no
+# `p/...` registry packs, no `--config auto`, no remote `extends`. The rules
+# below are hand-curated, small, and high-signal — a handful of taint/security
+# patterns that complement (not duplicate) bandit. Determinism is a hard
+# requirement of the scorer contract (ADR-0004): same input file => same
+# findings, every run, with zero network access.
+#
+# Rule ids are namespaced `tapps.python.<name>` so semgrep findings are
+# unambiguously distinguishable from bandit's `B###` codes when merged into
+# the security section of a score.
+rules:
+  # ---- Taint: command injection via shell=True on tainted input ----------
+  - id: tapps.python.dangerous-subprocess-shell-true
+    languages: [python]
+    severity: ERROR
+    message: >-
+      subprocess call with shell=True can enable OS command injection when any
+      argument is attacker-controlled. Prefer a list argv with shell=False.
+    metadata:
+      category: security
+      cwe: "CWE-78: OS Command Injection"
+      owasp: "A03:2021-Injection"
+    patterns:
+      - pattern-either:
+          - pattern: subprocess.$FUNC(..., shell=True, ...)
+          - pattern: subprocess.$FUNC(..., shell=$X, ...)
+      - metavariable-pattern:
+          metavariable: $FUNC
+          patterns:
+            - pattern-either:
+                - pattern: run
+                - pattern: call
+                - pattern: Popen
+                - pattern: check_call
+                - pattern: check_output
+
+  # ---- eval / exec on dynamic input --------------------------------------
+  - id: tapps.python.dangerous-eval-exec
+    languages: [python]
+    severity: ERROR
+    message: >-
+      Use of eval()/exec() on a non-constant value allows arbitrary code
+      execution. Avoid dynamic code evaluation; use safe parsers instead.
+    metadata:
+      category: security
+      cwe: "CWE-95: Eval Injection"
+      owasp: "A03:2021-Injection"
+    patterns:
+      - pattern-either:
+          - pattern: eval(...)
+          - pattern: exec(...)
+      - pattern-not: eval("...")
+      - pattern-not: exec("...")
+
+  # ---- Insecure deserialization -----------------------------------------
+  - id: tapps.python.insecure-pickle-load
+    languages: [python]
+    severity: ERROR
+    message: >-
+      Deserializing untrusted data with pickle can execute arbitrary code.
+      Use a safe format (json) for untrusted input.
+    metadata:
+      category: security
+      cwe: "CWE-502: Deserialization of Untrusted Data"
+      owasp: "A08:2021-Software and Data Integrity Failures"
+    pattern-either:
+      - pattern: pickle.load(...)
+      - pattern: pickle.loads(...)
+
+  # ---- yaml.load without SafeLoader --------------------------------------
+  - id: tapps.python.yaml-unsafe-load
+    languages: [python]
+    severity: WARNING
+    message: >-
+      yaml.load without an explicit SafeLoader can construct arbitrary Python
+      objects from untrusted input. Use yaml.safe_load(...) instead.
+    metadata:
+      category: security
+      cwe: "CWE-20: Improper Input Validation"
+      owasp: "A08:2021-Software and Data Integrity Failures"
+    patterns:
+      - pattern: yaml.load($X)
+      - pattern-not: yaml.load($X, Loader=yaml.SafeLoader)
+
+  # ---- Weak hash for security context ------------------------------------
+  - id: tapps.python.weak-hash-md5-sha1
+    languages: [python]
+    severity: WARNING
+    message: >-
+      MD5/SHA1 are cryptographically broken. Use SHA-256+ for security-relevant
+      hashing (or pass usedforsecurity=False when the hash is non-security).
+    metadata:
+      category: security
+      cwe: "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
+      owasp: "A02:2021-Cryptographic Failures"
+    patterns:
+      - pattern-either:
+          - pattern: hashlib.md5(...)
+          - pattern: hashlib.sha1(...)
+      - pattern-not: hashlib.md5(..., usedforsecurity=False)
+      - pattern-not: hashlib.sha1(..., usedforsecurity=False)

--- a/packages/tapps-mcp/src/tapps_mcp/tools/parallel.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/parallel.py
@@ -26,6 +26,7 @@ from tapps_mcp.tools.bandit import run_bandit_check_async
 from tapps_mcp.tools.mypy import run_mypy_check_async
 from tapps_mcp.tools.radon import run_radon_cc_async, run_radon_hal_async, run_radon_mi_async
 from tapps_mcp.tools.ruff import run_ruff_check_async
+from tapps_mcp.tools.semgrep import run_semgrep_check_async, semgrep_available
 from tapps_mcp.tools.vulture import run_vulture_async
 
 logger = structlog.get_logger(__name__)
@@ -40,6 +41,8 @@ class ParallelResults:
     lint_issues: list[LintIssue] = field(default_factory=list)
     type_issues: list[TypeIssue] = field(default_factory=list)
     security_issues: list[SecurityIssue] = field(default_factory=list)
+    semgrep_issues: list[SecurityIssue] = field(default_factory=list)
+    skipped_tools: list[str] = field(default_factory=list)
     radon_cc: list[dict[str, Any]] = field(default_factory=list)
     radon_mi: float = 50.0
     radon_hal: list[dict[str, Any]] = field(default_factory=list)
@@ -71,6 +74,14 @@ def _assign_result(name: str, results: ParallelResults, value: object) -> None:
             results.tool_parse_failures.append("bandit")
         else:
             results.security_issues = value  # type: ignore[assignment]
+    elif name == "semgrep":
+        if value is None:
+            # semgrep unavailable or produced no usable output — graceful skip.
+            # Record a skipped-checker note (NOT a hard failure); the security
+            # category still scores from bandit + heuristics.
+            results.skipped_tools.append("semgrep")
+        else:
+            results.semgrep_issues = value  # type: ignore[assignment]
     elif name == "radon_cc":
         results.radon_cc = value  # type: ignore[assignment]
     elif name == "radon_mi":
@@ -94,10 +105,11 @@ async def run_all_tools(
     run_radon: bool = True,
     run_vulture: bool = True,
     run_perflint: bool = True,
+    run_semgrep: bool = True,
     vulture_whitelist_patterns: list[str] | None = None,
     mode: str = "subprocess",
 ) -> ParallelResults:
-    """Run ruff, mypy, bandit, radon, vulture, and perflint concurrently.
+    """Run ruff, mypy, bandit, semgrep, radon, vulture, and perflint concurrently.
 
     Args:
         file_path: Path to the Python file to analyse.
@@ -131,6 +143,7 @@ async def run_all_tools(
             run_radon=run_radon,
             run_vulture=run_vulture,
             run_perflint=run_perflint,
+            run_semgrep=run_semgrep,
             vulture_whitelist_patterns=vulture_whitelist_patterns,
         )
 
@@ -145,7 +158,24 @@ async def run_all_tools(
         run_radon=run_radon,
         run_vulture=run_vulture,
         run_perflint=run_perflint,
+        run_semgrep=run_semgrep,
         vulture_whitelist_patterns=vulture_whitelist_patterns,
+    )
+
+
+def _finalize_semgrep(results: ParallelResults) -> None:
+    """Merge semgrep findings into ``security_issues`` with cross-checker dedupe.
+
+    Bandit findings already live in ``results.security_issues``; semgrep findings
+    (if any) are merged in, deduping known overlaps (e.g. shell=True flagged by
+    both). Deterministic — bandit findings first, surviving semgrep after.
+    """
+    if not results.semgrep_issues:
+        return
+    from tapps_mcp.scoring.dependency_security import merge_security_findings
+
+    results.security_issues = merge_security_findings(
+        results.security_issues, results.semgrep_issues
     )
 
 
@@ -165,6 +195,7 @@ async def _run_subprocess(
     run_radon: bool = True,
     run_vulture: bool = True,
     run_perflint: bool = True,
+    run_semgrep: bool = True,
     vulture_whitelist_patterns: list[str] | None = None,
 ) -> ParallelResults:
     """Run tools via async subprocess (original behaviour)."""
@@ -186,6 +217,12 @@ async def _run_subprocess(
         tasks["bandit"] = asyncio.create_task(run_bandit_check_async(file_path, **kw))
     elif run_bandit:
         _mark_missing("bandit", results)
+
+    # Semgrep: deterministic offline static security scan (graceful skip if absent).
+    if run_semgrep and semgrep_available():
+        tasks["semgrep"] = asyncio.create_task(run_semgrep_check_async(file_path, **kw))
+    elif run_semgrep:
+        results.skipped_tools.append("semgrep")
 
     if run_radon and shutil.which("radon"):
         tasks["radon_cc"] = asyncio.create_task(run_radon_cc_async(file_path, **kw))
@@ -239,6 +276,7 @@ async def _run_subprocess(
                 continue
             _assign_result(name, results, result)
 
+    _finalize_semgrep(results)
     if results.missing_tools:
         results.degraded = True
 
@@ -261,6 +299,7 @@ async def _run_direct(
     run_radon: bool = True,
     run_vulture: bool = True,
     run_perflint: bool = True,
+    run_semgrep: bool = True,
     vulture_whitelist_patterns: list[str] | None = None,
 ) -> ParallelResults:
     """Run tools via direct library calls and sync subprocess in thread pool.
@@ -276,6 +315,7 @@ async def _run_direct(
     from tapps_mcp.tools.mypy import run_mypy_check
     from tapps_mcp.tools.radon_direct import cc_direct, hal_direct, is_available, mi_direct
     from tapps_mcp.tools.ruff_direct import run_ruff_check_direct
+    from tapps_mcp.tools.semgrep import run_semgrep_check
 
     results = ParallelResults()
     tasks: dict[str, asyncio.Task[Any]] = {}
@@ -302,6 +342,14 @@ async def _run_direct(
         )
     elif run_bandit:
         _mark_missing("bandit", results)
+
+    # Semgrep: sync subprocess in thread pool (graceful skip if absent)
+    if run_semgrep and semgrep_available():
+        tasks["semgrep"] = asyncio.create_task(
+            asyncio.to_thread(run_semgrep_check, file_path, cwd=cwd, timeout=timeout),
+        )
+    elif run_semgrep:
+        results.skipped_tools.append("semgrep")
 
     # Radon: direct library import (no subprocess)
     if run_radon:
@@ -370,6 +418,7 @@ async def _run_direct(
                 continue
             _assign_result(name, results, result)
 
+    _finalize_semgrep(results)
     if results.missing_tools:
         results.degraded = True
 

--- a/packages/tapps-mcp/src/tapps_mcp/tools/semgrep.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/semgrep.py
@@ -1,0 +1,167 @@
+"""Semgrep security scanner wrapper — deterministic, offline (TAP-4529).
+
+Semgrep runs against a PINNED, in-repo ruleset (``scoring/semgrep_rules/``) and
+NEVER fetches from the semgrep registry. The scorer contract (ADR-0004) forbids
+any network call at scoring time, so this wrapper:
+
+- points ``--config`` at a local file only (never ``auto`` / ``p/...`` packs),
+- disables the semgrep version check and metrics upload via CLI flags AND
+  environment variables (belt-and-suspenders — no incidental egress), and
+- degrades gracefully: if the binary is absent or the run errors, callers get
+  ``None`` and record a skipped-checker note rather than crashing the score.
+
+Findings are tagged ``source="semgrep"`` so they carry distinct provenance from
+bandit's ``B###`` findings when merged into the security section of a score.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import structlog
+
+from tapps_mcp.scoring.models import SecurityIssue
+from tapps_mcp.tools.subprocess_runner import run_command, run_command_async
+
+logger = structlog.get_logger(__name__)
+
+# Pinned, in-repo ruleset. Resolved relative to this file so it travels with the
+# package wheel — no absolute paths, no network fetch.
+SEMGREP_RULESET: Path = (
+    Path(__file__).resolve().parent.parent / "scoring" / "semgrep_rules" / "tapps-security.yml"
+)
+
+# Map semgrep ERROR/WARNING/INFO to the SecurityIssue severity vocabulary.
+_SEVERITY_MAP: dict[str, str] = {
+    "ERROR": "high",
+    "WARNING": "medium",
+    "INFO": "low",
+}
+
+
+def _semgrep_env() -> dict[str, str]:
+    """Environment that guarantees no incidental network egress at scoring time."""
+    env = os.environ.copy()
+    env["SEMGREP_ENABLE_VERSION_CHECK"] = "0"
+    env["SEMGREP_SEND_METRICS"] = "off"
+    # Belt-and-suspenders: some semgrep versions read this too.
+    env["SEMGREP_METRICS"] = "off"
+    return env
+
+
+def _semgrep_args(file_path: str) -> list[str]:
+    """Build the semgrep argv — pinned local config, JSON out, offline flags."""
+    return [
+        "semgrep",
+        "scan",
+        "--config",
+        str(SEMGREP_RULESET),
+        "--json",
+        "--quiet",
+        "--disable-version-check",
+        "--metrics=off",
+        "--no-git-ignore",
+        file_path,
+    ]
+
+
+def semgrep_available() -> bool:
+    """Return True when the semgrep binary is on PATH and the ruleset exists."""
+    return shutil.which("semgrep") is not None and SEMGREP_RULESET.is_file()
+
+
+def parse_semgrep_json(raw: str) -> list[SecurityIssue] | None:
+    """Parse semgrep ``--json`` output into ``SecurityIssue`` models.
+
+    Returns ``None`` when output is empty or unparseable (skipped/parse failure).
+    Returns ``[]`` when semgrep ran cleanly and found nothing.
+    """
+    if not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    results = data.get("results", [])
+    if not isinstance(results, list):
+        return []
+    issues: list[SecurityIssue] = []
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        extra = r.get("extra", {}) if isinstance(r.get("extra"), dict) else {}
+        metadata = extra.get("metadata", {}) if isinstance(extra.get("metadata"), dict) else {}
+        start = r.get("start", {}) if isinstance(r.get("start"), dict) else {}
+        sem_sev = str(extra.get("severity", "WARNING")).upper()
+        issues.append(
+            SecurityIssue(
+                code=str(r.get("check_id", "semgrep.unknown")),
+                message=str(extra.get("message", "")).strip(),
+                file=str(r.get("path", "")),
+                line=int(start.get("line", 0) or 0),
+                severity=_SEVERITY_MAP.get(sem_sev, "medium"),
+                confidence="high",
+                owasp=_owasp_from_metadata(metadata),
+                source="semgrep",
+            )
+        )
+    return issues
+
+
+def _owasp_from_metadata(metadata: dict[str, object]) -> str | None:
+    """Pull the OWASP category out of a rule's metadata block, if present."""
+    owasp = metadata.get("owasp")
+    if isinstance(owasp, str):
+        return owasp
+    if isinstance(owasp, list) and owasp and isinstance(owasp[0], str):
+        return owasp[0]
+    return None
+
+
+def run_semgrep_check(
+    file_path: str, *, cwd: str | None = None, timeout: int = 30
+) -> list[SecurityIssue] | None:
+    """Run semgrep on a single file synchronously against the pinned ruleset.
+
+    Returns ``None`` when semgrep is unavailable or produced no usable output
+    (graceful skip). Returns ``[]`` when it ran and found nothing.
+    """
+    if not semgrep_available():
+        logger.info("semgrep_not_available", hint="pip install semgrep")
+        return None
+    result = run_command(
+        _semgrep_args(file_path),
+        cwd=cwd,
+        timeout=timeout,
+        env=_semgrep_env(),
+    )
+    if result.returncode < 0:  # not-found / timeout sentinel from run_command
+        return None
+    return parse_semgrep_json(result.stdout)
+
+
+async def run_semgrep_check_async(
+    file_path: str, *, cwd: str | None = None, timeout: int = 30
+) -> list[SecurityIssue] | None:
+    """Run semgrep on a single file asynchronously against the pinned ruleset.
+
+    Returns ``None`` when semgrep is unavailable or produced no usable output
+    (graceful skip). Returns ``[]`` when it ran and found nothing.
+    """
+    if not semgrep_available():
+        logger.info("semgrep_not_available", hint="pip install semgrep")
+        return None
+    result = await run_command_async(
+        _semgrep_args(file_path),
+        cwd=cwd,
+        timeout=timeout,
+        env=_semgrep_env(),
+    )
+    if result.returncode < 0:
+        return None
+    return parse_semgrep_json(result.stdout)

--- a/packages/tapps-mcp/tests/unit/test_parallel.py
+++ b/packages/tapps-mcp/tests/unit/test_parallel.py
@@ -355,5 +355,6 @@ class TestDirectMode:
                 run_radon=True,
                 run_vulture=True,
                 run_perflint=True,
+                run_semgrep=True,
                 vulture_whitelist_patterns=None,
             )

--- a/packages/tapps-mcp/tests/unit/test_semgrep.py
+++ b/packages/tapps-mcp/tests/unit/test_semgrep.py
@@ -1,0 +1,271 @@
+"""Tests for the semgrep deterministic-offline security checker (TAP-4529).
+
+Covers: JSON parsing, graceful skip when the binary is absent, cross-checker
+dedupe with bandit (no double-count), and an integration path that adapts to
+whether the semgrep binary is actually installed in the environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tapps_mcp.scoring.dependency_security import merge_security_findings
+from tapps_mcp.scoring.models import SecurityIssue
+from tapps_mcp.tools.parallel import run_all_tools
+from tapps_mcp.tools.semgrep import (
+    SEMGREP_RULESET,
+    _semgrep_env,
+    parse_semgrep_json,
+    run_semgrep_check,
+    semgrep_available,
+)
+from tapps_mcp.tools.subprocess_utils import CommandResult
+
+# A semgrep --json result flagging subprocess shell=True (the same class of bug
+# bandit reports as B602), plus an eval finding, so we can prove provenance and
+# dedupe behaviour.
+SAMPLE_SEMGREP_JSON = json.dumps(
+    {
+        "results": [
+            {
+                "check_id": "tapps.python.dangerous-subprocess-shell-true",
+                "path": "app.py",
+                "start": {"line": 20},
+                "extra": {
+                    "message": "subprocess call with shell=True",
+                    "severity": "ERROR",
+                    "metadata": {"owasp": "A03:2021-Injection"},
+                },
+            },
+            {
+                "check_id": "tapps.python.dangerous-eval-exec",
+                "path": "app.py",
+                "start": {"line": 42},
+                "extra": {
+                    "message": "eval on dynamic input",
+                    "severity": "ERROR",
+                    "metadata": {"owasp": ["A03:2021-Injection"]},
+                },
+            },
+        ]
+    }
+)
+
+
+class TestRuleset:
+    def test_ruleset_bundled_in_repo(self):
+        # AC2: the pinned ruleset must ship as a file in the package.
+        assert SEMGREP_RULESET.is_file()
+        assert SEMGREP_RULESET.suffix in {".yml", ".yaml"}
+
+    def test_ruleset_has_no_remote_config(self):
+        # No network fetch: reject registry packs / auto config sneaking in.
+        # Inspect non-comment lines only (comments legitimately mention `p/`).
+        code_lines = [
+            ln
+            for ln in SEMGREP_RULESET.read_text(encoding="utf-8").splitlines()
+            if not ln.lstrip().startswith("#")
+        ]
+        code = "\n".join(code_lines)
+        assert "config: auto" not in code
+        assert "registry" not in code
+        # No `extends:` pulling a remote pack.
+        assert "extends" not in code
+
+
+class TestSemgrepEnv:
+    def test_disables_network(self):
+        # Belt-and-suspenders: version check + metrics off so nothing egresses.
+        env = _semgrep_env()
+        assert env["SEMGREP_ENABLE_VERSION_CHECK"] == "0"
+        assert env["SEMGREP_SEND_METRICS"] == "off"
+        assert env["SEMGREP_METRICS"] == "off"
+
+
+class TestParseSemgrepJson:
+    def test_valid_output(self):
+        issues = parse_semgrep_json(SAMPLE_SEMGREP_JSON)
+        assert issues is not None
+        assert len(issues) == 2
+        assert issues[0].code == "tapps.python.dangerous-subprocess-shell-true"
+        assert issues[0].line == 20
+        assert issues[0].severity == "high"  # ERROR -> high
+        assert issues[0].source == "semgrep"
+        assert issues[0].owasp == "A03:2021-Injection"
+        # owasp given as a list should still resolve to a string
+        assert issues[1].owasp == "A03:2021-Injection"
+
+    def test_empty_string_is_skip(self):
+        assert parse_semgrep_json("") is None
+
+    def test_invalid_json_is_skip(self):
+        assert parse_semgrep_json("not json") is None
+
+    def test_empty_results(self):
+        assert parse_semgrep_json('{"results": []}') == []
+
+
+class TestGracefulSkip:
+    def test_returns_none_when_binary_absent(self):
+        # AC3: absence degrades gracefully — None, never a crash.
+        with patch("tapps_mcp.tools.semgrep.semgrep_available", return_value=False):
+            assert run_semgrep_check("whatever.py") is None
+
+    @patch("tapps_mcp.tools.semgrep.run_command")
+    @patch("tapps_mcp.tools.semgrep.semgrep_available", return_value=True)
+    def test_returns_none_on_not_found_sentinel(self, _avail, mock_cmd):
+        # run_command returns returncode=-1 on FileNotFoundError/timeout.
+        mock_cmd.return_value = CommandResult(returncode=-1, stdout="", stderr="not found")
+        assert run_semgrep_check("whatever.py") is None
+
+    @patch("tapps_mcp.tools.semgrep.run_command")
+    @patch("tapps_mcp.tools.semgrep.semgrep_available", return_value=True)
+    def test_parses_findings_when_available(self, _avail, mock_cmd):
+        mock_cmd.return_value = CommandResult(returncode=1, stdout=SAMPLE_SEMGREP_JSON, stderr="")
+        issues = run_semgrep_check("app.py")
+        assert issues is not None
+        assert len(issues) == 2
+        assert all(i.source == "semgrep" for i in issues)
+
+
+class TestMergeDedupe:
+    def _bandit_shell(self) -> SecurityIssue:
+        return SecurityIssue(
+            code="B602",
+            message="subprocess with shell=True",
+            file="app.py",
+            line=20,
+            severity="high",
+            source="bandit",
+        )
+
+    def _semgrep_shell(self, line: int = 20) -> SecurityIssue:
+        return SecurityIssue(
+            code="tapps.python.dangerous-subprocess-shell-true",
+            message="subprocess call with shell=True",
+            file="app.py",
+            line=line,
+            severity="high",
+            source="semgrep",
+        )
+
+    def test_overlap_deduped_bandit_wins(self):
+        # AC4: same taint at the same location must NOT be double-counted.
+        merged = merge_security_findings([self._bandit_shell()], [self._semgrep_shell()])
+        assert len(merged) == 1
+        assert merged[0].source == "bandit"
+        assert merged[0].code == "B602"
+
+    def test_distinct_locations_both_survive(self):
+        merged = merge_security_findings(
+            [self._bandit_shell()], [self._semgrep_shell(line=99)]
+        )
+        assert len(merged) == 2
+        sources = sorted(i.source for i in merged)
+        assert sources == ["bandit", "semgrep"]
+
+    def test_semgrep_only_finding_survives(self):
+        semgrep_eval = SecurityIssue(
+            code="tapps.python.dangerous-eval-exec",
+            message="eval",
+            file="app.py",
+            line=42,
+            severity="high",
+            source="semgrep",
+        )
+        merged = merge_security_findings([], [semgrep_eval])
+        assert len(merged) == 1
+        assert merged[0].source == "semgrep"
+
+    def test_deterministic_ordering(self):
+        bandit = [self._bandit_shell()]
+        semgrep = [self._semgrep_shell(line=99), self._semgrep_shell(line=100)]
+        first = merge_security_findings(bandit, semgrep)
+        second = merge_security_findings(bandit, semgrep)
+        assert [i.code for i in first] == [i.code for i in second]
+        # bandit findings come first, deterministically.
+        assert first[0].source == "bandit"
+
+
+@pytest.mark.asyncio
+async def test_taint_pattern_reported_and_not_double_counted(tmp_path: Path):
+    """End-to-end: a known taint pattern is reported and not double-counted.
+
+    When the semgrep binary is installed, run the real pinned ruleset against a
+    shell=True fixture and assert (a) semgrep reports it and (b) it is not
+    double-counted with bandit in the merged security_issues. When the binary
+    is absent, assert the graceful-skip path instead (semgrep in skipped_tools),
+    proving AC3.
+    """
+    fixture = tmp_path / "taint.py"
+    fixture.write_text(
+        "import subprocess\n"
+        "def run(cmd):\n"
+        "    return subprocess.run(cmd, shell=True)\n",
+        encoding="utf-8",
+    )
+
+    # Only run bandit + semgrep to keep the test fast and focused.
+    results = await run_all_tools(
+        str(fixture),
+        cwd=str(tmp_path),
+        timeout=60,
+        run_ruff=False,
+        run_mypy=False,
+        run_bandit=True,
+        run_radon=False,
+        run_vulture=False,
+        run_perflint=False,
+        run_semgrep=True,
+        mode="subprocess",
+    )
+
+    if not semgrep_available():
+        # AC3 graceful-skip path — no crash, semgrep noted as skipped.
+        assert "semgrep" in results.skipped_tools
+        assert results.semgrep_issues == []
+        return
+
+    # Binary present: semgrep must report the shell=True taint.
+    assert any(
+        "dangerous-subprocess-shell-true" in i.code for i in results.semgrep_issues
+    ), "semgrep should flag subprocess shell=True against the pinned ruleset"
+
+    # AC4: the shell-injection class must appear exactly once in the merged
+    # security_issues (bandit B602 + semgrep collapse to one at the same line).
+    shell_findings = [
+        i
+        for i in results.security_issues
+        if i.code in {"B602", "B603", "B604"}
+        or "dangerous-subprocess-shell-true" in i.code
+    ]
+    # Group by (file, line) — no location should carry two shell findings.
+    by_loc: dict[tuple[str, int], int] = {}
+    for f in shell_findings:
+        by_loc[(f.file, f.line)] = by_loc.get((f.file, f.line), 0) + 1
+    assert all(count == 1 for count in by_loc.values()), (
+        f"shell-injection double-counted across bandit+semgrep: {by_loc}"
+    )
+
+
+def test_semgrep_available_requires_binary_and_ruleset():
+    # Sanity: availability gate needs both the binary and the pinned ruleset.
+    with patch("tapps_mcp.tools.semgrep.shutil.which", return_value=None):
+        assert semgrep_available() is False
+    if shutil.which("semgrep"):
+        assert semgrep_available() is True
+
+
+def test_async_and_sync_wrappers_consistent():
+    # Both wrappers short-circuit to None when the binary is absent.
+    with patch("tapps_mcp.tools.semgrep.semgrep_available", return_value=False):
+        from tapps_mcp.tools.semgrep import run_semgrep_check_async
+
+        assert run_semgrep_check("x.py") is None
+        assert asyncio.run(run_semgrep_check_async("x.py")) is None


### PR DESCRIPTION
Closes TAP-4529 (Tier 1 of TAP-4525).

## What
Adds semgrep to the scorer's security fan-out beside bandit — semantic/taint findings (shell=True injection, eval/exec, insecure pickle, unsafe yaml.load, weak MD5/SHA1) via a **pinned in-repo ruleset** (`scoring/semgrep_rules/tapps-security.yml`, 5 rules). Deterministic and offline (ADR-0004): `--config <local-path>` only, `--disable-version-check`, `--metrics=off`, no registry/`auto` fetch.

## Key decisions
- **Not hard-pinned in `pyproject.toml`** — semgrep's `click<8.2`/`tomli<2.1` transitive pins conflict irreconcilably with the workspace + pip-audit, making `uv sync` unresolvable. It's an **optional out-of-band install** (`pipx install semgrep`) auto-detected via `shutil.which`; absence → `skipped_tools` note, never a crash (AC3).
- Cross-checker dedupe on `(semantic-category, file, line)`, bandit-wins, so overlapping shell/eval/pickle/yaml/hash findings aren't double-counted (AC4). `SecurityIssue.source` carries provenance.

## Tests
Live semgrep 1.168.0 ran: taint reported once across merged findings. 336 passed in the touched slice (`semgrep/scorer/security/parallel/quality_gate`); new code clean under ruff+mypy. Remaining full-suite failures are pre-existing, unrelated buckets (platform_generators/pyinstaller/skills/upgrade), verified present on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)