### PR TITLE
feat(call_graph): TypeScript cross-module resolution v1 + language-aware gap classifier (TAP-4539)

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_analyze_ts.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_analyze_ts.py
@@ -5,9 +5,19 @@ static call edges from ``.ts``/``.tsx`` files, mirroring the Python analyzer in
 ``call_graph_analyze.py`` (two-phase: register symbols, then collect calls with
 an explicit caller stack).
 
-Deterministic contract (ADR-0004): no LLM, no network. A call that does not
-resolve to an IN-MODULE symbol becomes a ``ResolutionGap`` — never a guessed
-edge. Cross-module resolution is deferred to S3.
+S3 (TAP-4539) adds v1 **cross-module** resolution via a lexical import-binding
+table, mirroring the Python analyzer's ``resolve_name`` / ``resolve_attribute``
+discipline in ``call_graph_resolve.py``. Resolved kinds: named imports, aliased
+imports (de-aliased), namespace imports (``import * as U`` → ``U.greet()``),
+plus the S2 in-module and intra-class ``this.method()`` cases. Everything else
+(default imports, typed-receiver instance methods, re-exports, tsconfig path
+aliases, external packages) becomes an honest ``ResolutionGap`` with a specific
+reason — NEVER a guessed edge. Full default-export / path-alias / re-export
+resolution is deferred to S4 (TAP-4540).
+
+Deterministic contract (ADR-0004): no LLM, no network. When resolution is not
+certain, emit a gap. Over-reaching resolution that fabricates an edge is the
+failure mode this file is written to avoid.
 
 Graceful degradation: a missing ``tree_sitter`` / ``tree_sitter_typescript``
 grammar yields an empty result (no crash); a genuine syntax error yields a
@@ -100,6 +110,36 @@ def analyze_file_ts(
     return analyzer.symbols, analyzer.edges, analyzer.gaps, []
 
 
+def _resolve_relative_module(module: str, specifier: str) -> str | None:
+    """Resolve a relative ES-module ``specifier`` against the importing ``module``.
+
+    Modules are slash-delimited names produced by ``_ts_file_to_module`` (S1),
+    e.g. ``a/b/consumer``. A specifier ``./util`` from ``a/b/consumer`` resolves
+    to ``a/b/util``; ``../shared/x`` walks up one directory. Returns ``None``
+    when the walk escapes above the module root (defensive — never guess).
+
+    Non-relative specifiers (``fs``, ``lodash``, ``@/util``) are not handled
+    here; the caller classifies those as external / path-alias gaps.
+    """
+    if not specifier.startswith("."):
+        return None
+    # Directory of the importing module (drop the file segment).
+    base_parts = module.split("/")[:-1]
+    spec_parts = specifier.split("/")
+    for part in spec_parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not base_parts:
+                return None  # escaped above root — do not fabricate a target.
+            base_parts.pop()
+            continue
+        base_parts.append(part)
+    if not base_parts:
+        return None
+    return "/".join(base_parts)
+
+
 def _node_text(node: Any, source: bytes) -> str:
     """Decode a node's source span (mirrors treesitter_base helper)."""
     return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
@@ -131,17 +171,93 @@ class _TsFileAnalyzer:
         self._local_functions: dict[str, str] = {}
         # "ClassName.method" -> qualified name.
         self._class_methods: dict[str, str] = {}
+        # Cross-module import bindings (TAP-4539). Each maps a local binding name
+        # to a resolution decision:
+        #  - _named_bindings: local -> qualified callee ("<module>.<realName>"),
+        #    a RESOLVABLE named/aliased import from an in-repo relative module.
+        #  - _namespace_bindings: local alias -> target module ("import * as U").
+        #  - _deferred_bindings: local -> gap reason for a binding we honestly
+        #    cannot resolve yet (default export, external pkg, path alias).
+        self._named_bindings: dict[str, str] = {}
+        self._namespace_bindings: dict[str, str] = {}
+        self._deferred_bindings: dict[str, str] = {}
 
     # ------------------------------------------------------------------
-    # Phase 1 — symbol registration
+    # Phase 0 — import binding table
     # ------------------------------------------------------------------
 
     def run(self, root: Any) -> None:
+        for node in _iter_statements(root):
+            self._scan_imports(node)
         for node in _iter_statements(root):
             self._register_top_level(node)
         # Phase 2 — collect calls per registered symbol body.
         for node in _iter_statements(root):
             self._collect_top_level(node)
+
+    def _scan_imports(self, node: Any) -> None:
+        """Record import/re-export bindings so phase 2 resolution is lexical.
+
+        Mirrors ``call_graph_resolve._apply_import_bindings``: a binding maps a
+        local name to a qualified target when it is a named/namespace import
+        from an in-repo relative module, and to a deferred gap reason otherwise.
+        """
+        if node.type == "export_statement" and _is_reexport(node):
+            # `export {x} from "./re"` — deferred to S4. Mark the point honestly.
+            self.gaps.append(
+                ResolutionGap(
+                    self.module,
+                    _node_text(node, self.source).strip(),
+                    _line_of(node),
+                    "reexport_unresolved",
+                    language="typescript",
+                )
+            )
+            return
+        if node.type != "import_statement":
+            return
+        specifier = _import_specifier(node, self.source)
+        if specifier is None:
+            return
+        clause = _first_child_of_type(node, "import_clause")
+        if clause is None:
+            return
+        self._bind_import_clause(clause, specifier)
+
+    def _bind_import_clause(self, clause: Any, specifier: str) -> None:
+        target_module = _resolve_relative_module(self.module, specifier)
+        is_relative = specifier.startswith(".")
+        is_path_alias = _is_path_alias(specifier)
+        for child in clause.children:
+            if child.type == "named_imports":
+                for local, real in _named_import_pairs(child, self.source):
+                    if target_module is not None:
+                        self._named_bindings[local] = f"{target_module}.{real}"
+                    elif is_path_alias:
+                        self._deferred_bindings[local] = "path_alias_unresolved"
+                    else:  # external package (fs, lodash, ...)
+                        self._deferred_bindings[local] = "import_unresolved"
+            elif child.type == "namespace_import":
+                alias = _namespace_alias(child, self.source)
+                if not alias:
+                    continue
+                if target_module is not None:
+                    self._namespace_bindings[alias] = target_module
+                elif is_path_alias:
+                    self._deferred_bindings[alias] = "path_alias_unresolved"
+                else:
+                    self._deferred_bindings[alias] = "import_unresolved"
+            elif child.type == "identifier":
+                # Default import: `import makeDefault from "./util"`.
+                # Default-export resolution is deferred to S4 regardless of
+                # whether the source module is in-repo — never guess.
+                local = _node_text(child, self.source)
+                if is_path_alias:
+                    self._deferred_bindings[local] = "path_alias_unresolved"
+                elif is_relative:
+                    self._deferred_bindings[local] = "unresolved_default_export"
+                else:
+                    self._deferred_bindings[local] = "import_unresolved"
 
     def _register_top_level(self, node: Any) -> None:
         node = _unwrap_export(node)
@@ -252,39 +368,69 @@ class _TsFileAnalyzer:
     def _record_call(self, call: Any, *, caller: str, class_name: str | None) -> None:
         func = call.child_by_field_name("function")
         if func is None:
-            self.gaps.append(
-                ResolutionGap(caller, _node_text(call, self.source), _line_of(call), "dynamic_dispatch")
-            )
+            self._gap(caller, _node_text(call, self.source), _line_of(call), "dynamic_dispatch")
             return
         expr = _node_text(func, self.source)
         line = _line_of(call)
         callee, reason = self._resolve(func, class_name)
         if callee is None:
-            self.gaps.append(ResolutionGap(caller, expr, line, reason))
+            self._gap(caller, expr, line, reason)
             return
         self.edges.append(CallEdge(caller, callee, expr, line, True))
 
+    def _gap(self, caller: str, expr: str, line: int, reason: str) -> None:
+        self.gaps.append(ResolutionGap(caller, expr, line, reason, language="typescript"))
+
     def _resolve(self, func: Any, class_name: str | None) -> tuple[str | None, str]:
-        """Resolve a call target to an in-module symbol, or return (None, reason)."""
+        """Resolve a call target to an in-repo symbol, or return (None, reason).
+
+        Resolution order mirrors ``call_graph_resolve.resolve_name``: local
+        module symbols first, then the lexical import-binding table. A binding
+        we cannot follow yet yields its recorded deferred reason — never a
+        guessed edge.
+        """
         if func.type == "identifier":
             name = _node_text(func, self.source)
             qname = self._local_functions.get(name)
             if qname is not None:
                 return qname, "unresolved_static_call"
-            # A bare name we do not own: could be an import or builtin.
+            # Named / aliased import from an in-repo relative module (resolved).
+            bound = self._named_bindings.get(name)
+            if bound is not None:
+                return bound, "unresolved_static_call"
+            # A binding we deliberately did not resolve (default / external / alias).
+            deferred = self._deferred_bindings.get(name)
+            if deferred is not None:
+                return None, deferred
+            # A bare name we do not own and never saw imported.
             return None, "import_unresolved"
         if func.type == "member_expression":
             obj = func.child_by_field_name("object")
             prop = func.child_by_field_name("property")
-            if obj is not None and prop is not None and obj.type == "this" and class_name:
+            if obj is None or prop is None:
+                return None, "unresolved_static_call"
+            if obj.type == "this" and class_name:
                 method_name = _node_text(prop, self.source)
                 qname = self._class_methods.get(f"{class_name}.{method_name}")
                 if qname is not None:
                     return qname, "unresolved_static_call"
                 # this.<something not a known method> — dynamic within class.
                 return None, "unresolved_static_call"
-            # obj.method() across a module boundary or external object.
-            return None, "unresolved_static_call"
+            if obj.type == "identifier":
+                obj_name = _node_text(obj, self.source)
+                # Namespace import: `import * as U from "./util"` -> U.greet().
+                ns_module = self._namespace_bindings.get(obj_name)
+                if ns_module is not None and prop.type == "property_identifier":
+                    return f"{ns_module}.{_node_text(prop, self.source)}", "unresolved_static_call"
+                # A namespace-like deferred binding (external `import * as fs`).
+                deferred = self._deferred_bindings.get(obj_name)
+                if deferred is not None:
+                    return None, deferred
+                # A local variable / typed receiver: `f.format()`. We cannot
+                # know the receiver's type without a type checker — defer.
+                return None, "receiver_untyped"
+            # obj.method() where obj is not a plain identifier (chained, etc.).
+            return None, "receiver_untyped"
         # call().foo(), (expr)(), tagged templates, etc.
         return None, "dynamic_dispatch"
 
@@ -364,3 +510,67 @@ def _first_child_text(node: Any, child_type: str, source: bytes) -> str:
         if child.type == child_type:
             return _node_text(child, source)
     return ""
+
+
+def _first_child_of_type(node: Any, child_type: str) -> Any | None:
+    for child in node.children:
+        if child.type == child_type:
+            return child
+    return None
+
+
+def _import_specifier(node: Any, source: bytes) -> str | None:
+    """The module specifier string of an ``import_statement`` (unquoted)."""
+    string_node = _first_child_of_type(node, "string")
+    if string_node is None:
+        return None
+    frag = _first_child_of_type(string_node, "string_fragment")
+    if frag is not None:
+        return _node_text(frag, source)
+    # Fallback: strip surrounding quotes from the raw string node.
+    raw = _node_text(string_node, source)
+    return raw.strip("\"'")
+
+
+def _named_import_pairs(named_imports: Any, source: bytes) -> list[tuple[str, str]]:
+    """Yield ``(local_name, real_name)`` for each ``import_specifier``.
+
+    De-aliases ``{shout as loud}`` to ``("loud", "shout")``. A plain
+    ``{greet}`` yields ``("greet", "greet")``.
+    """
+    out: list[tuple[str, str]] = []
+    for spec in named_imports.children:
+        if spec.type != "import_specifier":
+            continue
+        idents = [c for c in spec.children if c.type == "identifier"]
+        if not idents:
+            continue
+        real = _node_text(idents[0], source)
+        # `as` present -> the second identifier is the local binding name.
+        local = _node_text(idents[1], source) if len(idents) >= 2 else real
+        out.append((local, real))
+    return out
+
+
+def _namespace_alias(namespace_import: Any, source: bytes) -> str:
+    """Local alias of ``import * as U`` -> ``"U"`` (last identifier child)."""
+    idents = [c for c in namespace_import.children if c.type == "identifier"]
+    return _node_text(idents[-1], source) if idents else ""
+
+
+def _is_reexport(export_node: Any) -> bool:
+    """True for ``export {x} from "..."`` (a re-export, not a local export)."""
+    has_from = any(child.type == "from" for child in export_node.children)
+    has_clause = any(child.type == "export_clause" for child in export_node.children)
+    return has_from and has_clause
+
+
+def _is_path_alias(specifier: str) -> bool:
+    """True for a common tsconfig path alias (``@/util``, ``~/foo``).
+
+    Conservative on purpose: only the ``@/`` and ``~/`` (and bare ``~``) sigils
+    count. Scoped npm packages (``@angular/core``) start with ``@`` but are
+    external, not aliases — misclassifying them would distort the gap taxonomy,
+    so they fall through to the external ``import_unresolved`` branch.
+    """
+    return specifier.startswith(("@/", "~/")) or specifier == "~"

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_gap_classify.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_gap_classify.py
@@ -17,6 +17,24 @@ _EXTERNAL_REASONS = frozenset(
     }
 )
 
+# TypeScript (TAP-4539). A TS gap must NOT be run through the Python
+# stdlib/builtin name checks: `fs`/`lodash` are not in Python's stdlib set (so
+# they would wrongly count as in-repo), and Python stdlib names like `os`/`time`
+# are not TS externals. The reason field alone decides external vs in-repo:
+#  - external: an unresolvable import from outside the repo (`fs`, `lodash`) or
+#    an inherently non-static call.
+#  - in-repo (deferred to S4): default-export / re-export / path-alias / typed-
+#    receiver gaps — real in-repo edges we cannot draw yet. Counting them
+#    in-repo keeps `in_repo_gap_rate` honest about resolution debt.
+_TS_EXTERNAL_REASONS = frozenset(
+    {
+        "import_unresolved",
+        "dynamic_dispatch",
+        "callback_opaque",
+        "framework_hof",
+    }
+)
+
 
 @lru_cache(maxsize=1)
 def _stdlib_module_names() -> frozenset[str]:
@@ -68,7 +86,15 @@ def expr_root(expr: str) -> str:
 
 
 def is_external_gap(gap: ResolutionGap) -> bool:
-    """True when the gap is stdlib/builtin/third-party or expected dynamic dispatch."""
+    """True when the gap is stdlib/builtin/third-party or expected dynamic dispatch.
+
+    Language-aware (TAP-4539): a TypeScript gap is classified purely on its
+    ``reason`` — the Python stdlib/builtin name heuristics do not transfer to
+    TS and would misclassify both directions (see ``_TS_EXTERNAL_REASONS``).
+    """
+    language = getattr(gap, "language", "python")
+    if language == "typescript":
+        return gap.reason in _TS_EXTERNAL_REASONS
     if gap.reason in _EXTERNAL_REASONS:
         return True
     root = expr_root(gap.expr)

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
@@ -12,12 +12,18 @@ INDEX_VERSION = 3
 SymbolKind = Literal["function", "method"]
 
 # Stable taxonomy for resolution gaps (TAP-4092).
+# TAP-4539 adds the TypeScript-specific reasons for deferred-resolution cases
+# (default exports, untyped receivers, re-exports, tsconfig path aliases).
 ResolutionGapReason = Literal[
     "unresolved_static_call",
     "dynamic_dispatch",
     "callback_opaque",
     "import_unresolved",
     "framework_hof",
+    "receiver_untyped",
+    "unresolved_default_export",
+    "reexport_unresolved",
+    "path_alias_unresolved",
 ]
 
 PARSE_FAILURE_REASON = Literal["syntax_error", "decode_error", "io_error"]
@@ -50,6 +56,11 @@ class ResolutionGap:
     expr: str
     line: int
     reason: ResolutionGapReason | str
+    # Source language of the gap (TAP-4539). Lets the gap classifier apply
+    # language-aware external/in-repo rules (e.g. TS `fs`/`lodash` are external,
+    # not Python-stdlib misses). Defaults to "python" so older cached indexes
+    # and existing call sites keep working.
+    language: str = "python"
 
 
 @dataclass

--- a/packages/tapps-mcp/tests/unit/test_call_graph_analyze_ts.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_analyze_ts.py
@@ -112,7 +112,9 @@ class C {
 
 
 class TestResolutionGaps:
-    def test_non_in_module_call_becomes_gap(self, tmp_path: Path) -> None:
+    def test_relative_named_import_resolves_to_edge(self, tmp_path: Path) -> None:
+        # S3 (TAP-4539): a named import from an in-repo relative module now
+        # resolves to a cross-module edge (S2 deferred this as a gap).
         src = """\
 import { external } from "./other";
 function caller() { external(); }
@@ -120,8 +122,21 @@ function caller() { external(); }
         f = _write(tmp_path, "mod.ts", src)
         _symbols, edges, gaps, _f = analyze_file_ts(f, "mod", tmp_path)
 
-        assert not any(e.callee_expr == "external" for e in edges)
-        gap = next(g for g in gaps if g.expr == "external")
+        edge = next(e for e in edges if e.callee_expr == "external")
+        assert edge.caller == "mod.caller"
+        assert edge.callee == "other.external"
+        assert edge.resolved is True
+        assert not any(g.expr == "external" for g in gaps)
+
+    def test_unknown_bare_identifier_call_becomes_gap(self, tmp_path: Path) -> None:
+        # A bare name never imported and not locally defined stays a gap.
+        src = """\
+function caller() { mysteryGlobal(); }
+"""
+        f = _write(tmp_path, "mod.ts", src)
+        _symbols, edges, gaps, _f = analyze_file_ts(f, "mod", tmp_path)
+        assert not any(e.callee_expr == "mysteryGlobal" for e in edges)
+        gap = next(g for g in gaps if g.expr == "mysteryGlobal")
         assert gap.caller == "mod.caller"
         assert gap.reason == "import_unresolved"
 
@@ -205,3 +220,157 @@ function helper() {}
         assert failures == []
         assert any(s.qualified_name == "App.Component" for s in symbols)
         assert any(e.caller == "App.Component" and e.callee == "App.helper" for e in edges)
+
+
+class TestCrossModuleResolution:
+    """S3 (TAP-4539): named / aliased / namespace import resolution."""
+
+    def _edges(self, tmp_path: Path, module: str, src: str, name: str = "consumer.ts"):
+        f = _write(tmp_path, name, src)
+        _s, edges, gaps, _f = analyze_file_ts(f, module, tmp_path)
+        return edges, gaps
+
+    def test_named_import_resolves(self, tmp_path: Path) -> None:
+        src = """\
+import { greet } from "./util";
+function run() { greet(); }
+"""
+        edges, gaps = self._edges(tmp_path, "consumer", src)
+        edge = next(e for e in edges if e.callee_expr == "greet")
+        assert edge.caller == "consumer.run"
+        assert edge.callee == "util.greet"
+        assert edge.resolved is True
+        assert not any(g.expr == "greet" for g in gaps)
+
+    def test_aliased_import_de_aliases(self, tmp_path: Path) -> None:
+        # `import {shout as loud}` -> loud() resolves to util.shout.
+        src = """\
+import { shout as loud } from "./util";
+function run() { loud(); }
+"""
+        edges, _gaps = self._edges(tmp_path, "consumer", src)
+        edge = next(e for e in edges if e.callee_expr == "loud")
+        assert edge.callee == "util.shout"
+        assert edge.caller == "consumer.run"
+
+    def test_namespace_import_resolves(self, tmp_path: Path) -> None:
+        # `import * as U from "./util"` -> U.greet() resolves to util.greet.
+        src = """\
+import * as U from "./util";
+function run() { U.greet(); }
+"""
+        edges, _gaps = self._edges(tmp_path, "consumer", src)
+        edge = next(e for e in edges if e.callee_expr == "U.greet")
+        assert edge.callee == "util.greet"
+        assert edge.caller == "consumer.run"
+
+    def test_nested_relative_path_resolves(self, tmp_path: Path) -> None:
+        # From a/b/consumer, `./util` -> a/b/util.
+        src = """\
+import { greet } from "./util";
+function run() { greet(); }
+"""
+        edges, _gaps = self._edges(tmp_path, "a/b/consumer", src)
+        edge = next(e for e in edges if e.callee_expr == "greet")
+        assert edge.callee == "a/b/util.greet"
+
+    def test_parent_relative_path_resolves(self, tmp_path: Path) -> None:
+        # From a/b/consumer, `../shared/util` -> a/shared/util.
+        src = """\
+import { greet } from "../shared/util";
+function run() { greet(); }
+"""
+        edges, _gaps = self._edges(tmp_path, "a/b/consumer", src)
+        edge = next(e for e in edges if e.callee_expr == "greet")
+        assert edge.callee == "a/shared/util.greet"
+
+    def test_in_module_and_intra_class_still_resolve(self, tmp_path: Path) -> None:
+        # AC1: S2 cases must keep working alongside cross-module resolution.
+        src = """\
+import { greet } from "./util";
+function helper() {}
+function run() {
+  helper();
+  greet();
+}
+class C {
+  a() { this.b(); }
+  b() {}
+}
+"""
+        edges, _gaps = self._edges(tmp_path, "consumer", src)
+        callees = {e.callee for e in edges}
+        assert "consumer.helper" in callees  # in-module
+        assert "util.greet" in callees  # cross-module named import
+        assert "consumer.C.b" in callees  # intra-class this.method()
+
+
+class TestDeferredResolutionGaps:
+    """S3 (TAP-4539): honest gaps for cases deferred to S4 or external."""
+
+    def _gaps(self, tmp_path: Path, module: str, src: str):
+        f = _write(tmp_path, "consumer.ts", src)
+        _s, edges, gaps, _f = analyze_file_ts(f, module, tmp_path)
+        return edges, gaps
+
+    def test_default_import_is_unresolved_default_export(self, tmp_path: Path) -> None:
+        src = """\
+import makeDefault from "./util";
+function run() { makeDefault(); }
+"""
+        edges, gaps = self._gaps(tmp_path, "consumer", src)
+        assert not any(e.callee_expr == "makeDefault" for e in edges)
+        gap = next(g for g in gaps if g.expr == "makeDefault")
+        assert gap.reason == "unresolved_default_export"
+        assert gap.language == "typescript"
+
+    def test_typed_receiver_method_is_receiver_untyped(self, tmp_path: Path) -> None:
+        src = """\
+function run(f) { f.format(); }
+"""
+        edges, gaps = self._gaps(tmp_path, "consumer", src)
+        assert not any(e.callee_expr == "f.format" for e in edges)
+        gap = next(g for g in gaps if g.expr == "f.format")
+        assert gap.reason == "receiver_untyped"
+
+    def test_reexport_is_reexport_unresolved(self, tmp_path: Path) -> None:
+        src = """\
+export { x } from "./re";
+"""
+        _edges, gaps = self._gaps(tmp_path, "consumer", src)
+        gap = next(g for g in gaps if g.reason == "reexport_unresolved")
+        assert gap.caller == "consumer"
+        assert gap.language == "typescript"
+
+    def test_path_alias_import_is_path_alias_unresolved(self, tmp_path: Path) -> None:
+        src = """\
+import { util } from "@/util";
+function run() { util(); }
+"""
+        edges, gaps = self._gaps(tmp_path, "consumer", src)
+        assert not any(e.callee_expr == "util" for e in edges)
+        gap = next(g for g in gaps if g.expr == "util")
+        assert gap.reason == "path_alias_unresolved"
+
+    def test_external_package_import_is_import_unresolved(self, tmp_path: Path) -> None:
+        src = """\
+import { readFile } from "fs";
+import { debounce } from "lodash";
+function run() { readFile(); debounce(); }
+"""
+        edges, gaps = self._gaps(tmp_path, "consumer", src)
+        assert edges == []
+        for name in ("readFile", "debounce"):
+            gap = next(g for g in gaps if g.expr == name)
+            assert gap.reason == "import_unresolved"
+            assert gap.language == "typescript"
+
+    def test_scoped_npm_package_is_external_not_alias(self, tmp_path: Path) -> None:
+        # `@angular/core` starts with `@` but is an npm package, not a path alias.
+        src = """\
+import { Component } from "@angular/core";
+function run() { Component(); }
+"""
+        _edges, gaps = self._gaps(tmp_path, "consumer", src)
+        gap = next(g for g in gaps if g.expr == "Component")
+        assert gap.reason == "import_unresolved"

--- a/packages/tapps-mcp/tests/unit/test_call_graph_gap_classify.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_gap_classify.py
@@ -44,3 +44,62 @@ def test_split_gap_counts() -> None:
     assert external == 2
     assert in_repo == 1
     assert reasons == {"unresolved_static_call": 1}
+
+
+# --- Language-aware classification (TAP-4539) ---
+
+
+def test_ts_external_package_gap_is_external() -> None:
+    # `fs`/`lodash` are not in Python's stdlib set — without the language branch
+    # they'd wrongly count as in-repo and inflate the gap rate.
+    gap = ResolutionGap(
+        "consumer.run", "readFile()", 1, "import_unresolved", language="typescript"
+    )
+    assert is_external_gap(gap) is True
+
+
+def test_ts_stdlib_named_expr_does_not_borrow_python_heuristics() -> None:
+    # A TS gap whose root happens to be a Python stdlib name (`os`) must NOT be
+    # classified external via the Python heuristic — only its reason decides.
+    gap = ResolutionGap(
+        "consumer.run", "os.stuff()", 1, "receiver_untyped", language="typescript"
+    )
+    assert is_external_gap(gap) is False
+
+
+def test_ts_deferred_reasons_are_in_repo() -> None:
+    for reason in (
+        "unresolved_default_export",
+        "reexport_unresolved",
+        "path_alias_unresolved",
+        "receiver_untyped",
+    ):
+        gap = ResolutionGap("consumer.run", "x()", 1, reason, language="typescript")
+        assert is_external_gap(gap) is False, reason
+
+
+def test_ts_external_gap_does_not_inflate_in_repo_rate() -> None:
+    # AC5: a TS external (`fs`) gap alongside a real in-repo deferred gap must
+    # leave the in-repo count at 1, not 2.
+    gaps = [
+        ResolutionGap(
+            "consumer.run", "readFile()", 1, "import_unresolved", language="typescript"
+        ),
+        ResolutionGap(
+            "consumer.run",
+            "makeDefault()",
+            2,
+            "unresolved_default_export",
+            language="typescript",
+        ),
+    ]
+    external, in_repo, reasons = split_gap_counts(gaps)
+    assert external == 1
+    assert in_repo == 1
+    assert reasons == {"unresolved_default_export": 1}
+
+
+def test_python_gap_still_uses_heuristics() -> None:
+    # Regression: the Python path is unchanged — stdlib root => external.
+    gap = ResolutionGap("demo.run", "os.getcwd()", 1, "unresolved_static_call")
+    assert is_external_gap(gap) is True


### PR DESCRIPTION
Closes TAP-4539 (S3 of TAP-4531). Builds on S2 (#178).

## What
Adds v1 cross-module TS resolution + fixes the Python-centric gap classifier.
- Resolves: named imports, aliased imports (`shout as loud`), namespace (`import * as U` → `U.greet`), in-module, intra-class `this.method()` — lexical via an import-binding table (mirrors `call_graph_resolve` discipline).
- Honest gaps (never guessed): default import → `unresolved_default_export`; typed receiver → `receiver_untyped`; re-export → `reexport_unresolved`; path alias → `path_alias_unresolved`; external pkg → `import_unresolved`.
- Language-aware `is_external_gap`: TS gaps classify on `reason` (bypassing Python stdlib heuristics), so `fs`/`lodash` don't inflate `in_repo_gap_rate`. `ResolutionGap.language` threaded (defaults `python`).

## Live proof
Resolved: `run→util.greet` (named), `run→util.shout` (aliased de-alias), `run→util.greet` (namespace), `C.a→C.b` (this.b). Gaps: default-export, re-export, `@/util` path-alias, `fs` external, `f.format` receiver_untyped.

## Tests
115 passed; Python path green; gate 100 on all 5 files. Full-resolution of default-export/path-alias/re-export is S4 (TAP-4540) — here they're honest gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)