### PR TITLE
feat(skills): platform orchestration-prompt skill + multi-file smart-merge

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -1359,6 +1359,52 @@ def check_linear_issue_skill_current(project_root: Path) -> CheckResult:
     return CheckResult("linear-issue skill", False, message, detail)
 
 
+def check_orchestration_prompt_skill_current(project_root: Path) -> CheckResult:
+    """Check the ``orchestration-prompt`` skill is deployed with its companions.
+
+    The skill is multi-file (TAP orchestration-prompt platformisation): SKILL.md
+    carries the managed-block marker (proving smart-merge is wired, not a stale
+    hand-authored copy) and ships ``assets/prompt-template.md`` +
+    ``references/claude-feature-map.md``. Only hosts that already have the skill
+    deployed are validated — the skill is opt-in per host, so absence everywhere
+    is reported as ok (nothing to check), while a *partial* deployment is flagged.
+    """
+    marker = "<!-- BEGIN: tapps-skill orchestration-prompt"
+    companions = ("assets/prompt-template.md", "references/claude-feature-map.md")
+    valid_hosts: list[str] = []
+    problems: list[str] = []
+    for host_label, base in _tapps_skill_bases(project_root):
+        skill_dir = base / "orchestration-prompt"
+        skill_path = skill_dir / "SKILL.md"
+        if not skill_path.exists():
+            continue  # not deployed on this host — opt-in, not a failure
+        content = skill_path.read_text(encoding="utf-8")
+        if marker not in content:
+            problems.append(f"{host_label}/orchestration-prompt stale (no managed-block marker)")
+            continue
+        missing = [c for c in companions if not (skill_dir / c).exists()]
+        if missing:
+            problems.append(f"{host_label}/orchestration-prompt missing {', '.join(missing)}")
+            continue
+        valid_hosts.append(host_label)
+
+    if not valid_hosts and not problems:
+        return CheckResult(
+            "orchestration-prompt skill",
+            True,
+            "orchestration-prompt skill not deployed (opt-in) — nothing to check",
+        )
+    if valid_hosts and not problems:
+        return CheckResult(
+            "orchestration-prompt skill",
+            True,
+            f"orchestration-prompt skill current on: {', '.join(valid_hosts)}",
+        )
+    detail = "Run: tapps-mcp upgrade --force"
+    message = problems[0] if len(problems) == 1 else f"Issues: {'; '.join(problems)}"
+    return CheckResult("orchestration-prompt skill", False, message, detail)
+
+
 def check_pretooluse_matchers(project_root: Path) -> CheckResult:
     """Report each PreToolUse matcher present in .claude/settings.json (TAP-981).
 
@@ -4888,6 +4934,7 @@ def _collect_checks(root: Path, *, quick: bool = False) -> list[CheckResult]:
     checks.append(check_test_quality_rule(root))
     checks.append(check_config_files_rule(root))
     checks.append(check_linear_issue_skill_current(root))
+    checks.append(check_orchestration_prompt_skill_current(root))
     checks.append(check_finish_task_skill(root))
     checks.append(check_deprecated_wrapper_skills(root))
     checks.append(check_tapps_memory_skill(root))

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skill_orchestration.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skill_orchestration.py
@@ -1,0 +1,433 @@
+"""Platform ``orchestration-prompt`` skill — body + companion files.
+
+Shipped as a multi-file skill (SKILL.md smart-merged via
+``skill_managed_block``; companion reference/template refreshed wholesale;
+``learnings.md`` created-once and never overwritten). Kept in its own module so
+``platform_skills.py`` stays navigable.
+
+The body is the *generic platform core* of loop/harness engineering. Consumer
+specifics (fleet manifest path, observed-failure examples, run-as lines) live in
+each project's preserved region below the managed block — never here.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# SKILL.md body (managed block — smart-merged on upgrade)
+# ---------------------------------------------------------------------------
+
+ORCHESTRATION_PROMPT_SKILL_FRONTMATTER = """\
+---
+name: orchestration-prompt
+user-invocable: true
+model: claude-sonnet-4-6
+description: >-
+  Generate a ready-to-run orchestration PROMPT with an explicit Goal (verifiable
+  done-condition), a Loop (state→decide→execute→verify→repeat with termination),
+  an independent verification pass, and the right Claude Code feature + model tier
+  for each step (subagents, Workflow tool, /goal, /loop, Routines, brain memory).
+  Use whenever the user wants to orchestrate multi-step, multi-repo, autonomous, or
+  recurring work — "create a prompt to…", "orchestrate…", "make a goal for…",
+  "work the backlog", "loop until X" — even if they don't say "orchestrate".
+argument-hint: "[free-form objective]"
+---
+"""
+
+# NOTE: the body below is deliberately host-agnostic prose (no tool grants), so
+# the same text serves both the Claude and Cursor skill hosts.
+ORCHESTRATION_PROMPT_SKILL_BODY = (
+    ORCHESTRATION_PROMPT_SKILL_FRONTMATTER
+    + r"""
+# orchestration-prompt
+
+You produce **prompts, not actions**. The output is a self-contained orchestration
+prompt (a markdown file under `prompts/`) that the user — or a Routine, or a `/goal`
+run — executes later. You write the *loop*; you do not run it.
+
+## Why this exists (the 2026 shift)
+
+Work moved from *prompt engineering* to **loop / harness engineering**: an agent is
+an LLM wrapped in a loop with tools, and the leverage is in the loop's shape — its
+goal, its termination, its verification, and which capability + model tier handles
+each step — not in clever phrasing. Empirically the *harness* (planning →
+delegation → **independent verification** → context management), not the model,
+does most of the work: a well-shaped loop lets a cheaper or open model match a
+frontier one on verification-friendly tasks. A good orchestration prompt makes the
+loop explicit so Claude drives itself to a *provable* finish instead of stopping at
+"good enough".
+
+Every prompt rests on six load-bearing parts. If any is missing, the loop never
+terminates, terminates without finishing, verifies only by self-report, or can't be
+cold-started by a fresh session.
+
+## The method
+
+### 1. Pin the Goal to a *verifiable, demonstrable* done-condition
+
+A `/goal` run checks completion by sending the condition + conversation to a fast
+model after each turn. **That evaluator does not run commands or read files** — it
+judges only what Claude *surfaced in its output*. So the condition must be
+demonstrable, and it must be anchored to **ground truth, not narration**: name the
+deterministic artifact that proves it (an exit code, a test-count line, a diff, a
+query result the loop pasted), so a confident-but-wrong model can't score itself
+green by asserting success.
+
+- Good: "All five repos paste a `pytest` summary line showing 0 failures."
+- Good: "Zero open P1 issues — paste the final query result."
+- Weak: "The code is better" / "tests pass" (nothing in the transcript proves it).
+
+**Then pressure-test for *reachability*, not just verifiability.** A condition can be
+demonstrable yet impossible to satisfy without the system misbehaving. Distinguish
+**validate** goals ("prove X works" — a correct *negative* IS success) from
+**optimize** goals ("drive the metric to 100"). For a validation goal the Done-when
+must accept a *verified-correct negative*, e.g. "a created card passing the gate
+**OR** a verified zero-result run where every stage is green and the empty result is
+*because* the gate correctly held all inputs (≥1 hold validated against ground
+truth)." Otherwise the loop burns its whole budget chasing a target correct behavior
+won't produce.
+
+### 2. Decompose if the goal is large
+
+Break it into **sequential sub-goals, each with its own narrow verifiable
+condition**. The loop advances one sub-goal at a time; each is a checkpoint a fresh
+context can resume from.
+
+### 3. Map each chunk to a plane, a mechanism, and a model tier
+
+The highest-value step — most ad-hoc prompts pick the wrong mechanism *and* pay
+frontier-model rates for mechanical work. Two planes (full catalog in
+`references/claude-feature-map.md`):
+
+- **Coordination plane** — research, audit, triage, synthesis, dispatch,
+  **verification**. Fan-out is good. Tools: **subagents** (3–5 parallel), the
+  **Workflow tool** (budget-capped, resumable fan-out).
+- **Execution plane** — editing code. **One repo at a time, sequentially.** Tools:
+  per-repo PR, **Routines** / `claude -p`+cron for recurring runs. Never fan
+  parallel agents across coupled code — the documented worst fit.
+
+Give every chunk a **model tier**, not just a mechanism — this is how you get
+"frontier results from a cheaper model": run the harness cheap, spend the strong
+model only where judgement is load-bearing.
+
+| The chunk is… | Mechanism | Model tier |
+|---|---|---|
+| "Look across all repos and tell me X" | Workflow / 3–5 subagents | cheap/low-effort (mechanical fan-out) |
+| Mechanical edit, rename, codemod | per-repo dispatch | cheap/low-effort |
+| Hard reasoning, design, ambiguous fix | `/goal` drive | frontier/high-effort |
+| **Independent verify / judge (step 5)** | verifier subagent | **frontier/high-effort** |
+| "Re-check Z every N minutes" | `/loop` → Routine | cheap |
+| "Remember/recall across sessions" | brain (`tapps_memory`) | n/a |
+
+**Commit to the mechanism — don't hedge.** "You *may* dispatch subagents" forces the
+runner to re-decide and usually defaults to the weakest option. Name exactly one
+mechanism + tier per chunk. For **multi-stage parallel work** (N items × ≥2 steps)
+emit a companion Workflow script (`.claude/workflows/<slug>.js`) using
+`pipeline()`/`parallel()` with a result **schema**, a **`budget`** cap, and per-stage
+`model`/`effort`. A **single coupled item** (N=1) is a `/goal` drive, not a Workflow
+— say so in the prompt so the runner doesn't default to one.
+
+### 4. Write the loop with termination + guardrails
+
+Shape every loop as **state → decide → execute → verify → record → (repeat or
+stop)**, with a **diagnose-don't-repeat** branch on any failed verify. Open **state**
+with a brain recall of prior attempts; close each iteration by **recording** the
+outcome (incl. what failed and why). Give the loop an explicit exit, then bake in the
+guardrails below.
+
+**Context hygiene in every iteration.** A long loop rots its own context by
+re-reading the same files. Instruct the loop to prune stale reads, prefer a targeted
+grep/snippet over a full re-Read, and carry forward a compact state summary rather
+than raw transcripts — so iteration N isn't paying for iteration 1's tokens.
+
+### 5. Add an independent verification pass (the harness's biggest lever)
+
+Self-verification is the weakest link: the same agent that did the work judges the
+work and rationalizes its own output. The single largest quality gain in harness
+engineering is a **separate, adversarial verifier** — this is what lets a modest
+model ship reliable results.
+
+- Put verification on the **coordination plane** as its own step: after Execute,
+  spawn a **verifier subagent** (frontier tier) with a *fresh* context, prompted to
+  **refute** the sub-goal's proof — re-run the deterministic check (tests, lint,
+  build, the actual query) rather than trust the executor's narration. Default to
+  "not done" on any doubt.
+- For high-stakes or irreversible steps, use **N independent verifiers + majority**
+  (perspective-diverse where the finding can fail multiple ways: correctness,
+  security, does-it-reproduce), not one. In a Workflow, this is a `parallel()` of
+  verify agents keyed off each finding.
+- The verifier's verdict — not the executor's claim — is what advances the loop or
+  triggers the diagnose branch.
+
+### 6. Make it cold-start runnable (the drop-in test)
+
+The point is a prompt a **brand-new session** can run with zero hand-holding.
+
+- **Self-bootstrap launch line.** `/goal "<condition>"` carries only the *condition*
+  into a fresh session — not the prompt body. So every emitted prompt needs a
+  top-of-file **"How to run (cold start)"** block with one paste-able line that
+  **reads the file in full first, then enters the loop**.
+- **Self-healing preconditions.** Anything the loop needs (a runtime up, a
+  scorer/tool built, a branch, auth reachable) is a **Sub-goal 0** the loop
+  *establishes itself* — never a "set this up first" note the user must action.
+- **Deploy-freshness + smoke/health gate** (any prompt that runs against a live or
+  deployed target, not source): in Sub-goal 0, self-healing — (1) **merged ≠ live**:
+  if the target is a baked image, compare latest merged commit to the build time and
+  rebuild/redeploy (preserving overlays) if `main` is newer; make "ran against a
+  stale image" a required-fail cap. (2) **smoke before spend**: after any
+  rebuild/deploy and before the real run, hit `/health` and one cheap end-to-end
+  call to prove runtime + auth + transport.
+
+## Guardrails every emitted prompt must carry
+
+- **Verifiable termination** — the Goal condition *and* a hard cap (max iterations
+  or a token budget) so a stuck loop stops instead of burning quota.
+- **Independent verification** — the sub-goal's proof is confirmed by a verifier that
+  did not produce the work (method §5), against ground truth.
+- **Caps must not fire on *correct* behavior** — for every required-fail cap, ask "is
+  there a legitimate correct run where this still fires?" Separate *broken* from
+  *correct-empty* (the gate rightly held everything) or a correct negative scores red.
+- **No fan-out of coupled coding** — parallel agents editing related code cascade
+  errors; keep code edits sequential, per repo.
+- **Context hygiene** — prune stale reads each iteration; targeted grep over full
+  re-Read (method §4).
+- **Autonomy, not checkpoints** — act on every reversible in-scope step; for an
+  outward/irreversible step produce a reversible precursor (draft PR, staged diff)
+  and keep going.
+- **Scope** — name the exact repos/paths; reads can be fleet-wide, writes go through
+  the owning repo's channel.
+- **Budget** — every loop carries *both* an iteration cap and a token budget; set a
+  Workflow `budget` to a token ceiling (≈ the autonomy cost gate) so it self-aborts.
+- **Memory** — recall at the start, record the outcome (incl. failures) at each
+  checkpoint, so learning survives the session.
+
+## Autonomy contract (every emitted prompt carries this)
+
+Run like an operator, not an intern. Decide and act on every reversible, in-scope
+step — never insert "should I proceed?" checkpoints. For an irreversible/outward step,
+produce the *reversible precursor* (draft PR, staged diff, written proposal) and
+continue; the human reviews async. A draft PR is not a stop.
+
+Hard-stop and ask **once** (batched, with a recommendation) only when: the step is
+irreversible/outward with no reversible precursor (merge to main, force-push, delete
+un-recreatable data, external message, cross-project write); **or** the projected
+cost of the next step exceeds the configured ceiling (default ≈ $20; honor any higher
+pre-authorization); **or** a genuinely ambiguous decision where a wrong guess is
+expensive and unrecoverable. Enforce the cost gate mechanically via the Workflow
+`budget` so the run aborts itself instead of asking.
+
+## Failure handling (diagnose, don't repeat)
+
+On a failed verify, do **not** re-run the same action. Diagnose first: read the
+actual error, inspect state/files, recall prior failures from the brain, research the
+cause. Form a specific hypothesis, apply a fix, retry with *something changed*. Bound
+it: max **3 distinct strategies** per sub-goal, then escalate once (more capable
+model / different approach), then **stop and surface a concise diagnosis**. Repeating
+the same action on the same error is forbidden.
+
+## Engineering discipline (emit in every prompt's guardrails)
+
+Produce *solutions*, not band-aids: root-cause not workarounds; **no
+green-by-suppression** (never skip/disable a check to pass); **right-sized** (the
+simplest thing that fully solves it); durable over expedient; match repo conventions;
+no silent scope creep.
+
+## Output
+
+1. Read the workspace manifest (e.g. `fleet.md`) for the repos / Linear projects /
+   brain ids involved, if the project has one.
+2. Fill `assets/prompt-template.md` — keep only the sections the task needs. Always
+   keep the **"How to run (cold start)"** block, a **Sub-goal 0** for self-healing
+   preconditions, and the **Verify** step wired to an independent verifier.
+3. If any chunk is multi-stage parallel work, also write the companion
+   `.claude/workflows/<slug>.js` (schema + `budget` + per-stage `model`/`effort`) and
+   point Run-as at it. A single coupled item (N=1) is a `/goal` drive, not a Workflow.
+4. Save the prompt to `prompts/<short-slug>.md`.
+5. **Completeness self-check** — every chunk names a concrete mechanism *and* model
+   tier (no "may"); the loop has *both* an iteration cap and a budget; there's an
+   **independent verification** step (not self-report); any fan-out has a schema'd
+   return + per-agent contract; a memory recall+record step; an **Autonomy
+   contract**; a **bounded diagnose-don't-repeat** path; a **context-hygiene** line;
+   and the **Engineering discipline** line. For a live/deployed target, confirm
+   Sub-goal 0 has the deploy-freshness + smoke/health gate. Run the **cold-start
+   test**: a fresh session with nothing loaded can run it. Fix anything weak before
+   saving.
+6. Tell the user exactly how to run it — the `/goal` line, the `/loop` cadence, the
+   Routine schedule, or "invoke the Workflow tool `<script>`" — and from which
+   session.
+
+## Learn as you go (measured evolution)
+
+Before drafting, read `learnings.md` (project-scoped) and fold in relevant lessons.
+When a generation teaches a better pattern — or the user edits your output before
+running it — append a one-line lesson. Keep lessons **project-scoped**; never bleed
+them across repos. Treat this as a *measured* loop, not a scratchpad: the harness
+improves by observing its own runs. When a golden set (`evals/evals.json`) and a
+gated improvement loop (`SELF_IMPROVEMENT.md`) exist, promote a template change only
+when it shows measured lift against the evals — don't hand-tune blind.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# Companion files (refreshed wholesale on upgrade — canonical platform docs)
+# ---------------------------------------------------------------------------
+
+_PROMPT_TEMPLATE = r"""# <Objective title>
+
+> Generated by the `orchestration-prompt` skill. Keep only the sections this task
+> needs. Run from the orchestrator session unless noted.
+
+## How to run (cold start — paste into a NEW session)
+<`/goal "<condition>"` alone does NOT load this file's body, so the launch line must
+read the file first, then loop.>
+
+- **Goal loop (recommended):** `Read prompts/<slug>.md in full, then execute it as a goal loop — run the Loop section repeatedly until Done-when holds, printing the score line every iteration. Establish your own preconditions per Sub-goal 0; do not stop unless an Autonomy hard-stop fires.`
+- **Durable / recurring:** save as a Routine (one item per run) so it survives the terminal.
+
+## Objective
+<one sentence — the outcome, not the steps>
+
+## Done-when (Goal condition — ground-truth, not narration)
+<a single condition Claude's own output can demonstrate. Name the deterministic
+artifact that proves it — exit code, test-count line, diff, pasted query result.>
+
+## Sub-goals  (sequential; each a checkpoint)
+0. **Establish preconditions (self-healing — the loop sets these up, NOT the user).** <runtime up, scorer/tool built, auth reachable, branch ready>
+   - **Deploy freshness (live/deployed target only):** merged ≠ live. If baked image, compare latest merged commit to build time; rebuild/redeploy (preserve overlays) if `main` is newer. Stale image = required-fail cap.
+   - **Smoke + health gate (after any deploy, before the real run):** `/health` is `ok|degraded` and one cheap end-to-end call succeeds.
+   - proof: <preconditions verified; for live targets — image no older than latest merged commit + a 200/non-error smoke pasted>
+1. <narrow, verifiable> — proof: <ground-truth artifact>
+2. <…>
+
+## Plane map  (mechanism + model tier per chunk)
+| Step | Plane | Mechanism | Model tier | Notes |
+|------|-------|-----------|-----------|-------|
+| <audit/research> | coordination | Workflow / 3–5 subagents | cheap/low-effort | fan-out OK |
+| <code change> | execution | dispatch to <repo> via PR | cheap unless hard | one repo at a time |
+| <verify proof> | coordination | **verifier subagent (fresh context)** | **frontier/high-effort** | refutes the proof; re-runs the check |
+| <recurring check> | execution | Routine / `claude -p`+cron | cheap | human-gated |
+
+## Loop
+- **State:** <read first — status, brain recall of prior attempts, Linear>
+- **Decide:** <how to pick the next action / sub-goal>
+- **Execute:** <the action, on the committed mechanism + tier>
+- **Verify (independent):** spawn a fresh-context verifier (frontier tier) to *refute* the sub-goal's proof — re-run the deterministic check, don't trust the executor's claim. The verifier's verdict advances the loop.
+- **On fail:** diagnose (error + state + brain recall) → hypothesis → fix → retry *differently*; ≤3 distinct strategies, then escalate once, then stop with a diagnosis
+- **Record:** <save outcome + any failure-and-why to the brain>
+- **Context hygiene:** prune stale reads; carry a compact state summary, not raw transcripts.
+- **Repeat or stop:** loop until **Done-when** holds; caps: <N iterations> AND <token budget>
+
+## Guardrails
+- Termination: <goal condition>; caps: <N iterations> AND <token budget>.
+- Independent verification (not self-report); ground-truth proof.
+- No fan-out of coupled coding — sequential per-repo edits.
+- Context hygiene — targeted grep over full re-Read.
+- Scope: repos in play = <list>; reads fleet-wide, writes via owner.
+- Memory: recall at start; record outcome (incl. failures) at each checkpoint.
+- Discipline: root-cause not workarounds; no green-by-suppression; right-sized; durable; match conventions; no scope creep.
+
+## Autonomy
+- Act on every reversible, in-scope step — no "should I proceed?" checkpoints.
+- Irreversible/outward step → produce the reversible precursor (draft PR / staged diff / proposal) and continue; human reviews async.
+- Hard-stop once (batched, with a recommendation) only for: irreversible/outward with no precursor · projected next-step cost > ceiling · unsafe-to-guess ambiguity.
+
+## Failure handling
+- On failed verify: diagnose (error + state + brain recall) → hypothesis → fix → retry *differently*.
+- ≤3 distinct strategies per sub-goal; then escalate once; then stop with a concise diagnosis. Never repeat the same action on the same error.
+
+## Context
+- Repos: <manifest — path · Linear project · brain project_id>
+- Prior learnings: <brain recall query, if any>
+
+## Run-as
+<exact invocation, e.g.:>
+- **Cold-start loop (recommended):** the paste line from "How to run" above. **or**
+- `/goal <condition>` — only if this file is already in context. **or**
+- invoke the Workflow tool with `.claude/workflows/<script>.js` (fan-out only). **or**
+- Routine: schedule `<cadence>` with this prompt, push=draft-PR.
+"""
+
+_FEATURE_MAP = r"""# Claude feature map — intent → mechanism → model tier
+
+Read this when choosing how a chunk of an orchestration prompt should run. Put each
+step on the cheapest, most durable mechanism that fits — and the cheapest model tier
+that still gets it right. Spend the frontier model only where judgement is
+load-bearing (hard reasoning, and the independent verify/judge step).
+
+## The two planes
+
+- **Coordination plane** (research/audit/triage/synthesis/dispatch/**verification**):
+  fan-out is good — you can usefully spend tokens in parallel. Token-spend-in-parallel
+  is the test for whether to fan out at all.
+- **Execution plane** (writing code): sequential, one repo at a time. Coupled coding
+  is the worst fit for fan-out (tight dependencies, shared context, error cascade).
+
+## Mechanism catalog
+
+| Mechanism | What it is | Best for | Watch out |
+|---|---|---|---|
+| **`/goal <condition>`** | Drives turn-after-turn until a fast model judges the condition met (against Claude's *surfaced output*, not by running commands) | One job to a provable finish | Condition must be demonstrable + ground-truth-anchored; decompose large goals |
+| **`/loop [interval] <prompt>`** | Re-runs a prompt on a timer / each turn | Polling, babysitting a build/PR | Session-bound — dies with the terminal; never your durable layer |
+| **Scheduled Routine** | Saved config run on cloud cron | "Nightly: take top backlog item, open a draft PR" | Keep a human review gate |
+| **`claude -p` + cron / CI** | Headless one-shot via external scheduler | Durable recurring runs, zero preview risk | Feature-light; no session persistence |
+| **Workflow tool** | Deterministic JS orchestration (`phase/agent/parallel/pipeline`), budget-capped, resumable, per-stage `model`/`effort` | Bounded parallel multi-repo sweeps; fan-out verify | Per-invocation, not a persistent loop |
+| **Subagents** | Focused workers in isolated context, report back | 3–5 parallel research/review/**verify** tasks | Don't fan out coupled coding; declare minimal tools |
+| **Verifier subagent** | A fresh-context agent prompted to *refute* a claim, re-running the check | Confirming a sub-goal's proof independently of the executor | The whole point is a *different* context — don't reuse the executor |
+| **brain / `tapps_memory`** | Shared episodic+semantic memory (per-repo `project_id`) | Recall prior attempts; avoid rediscovery | Cross-project recall needs an explicit `project_id` |
+
+## Model-tier selector
+
+| The chunk is… | Tier |
+|---|---|
+| Mechanical fan-out, read/summarize, codemod, rename | cheap / low-effort |
+| Hard reasoning, ambiguous fix, architecture, design | frontier / high-effort |
+| **Independent verify / judge** | **frontier / high-effort** (a weak verifier defeats the pattern) |
+| Recurring poll, status check | cheap |
+
+Running the harness cheap and spending the strong model only on reasoning + verify is
+exactly how a modest base model reaches frontier-level reliability.
+
+## `/goal` vs `/loop`
+
+- `/goal` = **drive one job to done.** Condition-checked, self-terminating.
+- `/loop` = **poll/repeat on a cadence.** No notion of "done".
+- Recurring autonomous work that must survive the terminal → **Routine** (or
+  `claude -p`+cron), not `/loop`.
+
+## Anti-patterns to encode against
+
+- One enormous goal → sequence narrow sub-goals.
+- Unbounded loop (no cap/budget) → always set max iterations or a token budget.
+- **Self-verification only** → add an independent, adversarial verifier.
+- Paying frontier rates for mechanical fan-out → tier the model per chunk.
+- Parallel agents on coupled code → sequential per-repo dispatch.
+- Vague done-condition → demonstrable, ground-truth-anchored condition.
+- Context rot (re-reading the same files each iteration) → prune + targeted grep.
+"""
+
+_LEARNINGS_SEED = """\
+# orchestration-prompt learnings (project-scoped)
+
+Append one-line lessons as you generate prompts. Keep them project-scoped; never
+bleed across repos. This file is created once by the scaffolder and never
+overwritten on upgrade — it's yours.
+
+<!-- Example: -->
+<!-- - Validation goals need a verified-correct-negative Done-when, or the loop chases an unreachable target. (2026-06-18) -->
+"""
+
+# Companion files refreshed on every upgrade (canonical platform docs).
+ORCHESTRATION_PROMPT_COMPANION_FILES: dict[str, str] = {
+    "assets/prompt-template.md": _PROMPT_TEMPLATE,
+    "references/claude-feature-map.md": _FEATURE_MAP,
+}
+
+# Files created once and NEVER overwritten (project-owned).
+ORCHESTRATION_PROMPT_CREATE_ONLY_FILES: dict[str, str] = {
+    "learnings.md": _LEARNINGS_SEED,
+}
+
+__all__ = [
+    "ORCHESTRATION_PROMPT_COMPANION_FILES",
+    "ORCHESTRATION_PROMPT_CREATE_ONLY_FILES",
+    "ORCHESTRATION_PROMPT_SKILL_BODY",
+]

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skills.py
@@ -16,6 +16,12 @@ from tapps_mcp.pipeline.agent_contract import (
     TOOL_REFERENCE_CALL_GRAPH_ROWS,
     finish_task_checklist_and_doc_gaps,
 )
+from tapps_mcp.pipeline.platform_skill_orchestration import (
+    ORCHESTRATION_PROMPT_COMPANION_FILES,
+    ORCHESTRATION_PROMPT_CREATE_ONLY_FILES,
+    ORCHESTRATION_PROMPT_SKILL_BODY,
+)
+from tapps_mcp.pipeline.skill_managed_block import install_or_refresh_skill
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -110,9 +116,13 @@ DEPRECATED_TAPPS_SKILLS: frozenset[str] = frozenset(
     {"tapps-score", "tapps-gate", "tapps-validate", "tapps-report"}
 )
 
-_FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CURSOR = finish_task_checklist_and_doc_gaps(claude_nlt_prefix=False)
+_FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CURSOR = finish_task_checklist_and_doc_gaps(
+    claude_nlt_prefix=False
+)
 
-_FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CLAUDE = finish_task_checklist_and_doc_gaps(claude_nlt_prefix=True)
+_FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CLAUDE = finish_task_checklist_and_doc_gaps(
+    claude_nlt_prefix=True
+)
 
 # ---------------------------------------------------------------------------
 # Skills templates (Story 12.8)
@@ -133,9 +143,13 @@ Close out the current task end-to-end. Run each step; do NOT skip one that faile
 
 1. **Validate changed files.** Identify the files you edited this session (git status, your edit history). Call `mcp__nlt-build__tapps_validate_changed` with explicit `file_paths` (comma-separated) scoped to those files. **Never call without `file_paths`.** Default is quick mode. If any file fails, list it with the top blocking issue and stop — the task is not complete. Do not proceed to step 2 until all changed files pass.
 
-   """ + FINISH_TASK_VALIDATE_CALL_GRAPH_NOTE + """
+   """
+    + FINISH_TASK_VALIDATE_CALL_GRAPH_NOTE
+    + """
 
-""" + _FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CLAUDE + """
+"""
+    + _FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CLAUDE
+    + """
 
 4. **Save learnings (conditional).** If this session produced a non-obvious architectural or pattern-level decision — a new convention, a subtle trade-off, a gotcha someone else would re-discover — run `uv run tapps-mcp memory save --key <slug> --tier <architectural|pattern> --value "<concise decision>"` (CLI via BrainBridge). Skip for routine fixes, refactors where the code documents the decision, or trivial bugfixes. Brain offline → skip silently.
 
@@ -160,7 +174,9 @@ disable-model-invocation: true
 
 End the session with a durable handoff the next chat can load via `/tapps-continue-session`.
 
-""" + _HANDOFF_PRE_GATE + """
+"""
+    + _HANDOFF_PRE_GATE
+    + """
 
 1. **Draft handoff (5–10 bullets).** From this session's work, write:
    - **Done** — what shipped or was verified
@@ -171,11 +187,17 @@ End the session with a durable handoff the next chat can load via `/tapps-contin
    - **Verify** — commands to run first in the next session
    - **Success criterion** — one line
 
-""" + _HANDOFF_P0_GATE + """
+"""
+    + _HANDOFF_P0_GATE
+    + """
 
-""" + _HANDOFF_MARKDOWN_SHAPE + """
+"""
+    + _HANDOFF_MARKDOWN_SHAPE
+    + """
 
-""" + _HANDOFF_PERSIST + """
+"""
+    + _HANDOFF_PERSIST
+    + """
 
 3. **Report.** One line: `Handoff written: .tapps-mcp/session-handoff.md. Linear P0: <id|none>. brain_mirror: ok|skipped. session_end: ok|skipped. Next session: invoke /tapps-continue-session`
 """,
@@ -199,13 +221,17 @@ Start work in a fresh context window by assembling structured state — not a us
    - **Preferred:** Call `mcp__nlt-build__tapps_session_start()`. If `data.compaction_rehydration` is present, summarize it in one sentence.
    - **CLI fallback** (MCP unavailable): Run `uv run tapps-mcp doctor --quick` and read `.tapps-mcp.yaml` for project context (quality preset, brain URL, engagement). Proceed without blocking.
 
-""" + _CONTINUE_LOAD_AND_CONTEXT + """
+"""
+    + _CONTINUE_LOAD_AND_CONTEXT
+    + """
 
 3. **Linear context.**
    - If the user passed `TAP-####` (argument or in handoff **Linear P0**), call `mcp__plugin_linear_linear__get_issue(id=...)`.
    - For backlog/triage without a known id, invoke the `linear-read` skill instead of raw `list_issues` (do not call `list_issues` directly — cache gate).
 
-""" + _CONTINUE_EMIT_AND_PROCEED + """
+"""
+    + _CONTINUE_EMIT_AND_PROCEED
+    + """
 """,
     "tapps-review-pipeline": """\
 ---
@@ -446,7 +472,9 @@ provide the full tool reference from this skill.
 | **tapps_security_scan** | Security-sensitive changes or before security review |
 | **tapps_validate_config** | When adding/changing Dockerfile, docker-compose, infra |
 | **tapps_impact_analysis** | Module-level import blast radius before API or layout changes |
-""" + TOOL_REFERENCE_CALL_GRAPH_ROWS + """
+"""
+    + TOOL_REFERENCE_CALL_GRAPH_ROWS
+    + """
 | **tapps_dead_code** | Find unused code during refactoring |
 | **tapps_dependency_scan** | Check for CVEs before releases |
 | **tapps_dependency_graph** | Understand module dependencies, circular imports |
@@ -1144,9 +1172,13 @@ Close out the current task end-to-end. Run each step; do NOT skip one that faile
 
 1. **Validate changed files.** Identify files edited this session (git status, edit history). Call `tapps_validate_changed` with explicit `file_paths` (comma-separated). Never call without `file_paths`. If any file fails, list it with the top blocking issue and stop.
 
-   """ + FINISH_TASK_VALIDATE_CALL_GRAPH_NOTE + """
+   """
+    + FINISH_TASK_VALIDATE_CALL_GRAPH_NOTE
+    + """
 
-""" + _FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CURSOR + """
+"""
+    + _FINISH_TASK_CHECKLIST_AND_DOC_GAPS_CURSOR
+    + """
 
 4. **Save learnings (conditional).** If the session produced a non-obvious architectural or pattern-level decision, run `uv run tapps-mcp memory save --key <slug> --tier <architectural|pattern> --value "<decision>"` (CLI via BrainBridge). Skip for routine fixes. Brain offline → skip silently.
 5. **Report.** Emit a one-line summary: `Files validated: N pass. Checklist: <task_type> complete. Doc gaps: cleared|none. Memory saved: yes|no.`
@@ -1168,15 +1200,23 @@ mcp_tools:
 
 End the session with a durable handoff the next chat loads via `tapps-continue-session`.
 
-""" + _HANDOFF_PRE_GATE + """
+"""
+    + _HANDOFF_PRE_GATE
+    + """
 
 1. **Draft handoff (5–10 bullets):** Done, Open, Next (P0), Blockers (`- none` when clear), optional Changed files, Verify, Success criterion.
 
-""" + _HANDOFF_P0_GATE + """
+"""
+    + _HANDOFF_P0_GATE
+    + """
 
-""" + _HANDOFF_MARKDOWN_SHAPE + """
+"""
+    + _HANDOFF_MARKDOWN_SHAPE
+    + """
 
-""" + _HANDOFF_PERSIST + """
+"""
+    + _HANDOFF_PERSIST
+    + """
 
 3. **Report.** `Handoff: .tapps-mcp/session-handoff.md. Linear P0: <id|none>. brain_mirror: ok|skipped. session_end: ok|skipped. Next: tapps-continue-session`
 """,
@@ -1199,13 +1239,17 @@ Start work in a fresh context by assembling structured state.
    - **Preferred:** Call `tapps_session_start()`. Note `compaction_rehydration` if present.
    - **CLI fallback** (MCP unavailable): Run `uv run tapps-mcp doctor --quick` and read `.tapps-mcp.yaml` for project context. Proceed without blocking.
 
-""" + _CONTINUE_LOAD_AND_CONTEXT + """
+"""
+    + _CONTINUE_LOAD_AND_CONTEXT
+    + """
 
 3. **Linear context.**
    - If the user passed `TAP-####` (argument or handoff **Linear P0**), call `get_issue(id=...)`.
    - For backlog/triage without a known id, invoke the `linear-read` skill — do not call raw `list_issues` (cache gate).
 
-""" + _CONTINUE_EMIT_AND_PROCEED + """
+"""
+    + _CONTINUE_EMIT_AND_PROCEED
+    + """
 """,
     "tapps-review-pipeline": """\
 ---
@@ -1369,7 +1413,9 @@ tapps_validate_changed (before complete, always pass file_paths), tapps_checklis
 | **tapps_security_scan** | Security-sensitive changes or before security review |
 | **tapps_validate_config** | When adding/changing Dockerfile, docker-compose, infra |
 | **tapps_impact_analysis** | Module-level import blast radius before API or layout changes |
-""" + TOOL_REFERENCE_CALL_GRAPH_ROWS + """
+"""
+    + TOOL_REFERENCE_CALL_GRAPH_ROWS
+    + """
 | **tapps_dead_code** | Find unused code during refactoring |
 | **tapps_dependency_scan** | Check for CVEs before releases |
 | **tapps_dependency_graph** | Understand module dependencies, circular imports |
@@ -1726,13 +1772,55 @@ Post a structured Linear project update document when a new version is released.
 """,
 }
 
-from tapps_mcp.pipeline.platform_domain_skills import (  # noqa: E402
+from tapps_mcp.pipeline.platform_domain_skills import (
     CLAUDE_DOMAIN_SKILLS,
     CURSOR_DOMAIN_SKILLS,
 )
 
 CLAUDE_SKILLS.update(CLAUDE_DOMAIN_SKILLS)
 CURSOR_SKILLS.update(CURSOR_DOMAIN_SKILLS)
+
+# ---------------------------------------------------------------------------
+# Multi-file / smart-merge skills (orchestration-prompt platformisation)
+# ---------------------------------------------------------------------------
+# The body is host-agnostic prose (no tool grants), so the same text serves the
+# Claude and Cursor hosts.
+CLAUDE_SKILLS["orchestration-prompt"] = ORCHESTRATION_PROMPT_SKILL_BODY
+CURSOR_SKILLS["orchestration-prompt"] = ORCHESTRATION_PROMPT_SKILL_BODY
+
+# Skills whose SKILL.md is refreshed via the managed-block smart-merge instead of
+# the all-or-nothing skip/overwrite: the platform body is replaced surgically and
+# each project's customizations (outside the markers) are preserved.
+SMART_MERGE_SKILL_NAMES: frozenset[str] = frozenset({"orchestration-prompt"})
+
+# Companion files shipped alongside a skill's SKILL.md. Refreshed wholesale on
+# every init/upgrade — canonical platform docs, not customization points.
+SKILL_COMPANION_FILES: dict[str, dict[str, str]] = {
+    "orchestration-prompt": ORCHESTRATION_PROMPT_COMPANION_FILES,
+}
+
+# Companion files created once and NEVER overwritten (project-owned state).
+SKILL_CREATE_ONLY_FILES: dict[str, dict[str, str]] = {
+    "orchestration-prompt": ORCHESTRATION_PROMPT_CREATE_ONLY_FILES,
+}
+
+
+def _write_skill_companions(skill_dir: Path, skill_name: str) -> None:
+    """Write a skill's companion files: canonical docs (refresh) + seed-once state.
+
+    Canonical companion files (templates, references) are rewritten every call so
+    upgrades deliver doc fixes. Create-only files (``learnings.md``) are written
+    solely when absent so project-owned content is never clobbered.
+    """
+    for rel_path, content in SKILL_COMPANION_FILES.get(skill_name, {}).items():
+        target = skill_dir / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    for rel_path, content in SKILL_CREATE_ONLY_FILES.get(skill_name, {}).items():
+        target = skill_dir / rel_path
+        if not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
 
 
 def generate_skills(
@@ -1777,6 +1865,21 @@ def generate_skills(
         skill_dir = skills_base / skill_name
         skill_dir.mkdir(parents=True, exist_ok=True)
         target = skill_dir / "SKILL.md"
+
+        if skill_name in SMART_MERGE_SKILL_NAMES:
+            # Managed-block smart-merge: refresh the platform body in place while
+            # preserving each project's customizations outside the markers. Runs
+            # every call (init and upgrade) — the merger itself is idempotent.
+            action = install_or_refresh_skill(target, content, skill_name)
+            _write_skill_companions(skill_dir, skill_name)
+            if action == "created":
+                created.append(skill_name)
+            elif action == "unchanged":
+                skipped.append(skill_name)
+            else:  # refreshed | migrated
+                updated.append(skill_name)
+            continue
+
         full_content = engagement_note + content
         if target.exists():
             refresh = overwrite or skill_name in SESSION_TRANSFER_SKILL_NAMES

--- a/packages/tapps-mcp/src/tapps_mcp/pipeline/skill_managed_block.py
+++ b/packages/tapps-mcp/src/tapps_mcp/pipeline/skill_managed_block.py
@@ -1,0 +1,113 @@
+"""Marker-wrapped managed block for multi-file skills (orchestration-prompt).
+
+Most platform skills ship a single ``SKILL.md`` that ``generate_skills`` skips
+on upgrade to preserve customizations. That all-or-nothing rule is wrong for a
+skill like ``orchestration-prompt``, which has a large platform-canonical body
+*and* per-project customizations (fleet manifest refs, observed-failure
+examples, run-as specifics) interwoven by consumers.
+
+This module gives such skills a surgical smart-merge: the platform body lives
+inside two HTML-comment markers; ``tapps_upgrade`` refreshes only that block and
+preserves everything outside it (the project region) verbatim.
+
+Reference pattern: ``tapps_obligations_block.py`` / ``karpathy_block.py`` — the
+three are intentionally similar so a future refactor can share infrastructure.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Literal
+
+from tapps_mcp import __version__
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+Action = Literal["created", "refreshed", "migrated", "unchanged"]
+
+MARKER_BEGIN_PREFIX = "<!-- BEGIN: tapps-skill"
+MARKER_END = "<!-- END: tapps-skill -->"
+
+# Heading that introduces the preserved project region on a legacy migration.
+PROJECT_REGION_HEADING = (
+    "<!-- tapps-skill-project-customizations: preserved from the pre-marker "
+    "version — review and trim any content the managed block above now covers -->"
+)
+
+_VERSION_RE = re.compile(r"<!--\s*BEGIN:\s*tapps-skill\s+([\w-]+)\s+v([\d.]+)\s*-->")
+
+
+def _find_block_span(content: str) -> tuple[int, int] | None:
+    """Return ``(begin, end_exclusive)`` covering the BEGIN..END markers."""
+    begin = content.find(MARKER_BEGIN_PREFIX)
+    if begin == -1:
+        return None
+    end_idx = content.find(MARKER_END, begin)
+    if end_idx == -1:
+        return None
+    return begin, end_idx + len(MARKER_END)
+
+
+def wrap_with_markers(body: str, skill_name: str, *, version: str = __version__) -> str:
+    """Return *body* wrapped in BEGIN/END markers stamped with skill + version."""
+    inner = body.strip("\n")
+    return f"{MARKER_BEGIN_PREFIX} {skill_name} v{version} -->\n{inner}\n{MARKER_END}"
+
+
+def install_or_refresh_skill(
+    path: Path,
+    body: str,
+    skill_name: str,
+    *,
+    dry_run: bool = False,
+    version: str = __version__,
+) -> Action:
+    """Install or surgically refresh the managed block in a skill's ``SKILL.md``.
+
+    - **File missing** → write a fresh file containing only the markered block
+      (``"created"``).
+    - **Markers present** → replace the block if it differs (``"refreshed"``),
+      else ``"unchanged"``. Content outside the markers is preserved verbatim.
+    - **Markers absent (legacy hand-authored copy)** → keep the old content as a
+      preserved project region *below* the fresh managed block (``"migrated"``).
+      Nothing is lost; the operator trims the duplicated region afterwards.
+
+    ``dry_run=True`` computes the action without writing.
+    """
+    new_block = wrap_with_markers(body, skill_name, version=version)
+
+    if not path.exists():
+        if not dry_run:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(new_block + "\n", encoding="utf-8")
+        return "created"
+
+    original = path.read_text(encoding="utf-8")
+    span = _find_block_span(original)
+
+    if span is not None:
+        begin, end = span
+        if original[begin:end] == new_block:
+            return "unchanged"
+        updated = original[:begin] + new_block + original[end:]
+        action: Action = "refreshed"
+    else:
+        # Legacy unmarked skill: preserve the whole prior body as a project region.
+        preserved = original.strip("\n")
+        updated = f"{new_block}\n\n{PROJECT_REGION_HEADING}\n\n{preserved}\n"
+        action = "migrated"
+
+    if not dry_run:
+        path.write_text(updated, encoding="utf-8")
+    return action
+
+
+__all__ = [
+    "MARKER_BEGIN_PREFIX",
+    "MARKER_END",
+    "PROJECT_REGION_HEADING",
+    "Action",
+    "install_or_refresh_skill",
+    "wrap_with_markers",
+]

--- a/packages/tapps-mcp/tests/unit/test_orchestration_prompt_skill.py
+++ b/packages/tapps-mcp/tests/unit/test_orchestration_prompt_skill.py
@@ -1,0 +1,153 @@
+"""Tests for the multi-file, smart-merged ``orchestration-prompt`` platform skill.
+
+Covers three concerns:
+- ``generate_skills`` scaffolds SKILL.md + companion files + seed learnings.
+- ``skill_managed_block.install_or_refresh_skill`` refreshes the managed block
+  while preserving project customizations (and migrates legacy unmarked copies).
+- companion docs refresh on upgrade but ``learnings.md`` is never overwritten.
+- the doctor check reports current / stale / partial correctly.
+"""
+
+from __future__ import annotations
+
+from tapps_mcp.distribution.doctor import check_orchestration_prompt_skill_current
+from tapps_mcp.pipeline.platform_skills import generate_skills
+from tapps_mcp.pipeline.skill_managed_block import (
+    MARKER_BEGIN_PREFIX,
+    MARKER_END,
+    install_or_refresh_skill,
+    wrap_with_markers,
+)
+
+SKILL = "orchestration-prompt"
+
+
+def _skill_dir(root, host="claude"):
+    return root / f".{host}" / "skills" / SKILL
+
+
+class TestScaffold:
+    def test_creates_skill_and_companions(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        d = _skill_dir(tmp_path)
+        assert (d / "SKILL.md").exists()
+        assert (d / "assets" / "prompt-template.md").exists()
+        assert (d / "references" / "claude-feature-map.md").exists()
+        assert (d / "learnings.md").exists()
+
+    def test_skill_md_has_managed_marker(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        content = (_skill_dir(tmp_path) / "SKILL.md").read_text()
+        assert f"{MARKER_BEGIN_PREFIX} {SKILL} v" in content
+        assert MARKER_END in content
+        assert "name: orchestration-prompt" in content
+
+    def test_body_carries_the_four_enhancements(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        content = (_skill_dir(tmp_path) / "SKILL.md").read_text().lower()
+        # 1. independent adversarial verifier
+        assert "verifier subagent" in content
+        assert "refute" in content
+        # 2. model / effort tiering
+        assert "model tier" in content
+        # 3. ground-truth over LLM-judge
+        assert "ground truth" in content or "ground-truth" in content
+        # 4. context hygiene
+        assert "context hygiene" in content
+
+    def test_template_has_verifier_and_tier_columns(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        tpl = (_skill_dir(tmp_path) / "assets" / "prompt-template.md").read_text().lower()
+        assert "model tier" in tpl
+        assert "verifier subagent" in tpl
+
+    def test_cursor_host_also_gets_skill(self, tmp_path):
+        generate_skills(tmp_path, "cursor")
+        assert (_skill_dir(tmp_path, "cursor") / "SKILL.md").exists()
+        assert (_skill_dir(tmp_path, "cursor") / "references" / "claude-feature-map.md").exists()
+
+
+class TestSmartMerge:
+    def test_upgrade_preserves_project_region(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        skill_md = _skill_dir(tmp_path) / "SKILL.md"
+        # Simulate a consumer appending a project region below the managed block.
+        marker = "## Project: fleet wiring\n\nSee `fleet.md` for repo ids."
+        skill_md.write_text(skill_md.read_text() + "\n\n" + marker, encoding="utf-8")
+
+        generate_skills(tmp_path, "claude", overwrite=True)  # upgrade path
+        after = skill_md.read_text()
+        assert marker in after  # customization survived
+        assert MARKER_END in after
+
+    def test_learnings_not_overwritten_on_upgrade(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        learnings = _skill_dir(tmp_path) / "learnings.md"
+        learnings.write_text("- my project lesson\n", encoding="utf-8")
+        generate_skills(tmp_path, "claude", overwrite=True)
+        assert learnings.read_text() == "- my project lesson\n"
+
+    def test_companion_docs_refresh_on_upgrade(self, tmp_path):
+        generate_skills(tmp_path, "claude")
+        ref = _skill_dir(tmp_path) / "references" / "claude-feature-map.md"
+        ref.write_text("stale\n", encoding="utf-8")
+        generate_skills(tmp_path, "claude", overwrite=True)
+        assert "feature map" in ref.read_text().lower()  # canonical content restored
+
+
+class TestManagedBlockUnit:
+    def test_created_then_unchanged(self, tmp_path):
+        path = tmp_path / "SKILL.md"
+        assert install_or_refresh_skill(path, "body v1", SKILL) == "created"
+        assert install_or_refresh_skill(path, "body v1", SKILL) == "unchanged"
+
+    def test_refreshed_on_body_change(self, tmp_path):
+        path = tmp_path / "SKILL.md"
+        install_or_refresh_skill(path, "body v1", SKILL)
+        assert install_or_refresh_skill(path, "body v2", SKILL) == "refreshed"
+        assert "body v2" in path.read_text()
+
+    def test_legacy_migration_preserves_old_body(self, tmp_path):
+        path = tmp_path / "SKILL.md"
+        path.write_text("# hand-authored\n\nfleet-specific stuff\n", encoding="utf-8")
+        assert install_or_refresh_skill(path, "platform body", SKILL) == "migrated"
+        after = path.read_text()
+        assert "platform body" in after  # managed block installed
+        assert "fleet-specific stuff" in after  # old content preserved
+        assert after.index(MARKER_BEGIN_PREFIX) < after.index("fleet-specific")
+
+    def test_wrap_roundtrip_stamps_version(self, tmp_path):
+        wrapped = wrap_with_markers("x", SKILL, version="9.9.9")
+        assert f"{MARKER_BEGIN_PREFIX} {SKILL} v9.9.9 -->" in wrapped
+        assert wrapped.endswith(MARKER_END)
+
+
+class TestDoctorCheck:
+    def test_ok_when_fully_deployed(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        generate_skills(tmp_path, "claude")
+        result = check_orchestration_prompt_skill_current(tmp_path)
+        assert result.ok
+        assert "current" in result.message
+
+    def test_ok_when_not_deployed(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        result = check_orchestration_prompt_skill_current(tmp_path)
+        assert result.ok
+        assert "not deployed" in result.message
+
+    def test_flags_missing_companion(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        generate_skills(tmp_path, "claude")
+        (_skill_dir(tmp_path) / "references" / "claude-feature-map.md").unlink()
+        result = check_orchestration_prompt_skill_current(tmp_path)
+        assert not result.ok
+
+    def test_flags_stale_unmarked_skill(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        d = _skill_dir(tmp_path)
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("# legacy hand-authored, no marker\n", encoding="utf-8")
+        result = check_orchestration_prompt_skill_current(tmp_path)
+        assert not result.ok
+        assert "stale" in result.message

--- a/packages/tapps-mcp/tests/unit/test_platform_generators.py
+++ b/packages/tapps-mcp/tests/unit/test_platform_generators.py
@@ -175,16 +175,17 @@ class TestSkillTemplates:
     """Verify skill template dicts and generation."""
 
     def test_claude_skills_count(self) -> None:
-        # 16 tapps-* (incl. tapps-finish-task, tapps-handoff-session,
-        # tapps-continue-session, tapps-upgrade v3.11.0) + continuous-learning-v2
-        assert len(CLAUDE_SKILLS) == 17
+        # 23 single-file skills (base tapps-* + continuous-learning-v2 + domain
+        # skills) + orchestration-prompt (multi-file, smart-merged). The prior
+        # literal (17) had drifted stale as skills were added over time.
+        assert len(CLAUDE_SKILLS) == 24
 
     def test_cursor_skills_count(self) -> None:
-        assert len(CURSOR_SKILLS) == 17
+        assert len(CURSOR_SKILLS) == 24
 
     def test_generate_claude_skills(self, tmp_path: Path) -> None:
         result = generate_skills(tmp_path, "claude")
-        assert len(result["created"]) == 17
+        assert len(result["created"]) == 24
         assert (tmp_path / ".claude" / "skills" / "tapps-finish-task" / "SKILL.md").exists()
 
     def test_generate_skills_high_engagement(self, tmp_path: Path) -> None:
@@ -204,7 +205,8 @@ class TestSkillTemplates:
 
         generate_skills(tmp_path, "claude")
         result = generate_skills(tmp_path, "claude")
-        assert len(result["skipped"]) == 17 - len(SESSION_TRANSFER_SKILL_NAMES)
+        # orchestration-prompt re-generates identically → "unchanged" → skipped.
+        assert len(result["skipped"]) == 24 - len(SESSION_TRANSFER_SKILL_NAMES)
         assert set(result["updated"]) == set(SESSION_TRANSFER_SKILL_NAMES)
         assert len(result["created"]) == 0
 

--- a/packages/tapps-mcp/tests/unit/test_platform_skills.py
+++ b/packages/tapps-mcp/tests/unit/test_platform_skills.py
@@ -67,8 +67,11 @@ class TestClaudeAllowedTools:
             assert "\ntools:" not in fm, f"{name} still uses 'tools:' instead of 'allowed-tools:'"
 
     def test_all_skills_have_allowed_tools(self) -> None:
+        # orchestration-prompt, like continuous-learning-v2, is a host-agnostic
+        # prose/meta skill with no tool-grant frontmatter (shared body across hosts).
+        no_tool_grant_skills = {"continuous-learning-v2", "orchestration-prompt"}
         for name, content in CLAUDE_SKILLS.items():
-            if name == "continuous-learning-v2":
+            if name in no_tool_grant_skills:
                 continue
             fm = _get_frontmatter(content)
             assert "allowed-tools:" in fm, f"{name} missing 'allowed-tools:' field"
@@ -218,8 +221,10 @@ class TestCursorSkillsUnchanged:
     """Cursor skills should still use mcp_tools, not allowed-tools."""
 
     def test_cursor_skills_use_mcp_tools(self) -> None:
+        # Prose/meta skills carry no tool-grant frontmatter on either host.
+        no_tool_grant_skills = {"continuous-learning-v2", "orchestration-prompt"}
         for name, content in CURSOR_SKILLS.items():
-            if name == "continuous-learning-v2":
+            if name in no_tool_grant_skills:
                 continue
             fm = _get_frontmatter(content)
             assert "mcp_tools:" in fm, f"Cursor {name} should use 'mcp_tools:'"

--- a/packages/tapps-mcp/tests/unit/test_skills_generation.py
+++ b/packages/tapps-mcp/tests/unit/test_skills_generation.py
@@ -181,7 +181,9 @@ class TestSkipExisting:
 
     def test_result_dict_tracks_created(self, tmp_path):
         result = generate_skills(tmp_path, "claude")
-        assert len(result["created"]) == 16
+        # 23 single-file skills (base + domain) + orchestration-prompt (multi-file,
+        # smart-merged). The prior literal (16) had drifted stale as skills were added.
+        assert len(result["created"]) == 24
         assert len(result["skipped"]) == 0
 
     def test_unknown_platform_returns_error(self, tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,10 @@ ignore = [
 "packages/docs-mcp/src/docs_mcp/generators/pattern_poster.py" = ["RUF002", "RUF003"]
 "packages/docs-mcp/src/docs_mcp/generators/diagrams.py" = ["RUF002", "RUF003"]
 "packages/docs-mcp/tests/unit/test_pattern_poster.py" = ["RUF002"]
+# The orchestration-prompt skill body is markdown prose shipped verbatim to
+# SKILL.md; it intentionally uses en dashes, → arrows, and … ellipses to match
+# the other platform skill templates.
+"packages/tapps-mcp/src/tapps_mcp/pipeline/platform_skill_orchestration.py" = ["RUF001", "RUF002", "RUF003"]
 "scripts/**/*.py" = ["T201", "E501", "PLR2004", "ANN", "PTH"]
 "tests/**/*.py" = ["S101", "S105", "S106", "S108", "ANN", "PLR2004", "TC001", "TC003", "RUF059", "B007", "B017", "F841", "N806"]
 


### PR DESCRIPTION
## What

Makes `orchestration-prompt` a **tapps-mcp platform skill** so `init` / `upgrade` / `doctor` deliver and maintain it — instead of it living as hand-authored, drifting copies per repo (nlt-orchestrator, ReportLab). Along the way, adds the scaffolding tapps-mcp was missing for **multi-file skills** and a **surgical smart-merge** so upgrades refresh the platform body without clobbering each project's customizations.

Motivated by a review of AI *harness-engineering* (the "get frontier results from any model via a good harness/loop" idea): the skill's generic core now folds in four upgrades it was missing.

## Scaffolding (the reusable mechanism)

- **`skill_managed_block.py`** — BEGIN/END marker merge for a skill's `SKILL.md` (`created`/`refreshed`/`migrated`/`unchanged`), mirroring `tapps_obligations_block`. A legacy **unmarked** copy migrates: platform block installed, prior body preserved as a project region below the markers — nothing lost.
- **`generate_skills`** — `SMART_MERGE_SKILL_NAMES` route through the merger; companion docs (template, feature-map) refresh wholesale; `learnings.md` is **create-only** (never overwritten). Runs on init and upgrade.
- **doctor** — `check_orchestration_prompt_skill_current`: marker + companion presence. Opt-in (absent ⇒ ok), partial deployment flagged.

## Skill content — the four harness-engineering upgrades

1. **Independent adversarial verifier** as a first-class loop step + plane-map row (self-verification is the weakest link).
2. **Model/effort tiering** per chunk — run the harness cheap, spend the frontier model only on reasoning + verify.
3. **Ground-truth-anchored Done-when** (not LLM-judged narration).
4. **Context-hygiene** directive + measured (evals-gated) learnings evolution.

## Proof

Ran the scaffolder against nlt-orchestrator's **real** customized skill: legacy unmarked file → managed marker installed, fleet-specific `scout-cron-dryrun` example **preserved**, verifier enhancement delivered, companions written, `learnings.md` untouched.

## Tests / gate

- New `test_orchestration_prompt_skill.py` (16 tests: scaffold, smart-merge, legacy migration, doctor) — green.
- Updated stale skill-count literals (`17` → `24`) in three suites that had **already drifted on master**.
- Zero new ruff/mypy findings (prose module gets an en-dash/arrow per-file-ignore, matching the docs-mcp precedent). pre-commit tapps gate: 8/8 pass.

**Note:** master currently has ~6 pre-existing red tests (subagent-count + MCP tool-budget drift) unrelated to this change — confirmed they fail with this branch's code reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)