### PR TITLE
feat(call_graph): TypeScript language-dispatch scaffold (TAP-4537)

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import structlog
@@ -25,6 +26,63 @@ from tapps_mcp.project.call_graph_types import (
 from tapps_mcp.project.import_graph import _DEFAULT_EXCLUDES, _file_to_module, _should_skip
 
 logger = structlog.get_logger(__name__)
+
+# One analyze_file result tuple: (symbols, edges, gaps, parse_failures).
+AnalyzeResult = tuple[
+    list[SymbolRecord],
+    list[CallEdge],
+    list[ResolutionGap],
+    list[ParseFailure],
+]
+# A file analyzer takes (file_path, module, project_root) and returns AnalyzeResult.
+FileAnalyzer = Callable[[Path, str, Path], AnalyzeResult]
+
+# Suffixes we collect during the walk. Python routes to the real analyzer;
+# TypeScript routes to the S2 placeholder until the TS analyzer lands (TAP-4537).
+_PY_SUFFIXES = (".py",)
+_TS_SUFFIXES = (".ts", ".tsx")
+
+
+def _analyze_ts_placeholder(
+    file_path: Path,
+    module: str,
+    project_root: Path,
+) -> AnalyzeResult:
+    """Placeholder TS analyzer — returns empty results until S2 (TAP-4537).
+
+    The real tree-sitter TypeScript analyzer arrives in S2; this keeps the
+    suffix-dispatch wiring exercisable and the ``.ts``/``.tsx`` walk inert.
+    """
+    return ([], [], [], [])
+
+
+def _analyzer_for(suffix: str) -> FileAnalyzer | None:
+    """Route a file suffix to its analyzer, or ``None`` if unsupported."""
+    if suffix in _PY_SUFFIXES:
+        return analyze_file
+    if suffix in _TS_SUFFIXES:
+        return _analyze_ts_placeholder
+    return None
+
+
+def _ts_file_to_module(file_path: Path, project_root: Path) -> str:
+    """Convert a ``.ts``/``.tsx`` path to a slash-delimited module name (TAP-4537).
+
+    Mirrors ``import_graph._file_to_module`` for the Python side but keeps the
+    TS convention: strip a leading ``src/`` segment and drop the ``.ts``/``.tsx``
+    suffix. Returns "" when the path escapes ``project_root``.
+    """
+    try:
+        rel = file_path.relative_to(project_root)
+    except ValueError:
+        return ""
+    parts = list(rel.with_suffix("").parts)
+    if not parts:
+        return ""
+    if parts[0] == "src":
+        parts = parts[1:]
+    return "/".join(parts) if parts else ""
+
 
 __all__ = [
     "CALL_GRAPH_CACHE_REL",
@@ -72,14 +130,27 @@ def build_call_graph_index(
     gaps: list[ResolutionGap] = []
     parse_failures: list[ParseFailure] = []
 
-    for py_file in sorted(project_root.rglob("*.py")):
-        if _should_skip(py_file, excludes) or py_file.name.endswith("_pb2.py"):
+    walk_suffixes = _PY_SUFFIXES + _TS_SUFFIXES
+    source_files = sorted(
+        f
+        for suffix in walk_suffixes
+        for f in project_root.rglob(f"*{suffix}")
+    )
+    for source_file in source_files:
+        if _should_skip(source_file, excludes) or source_file.name.endswith("_pb2.py"):
             continue
-        module = _file_to_module(py_file, project_root, top_level_package)
+        suffix = source_file.suffix
+        analyzer = _analyzer_for(suffix)
+        if analyzer is None:
+            continue
+        if suffix in _TS_SUFFIXES:
+            module = _ts_file_to_module(source_file, project_root)
+        else:
+            module = _file_to_module(source_file, project_root, top_level_package)
         if not module:
             continue
-        file_symbols, file_edges, file_gaps, file_failures = analyze_file(
-            py_file, module, project_root
+        file_symbols, file_edges, file_gaps, file_failures = analyzer(
+            source_file, module, project_root
         )
         symbols.extend(file_symbols)
         edges.extend(file_edges)

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_fingerprint.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_fingerprint.py
@@ -9,6 +9,32 @@ from pathlib import Path
 
 from tapps_mcp.project.import_graph import _DEFAULT_EXCLUDES, _should_skip
 
+# Source-file suffixes folded into the fingerprint (TAP-4537). Python plus the
+# TypeScript pair so a new/edited .ts/.tsx invalidates the call-graph cache.
+_FINGERPRINT_SUFFIXES = (".py", ".ts", ".tsx")
+
+# Sentinel used when tree-sitter-typescript is not installed, so the fingerprint
+# stays stable across environments that lack the optional grammar (TAP-4537).
+_TS_GRAMMAR_ABSENT = "absent"
+
+
+def _ts_grammar_version() -> str:
+    """Return the installed ``tree_sitter_typescript`` version, or a sentinel.
+
+    Folded into the fingerprint so a grammar upgrade invalidates the cache.
+    Imported defensively: the grammar is an optional (``treesitter`` extra)
+    dependency and may be absent.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("tree-sitter-typescript")
+        except PackageNotFoundError:
+            return _TS_GRAMMAR_ABSENT
+    except ImportError:  # pragma: no cover - importlib.metadata always present on 3.12
+        return _TS_GRAMMAR_ABSENT
+
 
 @dataclass(frozen=True)
 class CallGraphFingerprintSettings:
@@ -48,7 +74,7 @@ def _git_fingerprint_component(project_root: Path) -> str | None:
         if head.returncode != 0:
             return None
         dirty = subprocess.run(
-            ["git", "status", "--porcelain", "--", "*.py"],
+            ["git", "status", "--porcelain", "--", *[f"*{s}" for s in _FINGERPRINT_SUFFIXES]],
             cwd=project_root,
             capture_output=True,
             text=True,
@@ -61,7 +87,7 @@ def _git_fingerprint_component(project_root: Path) -> str | None:
                 if len(line) < 4:
                     continue
                 path = line[3:].strip()
-                if path.endswith(".py"):
+                if path.endswith(_FINGERPRINT_SUFFIXES):
                     dirty_paths.append(path.replace("\\", "/"))
         dirty_paths.sort()
         return f"{head.stdout.strip()}|{'|'.join(dirty_paths)}"
@@ -74,14 +100,19 @@ def _mtime_fingerprint_component(settings: CallGraphFingerprintSettings, index_v
     if settings.exclude_patterns:
         excludes.update(settings.exclude_patterns)
     parts = [f"v{index_version}", settings.top_level_package]
-    for py_file in sorted(settings.project_root.rglob("*.py")):
-        if _should_skip(py_file, excludes) or py_file.name.endswith("_pb2.py"):
+    source_files = sorted(
+        f
+        for suffix in _FINGERPRINT_SUFFIXES
+        for f in settings.project_root.rglob(f"*{suffix}")
+    )
+    for source_file in source_files:
+        if _should_skip(source_file, excludes) or source_file.name.endswith("_pb2.py"):
             continue
         try:
-            stat = py_file.stat()
+            stat = source_file.stat()
         except OSError:
             continue
-        rel = py_file.relative_to(settings.project_root)
+        rel = source_file.relative_to(settings.project_root)
         parts.append(f"{rel}:{stat.st_mtime_ns}:{stat.st_size}")
     return "|".join(parts)
 
@@ -92,9 +123,13 @@ def compute_index_fingerprint(
     index_version: int,
 ) -> str:
     """Compute a stable fingerprint for call-graph cache invalidation."""
+    ts_grammar = _ts_grammar_version()
     git_part = _git_fingerprint_component(settings.project_root)
     if git_part is not None:
-        payload = f"git:{git_part}|pkg:{settings.top_level_package}|v{index_version}"
+        payload = (
+            f"git:{git_part}|pkg:{settings.top_level_package}"
+            f"|v{index_version}|ts:{ts_grammar}"
+        )
     else:
-        payload = _mtime_fingerprint_component(settings, index_version)
+        payload = f"{_mtime_fingerprint_component(settings, index_version)}|ts:{ts_grammar}"
     return hashlib.sha256(payload.encode()).hexdigest()[:16]

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 CALL_GRAPH_CACHE_REL = ".tapps-mcp/call-graph-index.json"
-INDEX_VERSION = 2
+# v3 (TAP-4537): SymbolRecord gains a ``language`` tag for the TypeScript
+# language-dispatch scaffold. Bumping this invalidates any v2 cache on load.
+INDEX_VERSION = 3
 SymbolKind = Literal["function", "method"]
 
 # Stable taxonomy for resolution gaps (TAP-4092).
@@ -28,6 +30,9 @@ class SymbolRecord:
     file_path: str
     line: int
     kind: SymbolKind
+    # Source language of the symbol (TAP-4537). Defaults to "python" so cached
+    # v2 indexes (which lack the field) still deserialize via index_from_dict.
+    language: str = "python"
 
 
 @dataclass

--- a/packages/tapps-mcp/tests/unit/test_call_graph_fingerprint.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_fingerprint.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from tapps_mcp.project import call_graph_fingerprint
 from tapps_mcp.project.call_graph_fingerprint import (
     compute_index_fingerprint,
     fingerprint_settings,
@@ -56,3 +59,58 @@ class TestFingerprintSettings:
         settings = fingerprint_settings(tmp_path)
         fp = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
         assert len(fp) == 16
+
+
+class TestTypeScriptFingerprint:
+    """TAP-4537: .ts/.tsx files and grammar version affect the fingerprint."""
+
+    def _write(self, root: Path, rel: str, body: str) -> Path:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def test_ts_file_presence_changes_fingerprint(self, tmp_path: Path) -> None:
+        _write_py(tmp_path, "demo/a.py")
+        settings = fingerprint_settings(tmp_path)
+        before = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        self._write(tmp_path, "demo/widget.ts", "export const x = 1;\n")
+        after = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        assert before != after
+
+    def test_ts_file_edit_changes_fingerprint(self, tmp_path: Path) -> None:
+        ts = self._write(tmp_path, "demo/widget.ts", "export const x = 1;\n")
+        settings = fingerprint_settings(tmp_path)
+        before = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        ts.write_text("export const x = 2;\n", encoding="utf-8")
+        after = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        assert before != after
+
+    def test_tsx_file_presence_changes_fingerprint(self, tmp_path: Path) -> None:
+        _write_py(tmp_path, "demo/a.py")
+        settings = fingerprint_settings(tmp_path)
+        before = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        self._write(tmp_path, "demo/Comp.tsx", "export const C = () => null;\n")
+        after = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        assert before != after
+
+    def test_grammar_version_change_changes_fingerprint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_py(tmp_path, "demo/a.py")
+        settings = fingerprint_settings(tmp_path)
+        monkeypatch.setattr(call_graph_fingerprint, "_ts_grammar_version", lambda: "0.23.2")
+        before = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        monkeypatch.setattr(call_graph_fingerprint, "_ts_grammar_version", lambda: "0.24.0")
+        after = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        assert before != after
+
+    def test_grammar_absent_sentinel_is_stable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_py(tmp_path, "demo/a.py")
+        settings = fingerprint_settings(tmp_path)
+        monkeypatch.setattr(call_graph_fingerprint, "_ts_grammar_version", lambda: "absent")
+        fp1 = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        fp2 = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
+        assert fp1 == fp2

--- a/packages/tapps-mcp/tests/unit/test_call_graph_ts_scaffold.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_ts_scaffold.py
@@ -1,0 +1,114 @@
+"""Tests for the TypeScript language-dispatch scaffold (TAP-4537).
+
+Covers the S1 plumbing only: the ``language`` tag on ``SymbolRecord``, its
+backward-compatible round-trip through ``index_from_dict``, and the suffix →
+analyzer dispatch (Python → real ``analyze_file``, ``.ts``/``.tsx`` → placeholder).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tapps_mcp.project.call_graph import (
+    _analyze_ts_placeholder,
+    _analyzer_for,
+    _ts_file_to_module,
+)
+from tapps_mcp.project.call_graph_analyze import analyze_file
+from tapps_mcp.project.call_graph_cache import index_from_dict, index_to_dict
+from tapps_mcp.project.call_graph_types import (
+    INDEX_VERSION,
+    CallGraphIndex,
+    SymbolRecord,
+)
+
+
+class TestSymbolLanguageTag:
+    def test_default_language_is_python(self) -> None:
+        rec = SymbolRecord(
+            qualified_name="pkg.mod.fn",
+            module="pkg.mod",
+            file_path="pkg/mod.py",
+            line=1,
+            kind="function",
+        )
+        assert rec.language == "python"
+
+    def test_language_round_trips_through_index_from_dict(self) -> None:
+        index = CallGraphIndex(
+            symbols=[
+                SymbolRecord(
+                    qualified_name="pkg.mod.fn",
+                    module="pkg.mod",
+                    file_path="pkg/mod.py",
+                    line=1,
+                    kind="function",
+                    language="typescript",
+                )
+            ],
+            fingerprint="deadbeef",
+        )
+        restored = index_from_dict(index_to_dict(index))
+        assert restored.symbols[0].language == "typescript"
+
+    def test_v2_cache_without_language_still_deserializes(self) -> None:
+        # A stale v2 payload predates the ``language`` field; index_from_dict
+        # must still construct a SymbolRecord (language defaults to "python").
+        legacy = {
+            "version": 2,
+            "fingerprint": "old",
+            "project_root": "/repo",
+            "symbols": [
+                {
+                    "qualified_name": "pkg.mod.fn",
+                    "module": "pkg.mod",
+                    "file_path": "pkg/mod.py",
+                    "line": 3,
+                    "kind": "function",
+                }
+            ],
+            "edges": [],
+            "resolution_gaps": [],
+            "parse_failures": [],
+        }
+        restored = index_from_dict(legacy)
+        assert restored.version == 2  # stale — triggers rebuild via version mismatch
+        assert restored.version != INDEX_VERSION
+        assert restored.symbols[0].language == "python"
+
+
+class TestSuffixDispatch:
+    def test_py_routes_to_analyze_file(self) -> None:
+        assert _analyzer_for(".py") is analyze_file
+
+    def test_ts_routes_to_placeholder(self) -> None:
+        assert _analyzer_for(".ts") is _analyze_ts_placeholder
+
+    def test_tsx_routes_to_placeholder(self) -> None:
+        assert _analyzer_for(".tsx") is _analyze_ts_placeholder
+
+    def test_unknown_suffix_has_no_analyzer(self) -> None:
+        assert _analyzer_for(".rb") is None
+
+    def test_placeholder_returns_empty_results(self, tmp_path: Path) -> None:
+        symbols, edges, gaps, failures = _analyze_ts_placeholder(
+            tmp_path / "x.ts", "x", tmp_path
+        )
+        assert (symbols, edges, gaps, failures) == ([], [], [], [])
+
+
+class TestTsFileToModule:
+    def test_strips_src_prefix_and_suffix(self, tmp_path: Path) -> None:
+        f = tmp_path / "src" / "components" / "Widget.ts"
+        assert _ts_file_to_module(f, tmp_path) == "components/Widget"
+
+    def test_tsx_suffix_dropped(self, tmp_path: Path) -> None:
+        f = tmp_path / "src" / "App.tsx"
+        assert _ts_file_to_module(f, tmp_path) == "App"
+
+    def test_no_src_prefix_kept_verbatim(self, tmp_path: Path) -> None:
+        f = tmp_path / "lib" / "util.ts"
+        assert _ts_file_to_module(f, tmp_path) == "lib/util"
+
+    def test_path_outside_root_returns_empty(self, tmp_path: Path) -> None:
+        assert _ts_file_to_module(Path("/elsewhere/x.ts"), tmp_path) == ""


### PR DESCRIPTION
Closes TAP-4537 (S1 of TAP-4531, Tier 2 / TAP-4530). Scaffold only — no TS analyzer yet (that's S2/TAP-4538).

## What
Lays the language-dispatch plumbing so S2–S4 add only the analyzer:
- `SymbolRecord.language = "python"` (backward-compatible); `INDEX_VERSION` 2→3 (stale v2 cache rebuilds — verified in gate log).
- Suffix→analyzer dispatch in `call_graph.py`: `.py`→`analyze_file` unchanged, `.ts`/`.tsx`→placeholder returning empty; walk broadened to `.ts`/`.tsx`.
- New `_ts_file_to_module` helper (Python helper untouched).
- **Fingerprint** now stats `.ts`/`.tsx` on both git-dirty and mtime paths, and folds the `tree-sitter-typescript` version in — closes the silent-staleness bug the spike flagged (a TS edit now invalidates the cache).

## Tests
113 passed in the call-graph slice; Python path unchanged/green. New tests cover language default + v2-legacy deserialize, suffix dispatch, TS fingerprint sensitivity, grammar-version change, absent-grammar sentinel. Gate scored all 5 files 100.

Deterministic (ADR-0004). Groundwork for the TS analyzer in TAP-4538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)