### PR TITLE
feat(call_graph): TypeScript deferred resolution — tsconfig paths, default exports, re-exports (TAP-4540)

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph.py
@@ -8,18 +8,22 @@ from pathlib import Path
 import structlog
 
 from tapps_mcp.project.call_graph_analyze import analyze_file
-from tapps_mcp.project.call_graph_analyze_ts import analyze_file_ts
+from tapps_mcp.project.call_graph_analyze_ts import analyze_file_ts, analyze_file_ts_full
 from tapps_mcp.project.call_graph_cache import (
     fingerprint_settings,
     load_call_graph_index,
     save_call_graph_index,
 )
 from tapps_mcp.project.call_graph_fingerprint import compute_index_fingerprint
+from tapps_mcp.project.call_graph_resolve_ts import resolve_ts_cross_file
+from tapps_mcp.project.call_graph_tsconfig import load_tsconfig_paths
 from tapps_mcp.project.call_graph_types import (
     CALL_GRAPH_CACHE_REL,
     INDEX_VERSION,
     CallEdge,
     CallGraphIndex,
+    DeferredCall,
+    ModuleExports,
     ParseFailure,
     ResolutionGap,
     SymbolRecord,
@@ -117,6 +121,10 @@ def build_call_graph_index(
     edges: list[CallEdge] = []
     gaps: list[ResolutionGap] = []
     parse_failures: list[ParseFailure] = []
+    # TS cross-file resolution material (S4, TAP-4540): each module's export
+    # surface plus the deferred call sites the per-file pass could not resolve.
+    ts_exports: dict[str, ModuleExports] = {}
+    ts_deferred: list[DeferredCall] = []
 
     walk_suffixes = _PY_SUFFIXES + _TS_SUFFIXES
     source_files = sorted(
@@ -137,13 +145,65 @@ def build_call_graph_index(
             module = _file_to_module(source_file, project_root, top_level_package)
         if not module:
             continue
-        file_symbols, file_edges, file_gaps, file_failures = analyzer(
-            source_file, module, project_root
-        )
+        if suffix in _TS_SUFFIXES:
+            (
+                file_symbols,
+                file_edges,
+                file_gaps,
+                file_failures,
+                module_exports,
+                deferred,
+            ) = analyze_file_ts_full(source_file, module, project_root)
+            ts_exports[module] = module_exports
+            ts_deferred.extend(deferred)
+        else:
+            file_symbols, file_edges, file_gaps, file_failures = analyzer(
+                source_file, module, project_root
+            )
         symbols.extend(file_symbols)
         edges.extend(file_edges)
         gaps.extend(file_gaps)
         parse_failures.extend(file_failures)
+
+    # S4 cross-file post-pass (TAP-4540): promote deferred default-export /
+    # path-alias / re-export calls to edges, and follow already-resolved edges
+    # through re-export barrels to their origin symbol. Anything unresolved
+    # keeps its honest gap (ADR-0004 — never fabricate an edge).
+    if ts_exports:
+        symbol_names = {s.qualified_name for s in symbols}
+        result = resolve_ts_cross_file(
+            deferred_calls=ts_deferred,
+            exports_by_module=ts_exports,
+            symbol_names=symbol_names,
+            resolved_edges=edges,
+            tsconfig=load_tsconfig_paths(project_root),
+        )
+        edges.extend(result.new_edges)
+        gaps.extend(result.remaining_gaps)
+        if result.edge_rewrites:
+            for edge in edges:
+                rewritten = result.edge_rewrites.get(edge.callee)
+                if rewritten is not None:
+                    edge.callee = rewritten
+        if result.dangling_callees:
+            # Demote phantom edges (eager S3 named imports whose callee module
+            # neither defines nor resolvably re-exports the symbol) to honest
+            # gaps — never keep a fabricated target (ADR-0004).
+            kept: list[CallEdge] = []
+            for edge in edges:
+                if edge.callee in result.dangling_callees:
+                    gaps.append(
+                        ResolutionGap(
+                            edge.caller,
+                            edge.callee_expr,
+                            edge.line,
+                            "reexport_unresolved",
+                            language="typescript",
+                        )
+                    )
+                else:
+                    kept.append(edge)
+            edges = kept
 
     symbols.sort(key=lambda s: (s.qualified_name, s.file_path, s.line))
     edges.sort(key=lambda e: (e.caller, e.line, e.callee_expr))

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_analyze_ts.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_analyze_ts.py
@@ -10,10 +10,18 @@ table, mirroring the Python analyzer's ``resolve_name`` / ``resolve_attribute``
 discipline in ``call_graph_resolve.py``. Resolved kinds: named imports, aliased
 imports (de-aliased), namespace imports (``import * as U`` → ``U.greet()``),
 plus the S2 in-module and intra-class ``this.method()`` cases. Everything else
-(default imports, typed-receiver instance methods, re-exports, tsconfig path
-aliases, external packages) becomes an honest ``ResolutionGap`` with a specific
-reason — NEVER a guessed edge. Full default-export / path-alias / re-export
-resolution is deferred to S4 (TAP-4540).
+(typed-receiver instance methods, external packages) becomes an honest
+``ResolutionGap`` with a specific reason — NEVER a guessed edge.
+
+S4 (TAP-4540) resolves the three previously-deferred classes — default exports,
+tsconfig path aliases, and re-exports — via a **cross-file post-pass** in
+``call_graph.build_call_graph_index``. The per-file analyzer still cannot see
+other modules' export tables, so it records each of those as a ``DeferredCall``
+(the gap it *would* emit plus structured hints: import kind, imported name,
+target module, raw specifier) and exposes each module's ``ModuleExports``
+(default symbol, named exports, re-export map). The post-pass promotes a
+``DeferredCall`` to an edge when the origin symbol is found, and follows
+re-export chains; anything still unresolved keeps its honest gap.
 
 Deterministic contract (ADR-0004): no LLM, no network. When resolution is not
 certain, emit a gap. Over-reaching resolution that fabricates an edge is the
@@ -26,11 +34,15 @@ grammar yields an empty result (no crash); a genuine syntax error yields a
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from tapps_mcp.project.call_graph_types import (
     CallEdge,
+    DeferredCall,
+    DeferredImportKind,
+    ModuleExports,
     ParseFailure,
     ResolutionGap,
     SymbolKind,
@@ -56,11 +68,38 @@ _ARROW_TYPE = "arrow_function"
 _METHOD_TYPE = "method_definition"
 _FUNCTION_DECL_TYPE = "function_declaration"
 
+
+@dataclass
+class _DeferredMeta:
+    """Structured hints for a deferred import binding (TAP-4540, per-file).
+
+    Recorded only for the classes the S4 post-pass can *potentially* resolve
+    (default export, path alias). ``target_module`` is set when the specifier is
+    a resolvable relative module; ``None`` when it is a path alias awaiting
+    tsconfig resolution against the raw ``specifier``.
+    """
+
+    kind: DeferredImportKind
+    imported_name: str | None
+    target_module: str | None
+    specifier: str
+
 AnalyzeResult = tuple[
     list[SymbolRecord],
     list[CallEdge],
     list[ResolutionGap],
     list[ParseFailure],
+]
+
+# Full result (TAP-4540): the 4-tuple plus the module's export surface and the
+# deferred call sites the cross-file post-pass must try to resolve.
+AnalyzeResultFull = tuple[
+    list[SymbolRecord],
+    list[CallEdge],
+    list[ResolutionGap],
+    list[ParseFailure],
+    ModuleExports,
+    list[DeferredCall],
 ]
 
 
@@ -73,6 +112,65 @@ def analyze_file_ts(
 
     Same 4-tuple contract as ``call_graph_analyze.analyze_file``:
     ``(symbols, edges, resolution_gaps, parse_failures)``.
+
+    Standalone (no cross-file context), the deferred-resolution cases (default
+    export / path alias) have no origin module to resolve against, so their
+    ``DeferredCall`` records are folded back into honest gaps here — the 4-tuple
+    API keeps the S3 contract. Re-exports are a module-level export fact (not a
+    call site) and produce a ``reexport_unresolved`` gap only in this standalone
+    view; the cross-file promotion happens in ``analyze_file_ts_full`` + the
+    post-pass, which consumes the export table instead.
+    """
+    analyzer, failure = _parse_and_run(file_path, module, project_root)
+    if analyzer is None:
+        return [], [], [], ([] if failure is None else [failure])
+    folded = list(analyzer.gaps)
+    folded.extend(dc.gap for dc in analyzer.deferred_calls)
+    folded.extend(analyzer.reexport_gaps)
+    return analyzer.symbols, analyzer.edges, folded, []
+
+
+def analyze_file_ts_full(
+    file_path: Path,
+    module: str,
+    project_root: Path,
+) -> AnalyzeResultFull:
+    """Like ``analyze_file_ts`` but also returns cross-file resolution material.
+
+    Adds ``ModuleExports`` (default symbol, named exports, re-export map) and the
+    list of ``DeferredCall`` records for calls the per-file pass could not
+    resolve alone. On any parse/IO failure the exports are empty and there are
+    no deferred calls — the post-pass simply has nothing to promote.
+
+    The returned ``gaps`` list holds only the genuinely-unresolvable-anywhere
+    cases (untyped receiver, external import, dynamic dispatch). Deferred call
+    gaps and re-export gaps are NOT in it: the cross-file post-pass owns those
+    (a re-export statement with no consumer produces no gap; a consumer call
+    through a broken chain produces its own deferred gap).
+    """
+    analyzer, failure = _parse_and_run(file_path, module, project_root)
+    if analyzer is None:
+        empty_exports = ModuleExports(module=module)
+        return [], [], [], ([] if failure is None else [failure]), empty_exports, []
+    return (
+        analyzer.symbols,
+        analyzer.edges,
+        analyzer.gaps,
+        [],
+        analyzer.exports,
+        analyzer.deferred_calls,
+    )
+
+
+def _parse_and_run(
+    file_path: Path,
+    module: str,
+    project_root: Path,
+) -> tuple[_TsFileAnalyzer | None, ParseFailure | None]:
+    """Parse ``file_path`` and run the two-phase analyzer.
+
+    Returns ``(analyzer, None)`` on success, ``(None, failure)`` on a parse/IO
+    error, or ``(None, None)`` when the grammar is unavailable (degrade empty).
     """
     try:
         rel_path = str(file_path.relative_to(project_root))
@@ -80,34 +178,33 @@ def analyze_file_ts(
         rel_path = str(file_path)
 
     if not HAS_TREE_SITTER:
-        # No grammar available — degrade to empty, never crash.
-        return [], [], [], []
+        return None, None
 
     try:
         source_bytes = file_path.read_bytes()
     except OSError as exc:
-        return [], [], [], [ParseFailure(rel_path, 0, f"io_error:{exc.__class__.__name__}")]
+        return None, ParseFailure(rel_path, 0, f"io_error:{exc.__class__.__name__}")
 
     try:
         source_bytes.decode("utf-8")
     except UnicodeDecodeError:
-        return [], [], [], [ParseFailure(rel_path, 0, "decode_error")]
+        return None, ParseFailure(rel_path, 0, "decode_error")
 
     lang = _TSX_LANGUAGE if file_path.suffix.lower() == ".tsx" else _TS_LANGUAGE
     try:
         parser = tree_sitter.Parser(lang)
         tree = parser.parse(source_bytes)
     except Exception:  # pragma: no cover - defensive; parse rarely raises
-        return [], [], [], [ParseFailure(rel_path, 0, "syntax_error")]
+        return None, ParseFailure(rel_path, 0, "syntax_error")
 
     root = tree.root_node
     if root.has_error:
         line = (root.start_point[0] + 1) if root.start_point else 0
-        return [], [], [], [ParseFailure(rel_path, line, "syntax_error")]
+        return None, ParseFailure(rel_path, line, "syntax_error")
 
     analyzer = _TsFileAnalyzer(module=module, rel_path=rel_path, source=source_bytes)
     analyzer.run(root)
-    return analyzer.symbols, analyzer.edges, analyzer.gaps, []
+    return analyzer, None
 
 
 def _resolve_relative_module(module: str, specifier: str) -> str | None:
@@ -167,6 +264,14 @@ class _TsFileAnalyzer:
         self.symbols: list[SymbolRecord] = []
         self.edges: list[CallEdge] = []
         self.gaps: list[ResolutionGap] = []
+        # Cross-file resolution material (TAP-4540).
+        self.exports = ModuleExports(module=module)
+        self.deferred_calls: list[DeferredCall] = []
+        # Standalone-view re-export gaps: what the 4-tuple ``analyze_file_ts``
+        # reports for `export ... from` statements when there is no cross-file
+        # context to follow the chain. The post-pass ignores these (it uses the
+        # export table instead).
+        self.reexport_gaps: list[ResolutionGap] = []
         # Bare function name -> qualified name (module-scoped functions/arrows).
         self._local_functions: dict[str, str] = {}
         # "ClassName.method" -> qualified name.
@@ -181,6 +286,11 @@ class _TsFileAnalyzer:
         self._named_bindings: dict[str, str] = {}
         self._namespace_bindings: dict[str, str] = {}
         self._deferred_bindings: dict[str, str] = {}
+        # Deferred-binding metadata for the S4 cross-file post-pass (TAP-4540):
+        # local binding name -> (kind, imported_name|None, target_module|None,
+        # specifier). Only populated for the resolvable-later classes (default
+        # export, path alias); external imports get no metadata (stay gaps).
+        self._deferred_meta: dict[str, _DeferredMeta] = {}
 
     # ------------------------------------------------------------------
     # Phase 0 — import binding table
@@ -191,6 +301,8 @@ class _TsFileAnalyzer:
             self._scan_imports(node)
         for node in _iter_statements(root):
             self._register_top_level(node)
+        for node in _iter_statements(root):
+            self._register_exports(node)
         # Phase 2 — collect calls per registered symbol body.
         for node in _iter_statements(root):
             self._collect_top_level(node)
@@ -201,18 +313,14 @@ class _TsFileAnalyzer:
         Mirrors ``call_graph_resolve._apply_import_bindings``: a binding maps a
         local name to a qualified target when it is a named/namespace import
         from an in-repo relative module, and to a deferred gap reason otherwise.
+
+        Re-export statements (``export {x} from "./y"``, ``export * from "./y"``)
+        are recorded in the module's re-export table (TAP-4540) so the post-pass
+        can follow the chain to the origin symbol — no longer an unconditional
+        gap.
         """
         if node.type == "export_statement" and _is_reexport(node):
-            # `export {x} from "./re"` — deferred to S4. Mark the point honestly.
-            self.gaps.append(
-                ResolutionGap(
-                    self.module,
-                    _node_text(node, self.source).strip(),
-                    _line_of(node),
-                    "reexport_unresolved",
-                    language="typescript",
-                )
-            )
+            self._record_reexport(node)
             return
         if node.type != "import_statement":
             return
@@ -234,7 +342,11 @@ class _TsFileAnalyzer:
                     if target_module is not None:
                         self._named_bindings[local] = f"{target_module}.{real}"
                     elif is_path_alias:
+                        # Path-alias named import — resolvable later via tsconfig.
                         self._deferred_bindings[local] = "path_alias_unresolved"
+                        self._deferred_meta[local] = _DeferredMeta(
+                            "named", real, None, specifier
+                        )
                     else:  # external package (fs, lodash, ...)
                         self._deferred_bindings[local] = "import_unresolved"
             elif child.type == "namespace_import":
@@ -244,18 +356,30 @@ class _TsFileAnalyzer:
                 if target_module is not None:
                     self._namespace_bindings[alias] = target_module
                 elif is_path_alias:
+                    # Path-alias namespace import — the accessed member name is
+                    # known only at the call site, so imported_name stays None
+                    # here and is filled in when the deferred call is recorded.
                     self._deferred_bindings[alias] = "path_alias_unresolved"
+                    self._deferred_meta[alias] = _DeferredMeta(
+                        "namespace", None, None, specifier
+                    )
                 else:
                     self._deferred_bindings[alias] = "import_unresolved"
             elif child.type == "identifier":
                 # Default import: `import makeDefault from "./util"`.
-                # Default-export resolution is deferred to S4 regardless of
-                # whether the source module is in-repo — never guess.
+                # Default-export resolution needs the target module's default
+                # symbol, which the per-file pass cannot see — defer to S4.
                 local = _node_text(child, self.source)
                 if is_path_alias:
                     self._deferred_bindings[local] = "path_alias_unresolved"
+                    self._deferred_meta[local] = _DeferredMeta(
+                        "default", None, None, specifier
+                    )
                 elif is_relative:
                     self._deferred_bindings[local] = "unresolved_default_export"
+                    self._deferred_meta[local] = _DeferredMeta(
+                        "default", None, target_module, specifier
+                    )
                 else:
                     self._deferred_bindings[local] = "import_unresolved"
 
@@ -296,6 +420,91 @@ class _TsFileAnalyzer:
             qname = self._qualify_method(class_name, method_name)
             self._class_methods[f"{class_name}.{method_name}"] = qname
             self.symbols.append(self._symbol(qname, member, "method"))
+
+    # ------------------------------------------------------------------
+    # Phase 1b — export surface (TAP-4540)
+    # ------------------------------------------------------------------
+
+    def _register_exports(self, node: Any) -> None:
+        """Record this module's export surface for cross-file resolution.
+
+        Sets ``exports.default_symbol`` (the ``export default`` target's
+        qualified name, when it names an in-module symbol) and records local
+        alias exports (``export { impl as pub }``) in the re-export table so the
+        post-pass can follow ``pub`` back to the local symbol. Plain
+        ``export function f`` needs no bookkeeping — the symbol is already in the
+        global symbol table under its own qualified name. Re-export ``from``
+        statements are handled in ``_scan_imports`` -> ``_record_reexport``.
+        """
+        if node.type != "export_statement":
+            return
+        if _is_reexport(node):
+            return  # handled during import scan
+        # `export default <name|decl>`
+        if _has_default_keyword(node):
+            self._register_default_export(node)
+            return
+        # `export { impl as pub }` (local export clause, no `from`): a rename
+        # means consumers import `pub`, but the symbol is registered as `impl`.
+        clause = _first_child_of_type(node, "export_clause")
+        if clause is not None:
+            for local, exported in _export_clause_pairs(clause, self.source):
+                if exported != local and local in self._local_functions:
+                    # Empty specifier == "origin is in this same module".
+                    self.exports.reexports[exported] = ("", local)
+
+    def _register_default_export(self, node: Any) -> None:
+        """Resolve ``export default <target>`` to a qualified in-module symbol."""
+        # `export default function foo() {}` / `export default class C {}`
+        for child in node.children:
+            if child.type in (_FUNCTION_DECL_TYPE, "class_declaration"):
+                name = self._decl_name(child, field="name") or _first_child_text(
+                    child, "type_identifier", self.source
+                )
+                if name:
+                    self.exports.default_symbol = self._qualify(name)
+                return
+        # `export default foo;` — a bare identifier naming a local symbol.
+        for child in node.children:
+            if child.type == "identifier":
+                name = _node_text(child, self.source)
+                qname = self._local_functions.get(name)
+                if qname is not None:
+                    self.exports.default_symbol = qname
+                return
+        # `export default () => {}` / `export default { ... }` — anonymous, no
+        # nameable symbol. Leave default_symbol None (post-pass keeps the gap).
+
+    def _record_reexport(self, node: Any) -> None:
+        """Record a ``... from "./y"`` re-export in the module's export table.
+
+        ``export { a as b } from "./y"`` -> reexports["b"] = ("./y", "a").
+        ``export * from "./y"`` -> star_reexports.append("./y").
+        """
+        specifier = _import_specifier(node, self.source)
+        if specifier is None:
+            return
+        # Standalone-view gap (unchanged from S3): honest until the post-pass
+        # follows the chain.
+        self.reexport_gaps.append(
+            ResolutionGap(
+                self.module,
+                _node_text(node, self.source).strip(),
+                _line_of(node),
+                "reexport_unresolved",
+                language="typescript",
+            )
+        )
+        clause = _first_child_of_type(node, "export_clause")
+        if clause is not None:
+            for local, exported in _export_clause_pairs(clause, self.source):
+                # For a re-export, ``local`` is the origin name in the source
+                # module and ``exported`` is what this module re-exports as.
+                self.exports.reexports[exported] = (specifier, local)
+            return
+        # `export * from "./y"` — no clause; a namespace/star re-export.
+        if any(child.type == "*" for child in node.children):
+            self.exports.star_reexports.append(specifier)
 
     # ------------------------------------------------------------------
     # Phase 2 — call collection
@@ -372,67 +581,100 @@ class _TsFileAnalyzer:
             return
         expr = _node_text(func, self.source)
         line = _line_of(call)
-        callee, reason = self._resolve(func, class_name)
-        if callee is None:
-            self._gap(caller, expr, line, reason)
+        callee, reason, deferred_key, member = self._resolve(func, class_name)
+        if callee is not None:
+            self.edges.append(CallEdge(caller, callee, expr, line, True))
             return
-        self.edges.append(CallEdge(caller, callee, expr, line, True))
+        gap = ResolutionGap(caller, expr, line, reason, language="typescript")
+        # A deferrable binding (default export / path alias) — hand the gap to
+        # the S4 cross-file post-pass with the structured hints it needs. If the
+        # post-pass cannot resolve it either, it emits this same gap unchanged.
+        meta = self._deferred_meta.get(deferred_key) if deferred_key else None
+        if meta is not None:
+            imported = member if meta.kind == "namespace" else meta.imported_name
+            self.deferred_calls.append(
+                DeferredCall(
+                    gap=gap,
+                    kind=meta.kind,
+                    imported_name=imported,
+                    target_module=meta.target_module,
+                    specifier=meta.specifier,
+                    caller=caller,
+                )
+            )
+            return
+        self.gaps.append(gap)
 
     def _gap(self, caller: str, expr: str, line: int, reason: str) -> None:
         self.gaps.append(ResolutionGap(caller, expr, line, reason, language="typescript"))
 
-    def _resolve(self, func: Any, class_name: str | None) -> tuple[str | None, str]:
-        """Resolve a call target to an in-repo symbol, or return (None, reason).
+    def _resolve(
+        self, func: Any, class_name: str | None
+    ) -> tuple[str | None, str, str | None, str | None]:
+        """Resolve a call target, or return the deferral hints for the post-pass.
+
+        Returns ``(callee, reason, deferred_key, member)``:
+          * ``callee`` — qualified in-repo symbol when resolved now, else ``None``.
+          * ``reason`` — gap reason when ``callee`` is ``None``.
+          * ``deferred_key`` — local binding name when this is a deferrable
+            import (default export / path alias) the S4 post-pass may resolve.
+          * ``member`` — accessed member name for a namespace call (``U.greet``
+            -> ``"greet"``), else ``None``.
 
         Resolution order mirrors ``call_graph_resolve.resolve_name``: local
-        module symbols first, then the lexical import-binding table. A binding
-        we cannot follow yet yields its recorded deferred reason — never a
-        guessed edge.
+        module symbols first, then the lexical import-binding table. A binding we
+        cannot follow yet yields its recorded deferred reason — never a guess.
         """
         if func.type == "identifier":
             name = _node_text(func, self.source)
             qname = self._local_functions.get(name)
             if qname is not None:
-                return qname, "unresolved_static_call"
+                return qname, "unresolved_static_call", None, None
             # Named / aliased import from an in-repo relative module (resolved).
             bound = self._named_bindings.get(name)
             if bound is not None:
-                return bound, "unresolved_static_call"
+                return bound, "unresolved_static_call", None, None
             # A binding we deliberately did not resolve (default / external / alias).
             deferred = self._deferred_bindings.get(name)
             if deferred is not None:
-                return None, deferred
+                return None, deferred, name, None
             # A bare name we do not own and never saw imported.
-            return None, "import_unresolved"
+            return None, "import_unresolved", None, None
         if func.type == "member_expression":
             obj = func.child_by_field_name("object")
             prop = func.child_by_field_name("property")
             if obj is None or prop is None:
-                return None, "unresolved_static_call"
+                return None, "unresolved_static_call", None, None
             if obj.type == "this" and class_name:
                 method_name = _node_text(prop, self.source)
                 qname = self._class_methods.get(f"{class_name}.{method_name}")
                 if qname is not None:
-                    return qname, "unresolved_static_call"
+                    return qname, "unresolved_static_call", None, None
                 # this.<something not a known method> — dynamic within class.
-                return None, "unresolved_static_call"
+                return None, "unresolved_static_call", None, None
             if obj.type == "identifier":
                 obj_name = _node_text(obj, self.source)
+                member = (
+                    _node_text(prop, self.source)
+                    if prop.type == "property_identifier"
+                    else None
+                )
                 # Namespace import: `import * as U from "./util"` -> U.greet().
                 ns_module = self._namespace_bindings.get(obj_name)
-                if ns_module is not None and prop.type == "property_identifier":
-                    return f"{ns_module}.{_node_text(prop, self.source)}", "unresolved_static_call"
-                # A namespace-like deferred binding (external `import * as fs`).
+                if ns_module is not None and member is not None:
+                    return f"{ns_module}.{member}", "unresolved_static_call", None, None
+                # A namespace-like deferred binding (external `import * as fs`,
+                # or a path-alias `import * as U from "@/util"` awaiting tsconfig).
                 deferred = self._deferred_bindings.get(obj_name)
                 if deferred is not None:
-                    return None, deferred
+                    return None, deferred, obj_name, member
                 # A local variable / typed receiver: `f.format()`. We cannot
                 # know the receiver's type without a type checker — defer.
-                return None, "receiver_untyped"
+                return None, "receiver_untyped", None, None
             # obj.method() where obj is not a plain identifier (chained, etc.).
-            return None, "receiver_untyped"
+            return None, "receiver_untyped", None, None
         # call().foo(), (expr)(), tagged templates, etc.
-        return None, "dynamic_dispatch"
+        return None, "dynamic_dispatch", None, None
 
     # ------------------------------------------------------------------
     # Helpers
@@ -485,6 +727,30 @@ def _unwrap_export(node: Any) -> Any | None:
     if node.type in (_FUNCTION_DECL_TYPE, "lexical_declaration", "class_declaration"):
         return node
     return None
+
+
+def _has_default_keyword(export_node: Any) -> bool:
+    """True for an ``export default ...`` statement (has a ``default`` child)."""
+    return any(child.type == "default" for child in export_node.children)
+
+
+def _export_clause_pairs(clause: Any, source: bytes) -> list[tuple[str, str]]:
+    """Yield ``(local_name, exported_name)`` for each ``export_specifier``.
+
+    ``{ a }`` -> ``("a", "a")``; ``{ a as b }`` -> ``("a", "b")``. The local name
+    is the source-module origin; the exported name is what consumers import.
+    """
+    out: list[tuple[str, str]] = []
+    for spec in clause.children:
+        if spec.type != "export_specifier":
+            continue
+        idents = [c for c in spec.children if c.type == "identifier"]
+        if not idents:
+            continue
+        local = _node_text(idents[0], source)
+        exported = _node_text(idents[1], source) if len(idents) >= 2 else local
+        out.append((local, exported))
+    return out
 
 
 def _arrow_declarators(lexical: Any, source: bytes) -> list[tuple[str, Any]]:
@@ -559,10 +825,14 @@ def _namespace_alias(namespace_import: Any, source: bytes) -> str:
 
 
 def _is_reexport(export_node: Any) -> bool:
-    """True for ``export {x} from "..."`` (a re-export, not a local export)."""
-    has_from = any(child.type == "from" for child in export_node.children)
-    has_clause = any(child.type == "export_clause" for child in export_node.children)
-    return has_from and has_clause
+    """True for any ``export ... from "..."`` (re-export, not a local export).
+
+    Covers both ``export { x } from "./y"`` (has ``export_clause``) and
+    ``export * from "./y"`` (has a ``*`` child). The discriminator is the
+    presence of a ``from`` clause: a bare ``export { x }`` (no ``from``) is a
+    local export, not a re-export.
+    """
+    return any(child.type == "from" for child in export_node.children)
 
 
 def _is_path_alias(specifier: str) -> bool:

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_resolve_ts.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_resolve_ts.py
@@ -1,0 +1,220 @@
+"""Cross-file TypeScript resolution post-pass for the call graph (TAP-4540).
+
+S4 of the call-graph language expansion. The per-file analyzer
+(``call_graph_analyze_ts``) cannot resolve three import classes on its own —
+default exports, tsconfig path aliases, and re-export chains — because each
+needs *another* module's export surface. This module runs after every file is
+analyzed and promotes those deferred cases to real edges where the origin
+symbol can be found, following re-export chains to their origin.
+
+Deterministic contract (ADR-0004): no LLM, no network. Every resolution ends at
+a symbol that exists in the global symbol table, or the honest gap is kept. A
+re-export cycle or a missing origin keeps the gap — never a fabricated edge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tapps_mcp.project.call_graph_analyze_ts import _resolve_relative_module
+from tapps_mcp.project.call_graph_tsconfig import TsconfigPaths, resolve_path_alias
+from tapps_mcp.project.call_graph_types import (
+    CallEdge,
+    DeferredCall,
+    ModuleExports,
+    ResolutionGap,
+)
+
+# Cap re-export chain traversal so a pathological (or cyclic) barrel graph can
+# never loop forever. Real re-export chains are shallow; 16 is generous.
+_MAX_REEXPORT_DEPTH = 16
+
+
+@dataclass
+class TsResolutionResult:
+    """Outcome of the cross-file TS post-pass."""
+
+    # Newly promoted edges (a DeferredCall that resolved to an origin symbol).
+    new_edges: list[CallEdge]
+    # Gaps for DeferredCalls that stayed unresolved (emitted verbatim).
+    remaining_gaps: list[ResolutionGap]
+    # Callee rewrites: original qualified callee -> origin qualified callee, for
+    # already-resolved edges whose target module merely re-exports the symbol.
+    edge_rewrites: dict[str, str]
+    # Dangling callees to demote from edge to gap: a named import resolved
+    # eagerly (S3) to ``module.name`` where the module neither defines nor
+    # (resolvably) re-exports the symbol — a broken chain. Keeping the edge
+    # would fabricate a target (ADR-0004), so it becomes an honest gap instead.
+    dangling_callees: set[str]
+
+
+class _ReexportResolver:
+    """Follows ``module.name`` through re-export tables to an origin symbol."""
+
+    def __init__(
+        self,
+        exports_by_module: dict[str, ModuleExports],
+        symbol_names: set[str],
+    ) -> None:
+        self._exports = exports_by_module
+        self._symbols = symbol_names
+
+    def exports_for(self, module: str) -> ModuleExports | None:
+        """Export surface of ``module``, or ``None`` if it wasn't analyzed."""
+        return self._exports.get(module)
+
+    def is_symbol(self, qualified_name: str) -> bool:
+        """True when ``qualified_name`` is a real symbol in the global table."""
+        return qualified_name in self._symbols
+
+    def resolve(self, module: str, name: str) -> str | None:
+        """Resolve ``name`` exported by ``module`` to a real qualified symbol.
+
+        Follows ``export { name } from "./other"`` / ``export * from "./other"``
+        chains to the origin. Returns the qualified name when it lands on a real
+        symbol, else ``None`` (unknown origin, broken chain, or cycle).
+        """
+        return self._resolve(module, name, depth=0, seen=set())
+
+    def _resolve(self, module: str, name: str, *, depth: int, seen: set[tuple[str, str]]) -> str | None:
+        if depth > _MAX_REEXPORT_DEPTH:
+            return None
+        key = (module, name)
+        if key in seen:
+            return None  # cycle — keep the gap.
+        seen.add(key)
+
+        exports = self._exports.get(module)
+        # Direct hit: the module owns a symbol with this qualified name.
+        candidate = f"{module}.{name}"
+        if candidate in self._symbols:
+            # If the module also re-exports this name from elsewhere, the local
+            # symbol wins (a same-name local definition shadows a re-export).
+            if exports is None or name not in exports.reexports:
+                return candidate
+
+        if exports is None:
+            return None
+
+        # Named re-export: `export { origin as name } from "./src"`.
+        reexport = exports.reexports.get(name)
+        if reexport is not None:
+            src_specifier, origin_name = reexport
+            if src_specifier == "":
+                # Local alias export (`export { impl as name }`) — origin lives
+                # in this same module.
+                origin_qual = f"{module}.{origin_name}"
+                return origin_qual if origin_qual in self._symbols else None
+            target = _resolve_relative_module(module, src_specifier)
+            if target is None:
+                return None  # non-relative re-export source — cannot follow.
+            return self._resolve(target, origin_name, depth=depth + 1, seen=seen)
+
+        # Star re-export: `export * from "./src"` — the name may live in any
+        # star source. Try each in declared order; first real hit wins.
+        for src_specifier in exports.star_reexports:
+            target = _resolve_relative_module(module, src_specifier)
+            if target is None:
+                continue
+            hit = self._resolve(target, name, depth=depth + 1, seen=set(seen))
+            if hit is not None:
+                return hit
+        return None
+
+
+def resolve_ts_cross_file(
+    *,
+    deferred_calls: list[DeferredCall],
+    exports_by_module: dict[str, ModuleExports],
+    symbol_names: set[str],
+    resolved_edges: list[CallEdge],
+    tsconfig: TsconfigPaths,
+) -> TsResolutionResult:
+    """Promote deferred TS calls to edges and follow re-export chains.
+
+    ``deferred_calls`` are the per-file cases the analyzer could not resolve.
+    ``exports_by_module`` maps every TS module to its export surface.
+    ``symbol_names`` is the set of all qualified symbol names (origin check).
+    ``resolved_edges`` are already-resolved edges we may rewrite when their
+    callee module only re-exports the symbol. ``tsconfig`` supplies path aliases.
+    """
+    resolver = _ReexportResolver(exports_by_module, symbol_names)
+    new_edges: list[CallEdge] = []
+    remaining_gaps: list[ResolutionGap] = []
+
+    for dc in deferred_calls:
+        origin = _resolve_deferred_call(dc, resolver=resolver, tsconfig=tsconfig)
+        if origin is not None:
+            gap = dc.gap
+            new_edges.append(CallEdge(dc.caller, origin, gap.expr, gap.line, True))
+        else:
+            remaining_gaps.append(dc.gap)
+
+    # Follow-through for already-resolved edges: a named import that landed on a
+    # barrel module (`barrel.x`) should point at the origin (`impl.x`) when
+    # `barrel` merely re-exports `x`. When the callee is NOT a real symbol and
+    # the re-export chain resolves nowhere, the eager S3 edge was a fabricated
+    # target — demote it to a gap (dangling) rather than keep the phantom edge.
+    edge_rewrites: dict[str, str] = {}
+    dangling_callees: set[str] = set()
+    for edge in resolved_edges:
+        callee = edge.callee
+        if callee in symbol_names or callee in edge_rewrites or callee in dangling_callees:
+            continue
+        module, _, name = callee.rpartition(".")
+        if not module or not name:
+            continue
+        exports = exports_by_module.get(module)
+        if exports is None:
+            # The callee module isn't a TS module we analyzed — leave it be
+            # (Python edges, or a symbol produced by another resolver).
+            continue
+        origin = resolver.resolve(module, name)
+        if origin is not None and origin != callee:
+            edge_rewrites[callee] = origin
+            continue
+        if origin is not None:
+            continue
+        # origin is None: the module neither defines the symbol nor resolvably
+        # re-exports it. Only demote when the callee is a *re-export* that broke
+        # (the name is in the re-export table or reachable solely via `export *`)
+        # — a name the module locally exports but our extractor didn't capture as
+        # a callable symbol is left as-is to preserve the S3 edge (no regression).
+        if name in exports.reexports or exports.star_reexports:
+            dangling_callees.add(callee)
+
+    return TsResolutionResult(
+        new_edges=new_edges,
+        remaining_gaps=remaining_gaps,
+        edge_rewrites=edge_rewrites,
+        dangling_callees=dangling_callees,
+    )
+
+
+def _resolve_deferred_call(
+    dc: DeferredCall,
+    *,
+    resolver: _ReexportResolver,
+    tsconfig: TsconfigPaths,
+) -> str | None:
+    """Resolve a single deferred call to an origin symbol, or ``None``."""
+    target_module = dc.target_module
+    if target_module is None:
+        # Path-alias case: resolve the specifier via tsconfig first. A missing
+        # or non-matching config keeps the gap (never guess).
+        target_module = resolve_path_alias(tsconfig, dc.specifier)
+        if target_module is None:
+            return None
+
+    if dc.kind == "default":
+        exports = resolver.exports_for(target_module)
+        if exports is None or exports.default_symbol is None:
+            return None
+        # A default symbol is already a real qualified symbol (the analyzer only
+        # sets it when it names an in-module declaration).
+        return exports.default_symbol if resolver.is_symbol(exports.default_symbol) else None
+
+    # Named / namespace import: resolve the accessed name through re-exports.
+    if dc.imported_name is None:
+        return None
+    return resolver.resolve(target_module, dc.imported_name)

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_tsconfig.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_tsconfig.py
@@ -1,0 +1,140 @@
+"""tsconfig ``compilerOptions.paths`` alias resolution for TS call graphs (TAP-4540).
+
+S4 of the call-graph language expansion. Reads ``tsconfig.json`` from the
+project root and turns a path-alias specifier (``@/util``) into a slash-delimited
+module name matching the ``_ts_file_to_module`` convention (leading ``src/``
+stripped, ``.ts``/``.tsx`` suffix dropped).
+
+Deterministic contract (ADR-0004): no LLM, no network. A missing / malformed
+config, or a specifier that matches no alias, yields ``None`` — the caller keeps
+the ``path_alias_unresolved`` gap rather than guessing a target.
+
+Scope kept deliberately small: the common ``{"@/*": ["src/*"]}`` wildcard form
+plus exact (non-wildcard) aliases. ``extends``, JSON5 comments/trailing commas,
+and project references are out of scope — a config we cannot parse cleanly
+degrades to "no aliases" (empty map), never a crash.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class TsconfigPaths:
+    """Resolved ``compilerOptions.paths`` + ``baseUrl`` from a project ``tsconfig``.
+
+    ``base_url`` is the directory (relative to the project root) that ``paths``
+    targets are resolved against; defaults to ``.`` (the project root) per the
+    TypeScript spec when ``paths`` is present but ``baseUrl`` is not.
+    """
+
+    base_url: str = "."
+    # Alias pattern -> list of substitution targets. A wildcard alias ends with
+    # ``/*`` and its targets contain a single ``*``. Exact aliases have neither.
+    aliases: dict[str, list[str]] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        return not self.aliases
+
+
+def load_tsconfig_paths(project_root: Path) -> TsconfigPaths:
+    """Load ``compilerOptions.paths`` / ``baseUrl`` from ``<root>/tsconfig.json``.
+
+    Returns an empty ``TsconfigPaths`` (no aliases) when the file is absent,
+    unreadable, not valid JSON, or has no ``paths`` block — the caller treats an
+    empty config as "cannot resolve, keep the gap".
+    """
+    path = project_root / "tsconfig.json"
+    if not path.is_file():
+        return TsconfigPaths()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        # Malformed / commented tsconfig — degrade to no aliases, never crash.
+        return TsconfigPaths()
+    if not isinstance(raw, dict):
+        return TsconfigPaths()
+    compiler = raw.get("compilerOptions")
+    if not isinstance(compiler, dict):
+        return TsconfigPaths()
+    paths_raw = compiler.get("paths")
+    if not isinstance(paths_raw, dict):
+        return TsconfigPaths()
+
+    base_url = compiler.get("baseUrl")
+    base = base_url if isinstance(base_url, str) and base_url.strip() else "."
+
+    aliases: dict[str, list[str]] = {}
+    for alias, targets in paths_raw.items():
+        if not isinstance(alias, str) or not isinstance(targets, list):
+            continue
+        target_list = [t for t in targets if isinstance(t, str) and t.strip()]
+        if target_list:
+            aliases[alias] = target_list
+    return TsconfigPaths(base_url=base, aliases=aliases)
+
+
+def resolve_path_alias(config: TsconfigPaths, specifier: str) -> str | None:
+    """Resolve an alias ``specifier`` to a module name, or ``None`` if no match.
+
+    Handles the two ``paths`` forms:
+
+    * **Wildcard** (``"@/*": ["src/*"]``): the ``*`` captures the tail of the
+      specifier and substitutes it into the target's ``*``.
+    * **Exact** (``"@app": ["src/app/index"]``): the whole specifier must equal
+      the alias key; the first target is used verbatim.
+
+    The resolved filesystem-style target (``baseUrl`` + substituted target) is
+    normalized to the ``_ts_file_to_module`` convention: leading ``src/``
+    stripped, any ``.ts``/``.tsx``/``.js``/``.jsx`` suffix dropped. Returns
+    ``None`` when nothing matches so the caller keeps the honest gap.
+    """
+    if config.is_empty():
+        return None
+    # Deterministic order: try the longest alias prefix first so a specific
+    # alias wins over a broad one. Exact matches are handled inside the loop.
+    for alias in sorted(config.aliases, key=len, reverse=True):
+        targets = config.aliases[alias]
+        substituted = _match_alias(alias, targets, specifier)
+        if substituted is not None:
+            return _target_to_module(config.base_url, substituted)
+    return None
+
+
+def _match_alias(alias: str, targets: list[str], specifier: str) -> str | None:
+    """Return the substituted target path for ``specifier`` under ``alias``.
+
+    Only the first target is consulted (the common single-target form); multiple
+    fallback targets would need on-disk existence checks to disambiguate, which
+    is out of scope for the deterministic contract.
+    """
+    if alias.endswith("/*"):
+        prefix = alias[:-1]  # keep the trailing slash, drop the star.
+        if not specifier.startswith(prefix):
+            return None
+        tail = specifier[len(prefix) :]
+        target = targets[0]
+        if "*" not in target:
+            return None
+        return target.replace("*", tail, 1)
+    # Exact alias: the specifier must equal the key exactly.
+    if specifier == alias:
+        return targets[0]
+    return None
+
+
+def _target_to_module(base_url: str, target: str) -> str:
+    """Normalize a ``baseUrl``-relative target path to a module name."""
+    combined = target if base_url in (".", "") else f"{base_url.rstrip('/')}/{target}"
+    # Drop a recognized TS/JS suffix.
+    for suffix in (".tsx", ".ts", ".jsx", ".js"):
+        if combined.endswith(suffix):
+            combined = combined[: -len(suffix)]
+            break
+    parts = [p for p in combined.split("/") if p not in ("", ".")]
+    if parts and parts[0] == "src":
+        parts = parts[1:]
+    return "/".join(parts)

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
@@ -70,6 +70,52 @@ class ParseFailure:
     reason: PARSE_FAILURE_REASON | str
 
 
+# --- TypeScript deferred cross-file resolution (TAP-4540) -----------------
+# The following records are internal to the build-time cross-file resolution
+# pass in ``call_graph.py``. They are NOT persisted in the on-disk index — they
+# carry the structured hints the per-file TS analyzer cannot resolve on its own
+# (default exports, tsconfig path aliases, re-export chains).
+
+# How a deferred call binding was imported.
+DeferredImportKind = Literal["default", "named", "namespace"]
+
+
+@dataclass
+class DeferredCall:
+    """A TS call site the per-file analyzer could not resolve alone (TAP-4540).
+
+    The cross-file post-pass tries to turn each ``DeferredCall`` into a
+    ``CallEdge`` using module export tables + tsconfig aliases. When it cannot,
+    the recorded ``gap`` is emitted verbatim so nothing is fabricated.
+    """
+
+    gap: ResolutionGap
+    kind: DeferredImportKind
+    # Real imported symbol name (named import) or accessed member (namespace).
+    # ``None`` for a bare default import.
+    imported_name: str | None
+    # Resolved in-repo target module when the specifier is relative, else ``None``
+    # (an unresolved specifier still needs ``specifier`` for alias resolution).
+    target_module: str | None
+    # Raw import specifier (``"./util"``, ``"@/util"``) for tsconfig aliasing.
+    specifier: str
+    caller: str
+
+
+@dataclass
+class ModuleExports:
+    """Export surface of one TS module, for cross-file resolution (TAP-4540)."""
+
+    module: str
+    # Qualified name of the module's ``export default`` symbol, if any.
+    default_symbol: str | None = None
+    # Re-export edges: local exported name -> (from-specifier, origin name).
+    # ``export {a as b} from "./y"`` -> {"b": ("./y", "a")}.
+    reexports: dict[str, tuple[str, str]] = field(default_factory=dict)
+    # ``export * from "./y"`` specifiers (star re-exports — any name may pass).
+    star_reexports: list[str] = field(default_factory=list)
+
+
 @dataclass
 class CallGraphIndex:
     symbols: list[SymbolRecord] = field(default_factory=list)

--- a/packages/tapps-mcp/tests/unit/test_call_graph_ts_deferred.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_ts_deferred.py
@@ -1,0 +1,284 @@
+"""S4 cross-file TS resolution tests (TAP-4540).
+
+Exercises the ``build_call_graph_index`` post-pass end to end: a default import
+resolving to the real default symbol, a ``@/``-alias resolving via a fixture
+``tsconfig.json``, and a re-export chain following through to the origin — each
+with a negative counterpart (no config / no default / broken chain → honest
+gap) per the deterministic contract (ADR-0004).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tapps_mcp.project.call_graph import build_call_graph_index
+from tapps_mcp.project.call_graph_analyze_ts import HAS_TREE_SITTER
+
+pytestmark = pytest.mark.skipif(
+    not HAS_TREE_SITTER, reason="tree-sitter TypeScript grammar not installed"
+)
+
+
+def _project(tmp_path: Path, files: dict[str, str], tsconfig: str | None = None) -> Path:
+    for name, content in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    if tsconfig is not None:
+        (tmp_path / "tsconfig.json").write_text(tsconfig, encoding="utf-8")
+    return tmp_path
+
+
+def _edge(idx, caller: str, callee: str) -> bool:
+    return any(e.caller == caller and e.callee == callee for e in idx.edges)
+
+
+def _gap(idx, caller: str, expr: str, reason: str) -> bool:
+    return any(
+        g.caller == caller and g.expr == expr and g.reason == reason
+        for g in idx.resolution_gaps
+    )
+
+
+class TestDefaultExportResolution:
+    def test_default_import_resolves_to_default_symbol(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export default function makeDefault() {}\n",
+                "src/consumer.ts": (
+                    'import makeDefault from "./util";\n'
+                    "function run() { makeDefault(); }\n"
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "util.makeDefault")
+        assert not _gap(idx, "consumer.run", "makeDefault", "unresolved_default_export")
+
+    def test_default_named_export_resolves(self, tmp_path: Path) -> None:
+        # `export default foo;` where foo is a local function.
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "function foo() {}\nexport default foo;\n",
+                "src/consumer.ts": 'import md from "./util";\nfunction run() { md(); }\n',
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "util.foo")
+
+    def test_no_default_symbol_stays_gap(self, tmp_path: Path) -> None:
+        # NEGATIVE: the target module has no default export at all.
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export const x = 1;\n",
+                "src/consumer.ts": (
+                    'import makeDefault from "./util";\n'
+                    "function run() { makeDefault(); }\n"
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert not _edge(idx, "consumer.run", "util.makeDefault")
+        assert _gap(idx, "consumer.run", "makeDefault", "unresolved_default_export")
+
+    def test_anonymous_default_arrow_stays_gap(self, tmp_path: Path) -> None:
+        # NEGATIVE: `export default () => {}` has no nameable symbol.
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export default () => {};\n",
+                "src/consumer.ts": 'import md from "./util";\nfunction run() { md(); }\n',
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert not any(e.callee_expr == "md" for e in idx.edges)
+        assert _gap(idx, "consumer.run", "md", "unresolved_default_export")
+
+
+class TestPathAliasResolution:
+    _TSCONFIG = '{"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["src/*"]}}}'
+
+    def test_alias_named_import_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export function util() {}\n",
+                "src/consumer.ts": (
+                    'import { util } from "@/util";\nfunction run() { util(); }\n'
+                ),
+            },
+            tsconfig=self._TSCONFIG,
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "util.util")
+        assert not _gap(idx, "consumer.run", "util", "path_alias_unresolved")
+
+    def test_alias_default_import_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export default function md() {}\n",
+                "src/consumer.ts": 'import md from "@/util";\nfunction run() { md(); }\n',
+            },
+            tsconfig=self._TSCONFIG,
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "util.md")
+
+    def test_alias_namespace_import_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export function greet() {}\n",
+                "src/consumer.ts": (
+                    'import * as U from "@/util";\nfunction run() { U.greet(); }\n'
+                ),
+            },
+            tsconfig=self._TSCONFIG,
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "util.greet")
+
+    def test_no_tsconfig_stays_gap(self, tmp_path: Path) -> None:
+        # NEGATIVE: without a tsconfig the alias cannot be resolved.
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export function util() {}\n",
+                "src/consumer.ts": (
+                    'import { util } from "@/util";\nfunction run() { util(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert not _edge(idx, "consumer.run", "util.util")
+        assert _gap(idx, "consumer.run", "util", "path_alias_unresolved")
+
+    def test_non_matching_alias_stays_gap(self, tmp_path: Path) -> None:
+        # NEGATIVE: config exists but the specifier matches no alias key.
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export function util() {}\n",
+                "src/consumer.ts": (
+                    'import { util } from "@/util";\nfunction run() { util(); }\n'
+                ),
+            },
+            tsconfig='{"compilerOptions": {"paths": {"#lib/*": ["lib/*"]}}}',
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _gap(idx, "consumer.run", "util", "path_alias_unresolved")
+
+
+class TestReexportResolution:
+    def test_named_reexport_chain_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/impl.ts": "export function origin() {}\n",
+                "src/barrel.ts": 'export { origin } from "./impl";\n',
+                "src/consumer.ts": (
+                    'import { origin } from "./barrel";\nfunction run() { origin(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        # Follows through the barrel to the origin symbol.
+        assert _edge(idx, "consumer.run", "impl.origin")
+        assert not _edge(idx, "consumer.run", "barrel.origin")
+
+    def test_aliased_reexport_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/impl.ts": "export function realThing() {}\n",
+                "src/barrel.ts": 'export { realThing as pub } from "./impl";\n',
+                "src/consumer.ts": (
+                    'import { pub } from "./barrel";\nfunction run() { pub(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "impl.realThing")
+
+    def test_star_reexport_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/impl.ts": "export function starFn() {}\n",
+                "src/barrel.ts": 'export * from "./impl";\n',
+                "src/consumer.ts": (
+                    'import { starFn } from "./barrel";\nfunction run() { starFn(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "impl.starFn")
+
+    def test_transitive_reexport_chain_resolves(self, tmp_path: Path) -> None:
+        root = _project(
+            tmp_path,
+            {
+                "src/impl.ts": "export function deep() {}\n",
+                "src/mid.ts": 'export { deep } from "./impl";\n',
+                "src/barrel.ts": 'export { deep } from "./mid";\n',
+                "src/consumer.ts": (
+                    'import { deep } from "./barrel";\nfunction run() { deep(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "impl.deep")
+
+    def test_broken_reexport_chain_stays_gap(self, tmp_path: Path) -> None:
+        # NEGATIVE: the barrel re-exports from a module that doesn't exist.
+        root = _project(
+            tmp_path,
+            {
+                "src/barrel.ts": 'export { origin } from "./missing";\n',
+                "src/consumer.ts": (
+                    'import { origin } from "./barrel";\nfunction run() { origin(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert not _edge(idx, "consumer.run", "barrel.origin")
+        assert _gap(idx, "consumer.run", "origin", "reexport_unresolved")
+
+    def test_reexport_cycle_stays_gap(self, tmp_path: Path) -> None:
+        # NEGATIVE: a -> b -> a re-export cycle must not loop; keep the gap.
+        root = _project(
+            tmp_path,
+            {
+                "src/a.ts": 'export { x } from "./b";\n',
+                "src/b.ts": 'export { x } from "./a";\n',
+                "src/consumer.ts": (
+                    'import { x } from "./a";\nfunction run() { x(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert not any(e.callee_expr == "x" for e in idx.edges)
+        assert _gap(idx, "consumer.run", "x", "reexport_unresolved")
+
+
+class TestNoRegressionOnResolvedCases:
+    def test_plain_named_import_still_resolves(self, tmp_path: Path) -> None:
+        # A direct (non-re-exported) named import must keep its edge; the
+        # post-pass must not demote it.
+        root = _project(
+            tmp_path,
+            {
+                "src/util.ts": "export function greet() {}\n",
+                "src/consumer.ts": (
+                    'import { greet } from "./util";\nfunction run() { greet(); }\n'
+                ),
+            },
+        )
+        idx = build_call_graph_index(root, force_rebuild=True)
+        assert _edge(idx, "consumer.run", "util.greet")

--- a/packages/tapps-mcp/tests/unit/test_call_graph_tsconfig.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_tsconfig.py
@@ -1,0 +1,95 @@
+"""Unit tests for tsconfig path-alias resolution (TAP-4540).
+
+Covers the ``{"@/*": ["src/*"]}`` wildcard form, exact aliases, baseUrl
+handling, and the honest-negative cases (missing / malformed config, no match)
+required by the deterministic contract (ADR-0004).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tapps_mcp.project.call_graph_tsconfig import (
+    TsconfigPaths,
+    load_tsconfig_paths,
+    resolve_path_alias,
+)
+
+
+def _write_tsconfig(tmp_path: Path, body: str) -> Path:
+    (tmp_path / "tsconfig.json").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+class TestLoadTsconfigPaths:
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        cfg = load_tsconfig_paths(tmp_path)
+        assert cfg.is_empty()
+        assert cfg.aliases == {}
+
+    def test_wildcard_alias_loads(self, tmp_path: Path) -> None:
+        _write_tsconfig(
+            tmp_path,
+            '{"compilerOptions": {"baseUrl": ".", "paths": {"@/*": ["src/*"]}}}',
+        )
+        cfg = load_tsconfig_paths(tmp_path)
+        assert not cfg.is_empty()
+        assert cfg.aliases == {"@/*": ["src/*"]}
+        assert cfg.base_url == "."
+
+    def test_malformed_json_degrades_to_empty(self, tmp_path: Path) -> None:
+        # Trailing comma / comments — not standard JSON. Degrade, never crash.
+        _write_tsconfig(tmp_path, '{"compilerOptions": {"paths": {"@/*": ["src/*"]},}}')
+        cfg = load_tsconfig_paths(tmp_path)
+        assert cfg.is_empty()
+
+    def test_no_paths_block_is_empty(self, tmp_path: Path) -> None:
+        _write_tsconfig(tmp_path, '{"compilerOptions": {"baseUrl": "src"}}')
+        cfg = load_tsconfig_paths(tmp_path)
+        assert cfg.is_empty()
+
+    def test_default_base_url_when_absent(self, tmp_path: Path) -> None:
+        _write_tsconfig(tmp_path, '{"compilerOptions": {"paths": {"@/*": ["src/*"]}}}')
+        cfg = load_tsconfig_paths(tmp_path)
+        assert cfg.base_url == "."
+
+
+class TestResolvePathAlias:
+    def test_wildcard_alias_resolves_to_module(self) -> None:
+        cfg = TsconfigPaths(base_url=".", aliases={"@/*": ["src/*"]})
+        # @/util -> src/util -> module "util" (leading src/ stripped).
+        assert resolve_path_alias(cfg, "@/util") == "util"
+
+    def test_wildcard_alias_nested(self) -> None:
+        cfg = TsconfigPaths(base_url=".", aliases={"@/*": ["src/*"]})
+        assert resolve_path_alias(cfg, "@/a/b/util") == "a/b/util"
+
+    def test_no_src_prefix_target(self) -> None:
+        cfg = TsconfigPaths(base_url=".", aliases={"~/*": ["lib/*"]})
+        assert resolve_path_alias(cfg, "~/thing") == "lib/thing"
+
+    def test_exact_alias_resolves(self) -> None:
+        cfg = TsconfigPaths(base_url=".", aliases={"@app": ["src/app/index"]})
+        assert resolve_path_alias(cfg, "@app") == "app/index"
+
+    def test_base_url_prepended(self) -> None:
+        # baseUrl "packages" + target "src/util" -> packages/src/util ->
+        # (only a *leading* src is stripped) -> packages/src/util.
+        cfg = TsconfigPaths(base_url="packages", aliases={"@/*": ["mod/*"]})
+        assert resolve_path_alias(cfg, "@/util") == "packages/mod/util"
+
+    def test_empty_config_returns_none(self) -> None:
+        assert resolve_path_alias(TsconfigPaths(), "@/util") is None
+
+    def test_non_matching_specifier_returns_none(self) -> None:
+        cfg = TsconfigPaths(base_url=".", aliases={"@/*": ["src/*"]})
+        assert resolve_path_alias(cfg, "#/util") is None
+        assert resolve_path_alias(cfg, "./relative") is None
+
+    def test_longest_alias_wins(self) -> None:
+        cfg = TsconfigPaths(
+            base_url=".",
+            aliases={"@/*": ["src/*"], "@/features/*": ["src/features/*"]},
+        )
+        # The more specific alias must be tried first.
+        assert resolve_path_alias(cfg, "@/features/x") == "features/x"


### PR DESCRIPTION
Closes TAP-4540 (S4 of TAP-4531). Builds on S3 (#179). Completes TS v1 resolution.

## What
Turns S3's three deferred gap classes into resolved edges via a cross-file post-pass in `build_call_graph_index`:
- **Default exports** — per-module `export default` symbol table → default imports resolve.
- **tsconfig path aliases** — new `call_graph_tsconfig.py` reads `compilerOptions.paths`/`baseUrl`, resolves `@/*` wildcard + exact aliases. Missing/malformed → gap (never guessed).
- **Re-exports** — named/aliased/`export *`/transitive chains with depth cap + cycle guard.
- **Phantom-edge demotion** — a "resolved" edge whose target module neither defines nor resolvably re-exports the symbol is demoted to `reexport_unresolved` rather than fabricated.

Build-time-only types (`DeferredCall`/`ModuleExports`) — not persisted, so cache serialization is unchanged. Deterministic (ADR-0004).

## Tests
145 passed (29 new); Python path green. Resolved: default import, `@/`-alias import + namespace, named/aliased/`export *`/2-hop re-export chains. Negative gaps kept: no-tsconfig, anonymous default, broken chain, re-export cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)