### PR TITLE
feat(call_graph): HTTP route-to-handler edges for FastAPI + React Router (TAP-4532)

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph.py
@@ -16,6 +16,10 @@ from tapps_mcp.project.call_graph_cache import (
 )
 from tapps_mcp.project.call_graph_fingerprint import compute_index_fingerprint
 from tapps_mcp.project.call_graph_resolve_ts import resolve_ts_cross_file
+from tapps_mcp.project.call_graph_routes import (
+    extract_fastapi_routes,
+    extract_react_router_routes,
+)
 from tapps_mcp.project.call_graph_tsconfig import load_tsconfig_paths
 from tapps_mcp.project.call_graph_types import (
     CALL_GRAPH_CACHE_REL,
@@ -26,6 +30,7 @@ from tapps_mcp.project.call_graph_types import (
     ModuleExports,
     ParseFailure,
     ResolutionGap,
+    RouteEdge,
     SymbolRecord,
 )
 from tapps_mcp.project.import_graph import _DEFAULT_EXCLUDES, _file_to_module, _should_skip
@@ -121,6 +126,9 @@ def build_call_graph_index(
     edges: list[CallEdge] = []
     gaps: list[ResolutionGap] = []
     parse_failures: list[ParseFailure] = []
+    # HTTP route -> handler edges (TAP-4532): FastAPI decorators (Python) and
+    # React Router JSX (TS). Deterministic; dynamic routes are omitted, not guessed.
+    routes: list[RouteEdge] = []
     # TS cross-file resolution material (S4, TAP-4540): each module's export
     # surface plus the deferred call sites the per-file pass could not resolve.
     ts_exports: dict[str, ModuleExports] = {}
@@ -156,10 +164,12 @@ def build_call_graph_index(
             ) = analyze_file_ts_full(source_file, module, project_root)
             ts_exports[module] = module_exports
             ts_deferred.extend(deferred)
+            routes.extend(extract_react_router_routes(source_file, module, project_root))
         else:
             file_symbols, file_edges, file_gaps, file_failures = analyzer(
                 source_file, module, project_root
             )
+            routes.extend(extract_fastapi_routes(source_file, module, project_root))
         symbols.extend(file_symbols)
         edges.extend(file_edges)
         gaps.extend(file_gaps)
@@ -209,15 +219,23 @@ def build_call_graph_index(
     edges.sort(key=lambda e: (e.caller, e.line, e.callee_expr))
     gaps.sort(key=lambda g: (g.caller, g.line, g.expr))
     parse_failures.sort(key=lambda p: (p.file_path, p.line))
+    routes.sort(key=lambda r: (r.file_path, r.line, r.method, r.path))
 
     index = CallGraphIndex(
         symbols=symbols,
         edges=edges,
         resolution_gaps=gaps,
         parse_failures=parse_failures,
+        routes=routes,
         project_root=str(project_root),
         fingerprint=fingerprint,
     )
     save_call_graph_index(project_root, index)
-    logger.info("call_graph_index_built", symbols=len(symbols), edges=len(edges), gaps=len(gaps))
+    logger.info(
+        "call_graph_index_built",
+        symbols=len(symbols),
+        edges=len(edges),
+        gaps=len(gaps),
+        routes=len(routes),
+    )
     return index

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
@@ -29,6 +29,7 @@ from tapps_mcp.project.call_graph_types import (
     CallGraphIndex,
     ParseFailure,
     ResolutionGap,
+    RouteEdge,
     SymbolRecord,
 )
 
@@ -99,6 +100,7 @@ def index_to_dict(index: CallGraphIndex) -> dict[str, object]:
         "edges": [asdict(e) for e in index.edges],
         "resolution_gaps": [asdict(g) for g in index.resolution_gaps],
         "parse_failures": [asdict(p) for p in index.parse_failures],
+        "routes": [asdict(r) for r in index.routes],
     }
 
 
@@ -109,11 +111,13 @@ def index_from_dict(raw: dict[str, object]) -> CallGraphIndex:
     failures = [
         ParseFailure(**p) for p in raw.get("parse_failures", []) if isinstance(p, dict)
     ]  # type: ignore[arg-type]
+    routes = [RouteEdge(**r) for r in raw.get("routes", []) if isinstance(r, dict)]  # type: ignore[arg-type]
     return CallGraphIndex(
         symbols=symbols,
         edges=edges,
         resolution_gaps=gaps,
         parse_failures=failures,
+        routes=routes,
         project_root=str(raw.get("project_root", "")),
         fingerprint=str(raw.get("fingerprint", "")),
         version=int(raw.get("version", INDEX_VERSION)),

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_queries.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_queries.py
@@ -7,6 +7,7 @@ from collections import deque
 from dataclasses import asdict
 from typing import Any, Literal
 
+from tapps_mcp.project.call_graph_routes import handlers_for_path, routes_for_handler
 from tapps_mcp.project.call_graph_types import CallGraphIndex, ResolutionGap
 
 DEFAULT_TOKEN_BUDGET = 4000
@@ -257,4 +258,24 @@ def compact_symbol_impact(
         "symbols": symbols_out,
         "truncated": truncated,
         "token_budget": token_budget,
+    }
+
+
+def query_route_handler(index: CallGraphIndex, path: str) -> dict[str, Any]:
+    """Which handler(s) serve HTTP/route *path* (TAP-4532 AC2)."""
+    matches = handlers_for_path(index.routes, path.strip())
+    return {
+        "path": path,
+        "found": bool(matches),
+        "handlers": [asdict(r) for r in matches],
+    }
+
+
+def query_routes_for_handler(index: CallGraphIndex, handler: str) -> dict[str, Any]:
+    """Which routes break if handler *handler* changes — blast radius (AC2)."""
+    matches = routes_for_handler(index.routes, handler)
+    return {
+        "handler": handler,
+        "found": bool(matches),
+        "routes": [asdict(r) for r in matches],
     }

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_routes.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_routes.py
@@ -1,0 +1,364 @@
+"""HTTP route -> handler edge extraction (TAP-4532).
+
+Models the endpoint <-> handler relationship as a first-class ``RouteEdge`` so an
+agent can ask "which handler serves path X" and "which routes break if I change
+handler Y" (blast radius). Two frameworks are covered:
+
+* **FastAPI (Python ``ast``)** — decorator routes ``@app.get("/x")``,
+  ``@router.post("/y")``, ``@some_router.route("/z")`` on ``APIRouter``/``FastAPI``
+  instances. The decorated function is the handler symbol (qualified with the same
+  scheme as ``call_graph_analyze``); the HTTP verb is the decorator method and the
+  first string-literal argument is the path.
+
+* **React Router (TypeScript, tree-sitter)** — the JSX ``<Route path="/x"
+  element={<Comp/>} />`` form. The component named in ``element`` is the handler
+  symbol; when the component is imported from an in-repo relative module the symbol
+  is qualified to ``<module>.<Comp>``, otherwise the bare local name is kept.
+
+Deterministic contract (ADR-0004): no LLM, no network. A route whose path or
+handler cannot be read from a literal (dynamic ``add_api_route`` calls, a spread
+``{...route}`` element, a computed path expression, the ``createBrowserRouter``
+object-literal form) is simply **not emitted** — never a guessed edge. The
+object-literal router form is intentionally deferred for a clean v1 (see the
+module docstring in the ticket); only the JSX ``<Route>`` form is extracted.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from tapps_mcp.project.call_graph_analyze_ts import (
+    _TSX_LANGUAGE,
+    HAS_TREE_SITTER,
+    _import_specifier,
+    _iter_statements,
+    _named_import_pairs,
+    _node_text,
+    _resolve_relative_module,
+)
+from tapps_mcp.project.call_graph_types import RouteEdge
+
+# Guard tree-sitter import for graceful degradation (mirrors call_graph_analyze_ts).
+try:
+    import tree_sitter
+except ImportError:  # pragma: no cover - exercised only when grammar absent
+    tree_sitter = None  # type: ignore[assignment]
+
+# HTTP verbs FastAPI exposes as decorator methods on ``FastAPI`` / ``APIRouter``.
+_FASTAPI_HTTP_METHODS = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+)
+# ``@app.route("/x")`` (Starlette/Flask-style) carries no single verb; record it
+# under the generic ROUTE method so it is still queryable.
+_FASTAPI_GENERIC = "route"
+
+
+def extract_fastapi_routes(
+    file_path: Path,
+    module: str,
+    project_root: Path,
+) -> list[RouteEdge]:
+    """Extract FastAPI decorator route -> handler edges from a Python file.
+
+    Returns one ``RouteEdge`` per ``@<router>.<verb>("path")`` decorator on a
+    module-level or method function. A decorator whose first argument is not a
+    string literal (dynamic path) is skipped, not guessed.
+    """
+    try:
+        source = file_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(file_path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+    try:
+        rel_path = str(file_path.relative_to(project_root))
+    except ValueError:
+        rel_path = str(file_path)
+
+    routes: list[RouteEdge] = []
+    _scan_body(tree.body, module=module, outer=[], rel_path=rel_path, routes=routes)
+    return routes
+
+
+def _scan_body(
+    body: list[ast.stmt],
+    *,
+    module: str,
+    outer: list[str],
+    rel_path: str,
+    routes: list[RouteEdge],
+) -> None:
+    for node in body:
+        if isinstance(node, ast.ClassDef):
+            _scan_body(
+                node.body,
+                module=module,
+                outer=[*outer, node.name],
+                rel_path=rel_path,
+                routes=routes,
+            )
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            handler = ".".join([module, *outer, node.name])
+            for dec in node.decorator_list:
+                edge = _route_edge_from_decorator(dec, handler, rel_path)
+                if edge is not None:
+                    routes.append(edge)
+
+
+def _route_edge_from_decorator(
+    dec: ast.expr,
+    handler: str,
+    rel_path: str,
+) -> RouteEdge | None:
+    """Turn a ``@router.get("/x")`` decorator into a RouteEdge, or ``None``.
+
+    Only ``Call`` decorators of the shape ``<attr>.<verb>(<str>, ...)`` where
+    ``<verb>`` is a known FastAPI HTTP method (or the generic ``route``) produce
+    an edge. The path must be a string literal — a non-literal first argument is
+    a dynamic route we refuse to guess.
+    """
+    if not isinstance(dec, ast.Call):
+        return None
+    func = dec.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    verb = func.attr.lower()
+    if verb not in _FASTAPI_HTTP_METHODS and verb != _FASTAPI_GENERIC:
+        return None
+    path = _first_string_arg(dec)
+    if path is None:
+        return None
+    method = "ROUTE" if verb == _FASTAPI_GENERIC else verb.upper()
+    return RouteEdge(
+        method=method,
+        path=path,
+        handler_symbol=handler,
+        framework="fastapi",
+        file_path=rel_path,
+        line=dec.lineno,
+    )
+
+
+def _first_string_arg(call: ast.Call) -> str | None:
+    """The first positional string-literal argument of *call*, or ``None``."""
+    for arg in call.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+        # First positional arg is not a string literal -> dynamic path.
+        return None
+    return None
+
+
+# ----------------------------------------------------------------------
+# React Router (TypeScript / JSX)
+# ----------------------------------------------------------------------
+
+
+def extract_react_router_routes(
+    file_path: Path,
+    module: str,
+    project_root: Path,
+) -> list[RouteEdge]:
+    """Extract React Router ``<Route path=... element={<Comp/>} />`` edges.
+
+    Covers only the JSX ``<Route>`` element form. The ``createBrowserRouter([...])``
+    object-literal form is deferred (v1) — nothing is emitted for it rather than
+    guessing. A ``<Route>`` missing a literal ``path`` or a nameable ``element``
+    component is skipped.
+
+    The component's handler symbol is qualified to ``<target_module>.<Comp>`` when
+    the component is imported from an in-repo relative module; otherwise the bare
+    component name is used (never a fabricated cross-module target).
+    """
+    if not HAS_TREE_SITTER or _TSX_LANGUAGE is None:
+        return []
+    if file_path.suffix.lower() != ".tsx":
+        # React Router JSX only appears in ``.tsx`` files.
+        return []
+    try:
+        source = file_path.read_bytes()
+        source.decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        rel_path = str(file_path.relative_to(project_root))
+    except ValueError:
+        rel_path = str(file_path)
+
+    try:
+        parser = tree_sitter.Parser(_TSX_LANGUAGE)
+        tree = parser.parse(source)
+    except Exception:  # pragma: no cover - defensive
+        return []
+    root = tree.root_node
+    if root.has_error:
+        return []
+
+    component_modules = _react_component_import_modules(root, source, module)
+    routes: list[RouteEdge] = []
+    _walk_jsx_routes(root, source, rel_path, component_modules, routes)
+    return routes
+
+
+def _react_component_import_modules(root: Any, source: bytes, module: str) -> dict[str, str]:
+    """Map an imported component's local name -> resolved in-repo module.
+
+    Handles both ``import Comp from "./Comp"`` (default) and
+    ``import { Comp } from "./Comp"`` (named), but only for relative specifiers
+    that resolve inside the repo. Non-relative / path-alias imports are omitted so
+    the caller falls back to the bare component name.
+    """
+    out: dict[str, str] = {}
+    for node in _iter_statements(root):
+        if node.type != "import_statement":
+            continue
+        specifier = _import_specifier(node, source)
+        if specifier is None or not specifier.startswith("."):
+            continue
+        target = _resolve_relative_module(module, specifier)
+        if target is None:
+            continue
+        clause = None
+        for child in node.children:
+            if child.type == "import_clause":
+                clause = child
+                break
+        if clause is None:
+            continue
+        for child in clause.children:
+            if child.type == "identifier":
+                # Default import: `import Comp from "./Comp"`.
+                out[_node_text(child, source)] = target
+            elif child.type == "named_imports":
+                for local, _real in _named_import_pairs(child, source):
+                    out[local] = target
+    return out
+
+
+def _walk_jsx_routes(
+    node: Any,
+    source: bytes,
+    rel_path: str,
+    component_modules: dict[str, str],
+    routes: list[RouteEdge],
+) -> None:
+    """Depth-first walk collecting ``<Route>`` JSX elements."""
+    if node.type in ("jsx_self_closing_element", "jsx_opening_element"):
+        name = _jsx_element_name(node, source)
+        if name == "Route":
+            edge = _route_edge_from_jsx(node, source, rel_path, component_modules)
+            if edge is not None:
+                routes.append(edge)
+    for child in node.children:
+        _walk_jsx_routes(child, source, rel_path, component_modules, routes)
+
+
+def _jsx_element_name(element: Any, source: bytes) -> str | None:
+    """The tag name of a jsx opening/self-closing element (first ``identifier``)."""
+    for child in element.children:
+        if child.type == "identifier":
+            return _node_text(child, source)
+    return None
+
+
+def _route_edge_from_jsx(
+    element: Any,
+    source: bytes,
+    rel_path: str,
+    component_modules: dict[str, str],
+) -> RouteEdge | None:
+    path: str | None = None
+    component: str | None = None
+    for child in element.children:
+        if child.type != "jsx_attribute":
+            continue
+        attr_name = _jsx_attr_name(child, source)
+        if attr_name == "path":
+            path = _jsx_attr_string(child, source)
+        elif attr_name == "element":
+            component = _jsx_element_component(child, source)
+    if path is None or component is None:
+        return None
+    handler = component
+    target = component_modules.get(component)
+    if target is not None:
+        handler = f"{target}.{component}"
+    line = int(element.start_point[0]) + 1
+    return RouteEdge(
+        method="ROUTE",
+        path=path,
+        handler_symbol=handler,
+        framework="react-router",
+        file_path=rel_path,
+        line=line,
+    )
+
+
+def _jsx_attr_name(attr: Any, source: bytes) -> str | None:
+    for child in attr.children:
+        if child.type == "property_identifier":
+            return _node_text(child, source)
+    return None
+
+
+def _jsx_attr_string(attr: Any, source: bytes) -> str | None:
+    """The string-literal value of a JSX attribute (``path="/x"``), or ``None``."""
+    for child in attr.children:
+        if child.type == "string":
+            for frag in child.children:
+                if frag.type == "string_fragment":
+                    return _node_text(frag, source)
+            # Empty string literal (``path=""``).
+            return ""
+    return None
+
+
+def _jsx_element_component(attr: Any, source: bytes) -> str | None:
+    """Component name inside ``element={<Comp/>}``, or ``None`` if not nameable.
+
+    A spread or expression that is not a plain JSX element (``element={route.el}``)
+    yields no component -> the route is skipped rather than guessed.
+    """
+    for child in attr.children:
+        if child.type != "jsx_expression":
+            continue
+        for inner in child.children:
+            if inner.type in ("jsx_self_closing_element", "jsx_element"):
+                target = inner
+                if inner.type == "jsx_element":
+                    # <Comp>...</Comp> -> use the opening element's name.
+                    for sub in inner.children:
+                        if sub.type == "jsx_opening_element":
+                            target = sub
+                            break
+                return _jsx_element_name(target, source)
+    return None
+
+
+# ----------------------------------------------------------------------
+# Query helpers (TAP-4532 AC2)
+# ----------------------------------------------------------------------
+
+
+def handlers_for_path(routes: list[RouteEdge], path: str) -> list[RouteEdge]:
+    """Route edges whose path matches *path* exactly (deterministic, no globbing)."""
+    return [r for r in routes if r.path == path]
+
+
+def routes_for_handler(routes: list[RouteEdge], handler: str) -> list[RouteEdge]:
+    """Route edges whose handler is *handler* (exact or short-name suffix match).
+
+    Blast radius: which routes break if this handler symbol changes. A short name
+    (``list_users``) matches any qualified handler ending in ``.list_users``; an
+    exact qualified name matches only itself.
+    """
+    trimmed = handler.strip()
+    if not trimmed:
+        return []
+    exact = [r for r in routes if r.handler_symbol == trimmed]
+    if exact:
+        return exact
+    return [
+        r for r in routes if r.handler_symbol == trimmed or r.handler_symbol.endswith(f".{trimmed}")
+    ]

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_types.py
@@ -8,7 +8,9 @@ from typing import Literal
 CALL_GRAPH_CACHE_REL = ".tapps-mcp/call-graph-index.json"
 # v3 (TAP-4537): SymbolRecord gains a ``language`` tag for the TypeScript
 # language-dispatch scaffold. Bumping this invalidates any v2 cache on load.
-INDEX_VERSION = 3
+# v4 (TAP-4532): CallGraphIndex gains a persisted ``routes: list[RouteEdge]``
+# for HTTP route -> handler edges (FastAPI decorators + React Router JSX).
+INDEX_VERSION = 4
 SymbolKind = Literal["function", "method"]
 
 # Stable taxonomy for resolution gaps (TAP-4092).
@@ -70,6 +72,26 @@ class ParseFailure:
     reason: PARSE_FAILURE_REASON | str
 
 
+# HTTP route -> handler relationships as first-class edges (TAP-4532).
+# ``framework`` names the router this edge came from ("fastapi" for Python
+# decorator routes, "react-router" for React Router JSX). ``method`` is the
+# uppercased HTTP verb for FastAPI (``GET``/``POST``/...) or the literal
+# ``"ROUTE"`` for React Router (client-side routes have no HTTP method).
+# ``handler_symbol`` is the qualified name of the handler function / component
+# symbol when resolvable, else the bare local name (never a fabricated target).
+RouteFramework = Literal["fastapi", "react-router"]
+
+
+@dataclass
+class RouteEdge:
+    method: str
+    path: str
+    handler_symbol: str
+    framework: RouteFramework | str
+    file_path: str
+    line: int
+
+
 # --- TypeScript deferred cross-file resolution (TAP-4540) -----------------
 # The following records are internal to the build-time cross-file resolution
 # pass in ``call_graph.py``. They are NOT persisted in the on-disk index — they
@@ -122,6 +144,8 @@ class CallGraphIndex:
     edges: list[CallEdge] = field(default_factory=list)
     resolution_gaps: list[ResolutionGap] = field(default_factory=list)
     parse_failures: list[ParseFailure] = field(default_factory=list)
+    # HTTP route -> handler edges (TAP-4532). Persisted in the v4 index.
+    routes: list[RouteEdge] = field(default_factory=list)
     project_root: str = ""
     fingerprint: str = ""
     version: int = INDEX_VERSION

--- a/packages/tapps-mcp/src/tapps_mcp/server_analysis_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_analysis_tools.py
@@ -466,14 +466,23 @@ async def tapps_call_graph(
     token_budget: int = 4000,
     force_rebuild: bool = False,
 ) -> dict[str, Any]:
-    """Query function-level callers, callees, or call chains for one symbol.
+    """Query function-level callers, callees, call chains, or HTTP routes.
 
-    Deterministic Python AST call graph (ADR-0017). Use before refactoring a
-    function to replace grep-based caller discovery.
+    Deterministic Python/TypeScript call graph (ADR-0017). Use before refactoring
+    a function to replace grep-based caller discovery.
+
+    Route queries (TAP-4532) resolve HTTP route <-> handler edges (FastAPI
+    decorators, React Router JSX):
+      * ``query="route_handler"`` — pass ``symbol`` as a route path (e.g.
+        ``/users/{id}``); returns the handler(s) serving it.
+      * ``query="handler_routes"`` — pass ``symbol`` as a handler function /
+        component name; returns the routes that break if it changes (blast radius).
 
     Args:
-        symbol: Qualified or short function/method name.
-        query: ``callers``, ``callees``, ``chain``, or ``all`` (default).
+        symbol: Qualified or short function/method name; a route path for
+            ``route_handler``; a handler symbol for ``handler_routes``.
+        query: ``callers``, ``callees``, ``chain``, ``all`` (default),
+            ``route_handler``, or ``handler_routes``.
         project_root: Optional project root override.
         max_depth: Max expansion depth for graph traversal.
         token_budget: Approximate token cap for serialized graph payload.
@@ -493,24 +502,33 @@ async def tapps_call_graph(
     root = root_result.root
 
     mode = query.strip().lower() or "all"
-    if mode not in {"callers", "callees", "chain", "all"}:
+    if mode not in {"callers", "callees", "chain", "all", "route_handler", "handler_routes"}:
         return error_response(
             "tapps_call_graph",
             "invalid_query",
-            "query must be callers, callees, chain, or all",
+            "query must be callers, callees, chain, all, route_handler, or handler_routes",
         )
 
     from tapps_mcp.project.call_graph import build_call_graph_index
-    from tapps_mcp.project.call_graph_queries import query_call_graph
+    from tapps_mcp.project.call_graph_queries import (
+        query_call_graph,
+        query_route_handler,
+        query_routes_for_handler,
+    )
 
     index = build_call_graph_index(root, force_rebuild=force_rebuild)
-    result = query_call_graph(
-        index,
-        symbol,
-        mode=mode,  # type: ignore[arg-type]
-        max_depth=max(1, max_depth),
-        token_budget=max(256, token_budget),
-    )
+    if mode == "route_handler":
+        result = query_route_handler(index, symbol)
+    elif mode == "handler_routes":
+        result = query_routes_for_handler(index, symbol)
+    else:
+        result = query_call_graph(
+            index,
+            symbol,
+            mode=mode,  # type: ignore[arg-type]
+            max_depth=max(1, max_depth),
+            token_budget=max(256, token_budget),
+        )
 
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution(

--- a/packages/tapps-mcp/tests/unit/test_call_graph_routes.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_routes.py
@@ -1,0 +1,319 @@
+"""Tests for HTTP route -> handler edges (TAP-4532).
+
+Covers FastAPI decorator routes (Python ``ast``), React Router JSX routes
+(TypeScript tree-sitter), the two query directions (handler-for-path,
+routes-for-handler / blast radius), and the deterministic contract: dynamic /
+unresolvable route registration is omitted, never guessed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tapps_mcp.project.call_graph import build_call_graph_index
+from tapps_mcp.project.call_graph_analyze_ts import HAS_TREE_SITTER
+from tapps_mcp.project.call_graph_queries import (
+    query_route_handler,
+    query_routes_for_handler,
+)
+from tapps_mcp.project.call_graph_routes import (
+    handlers_for_path,
+    routes_for_handler,
+)
+
+
+def _write(root: Path, rel: str, source: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+class TestFastAPIRoutes:
+    def test_decorator_routes_produce_edges(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/api.py",
+            """
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+router = APIRouter()
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@router.post("/users/{user_id}")
+async def create_user(user_id: int):
+    return user_id
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        by_handler = {r.handler_symbol: r for r in index.routes}
+
+        assert "app.api.health" in by_handler
+        health = by_handler["app.api.health"]
+        assert health.method == "GET"
+        assert health.path == "/health"
+        assert health.framework == "fastapi"
+        assert health.file_path == "app/api.py"
+        assert health.line == 8
+
+        create = by_handler["app.api.create_user"]
+        assert create.method == "POST"
+        assert create.path == "/users/{user_id}"
+
+    def test_generic_route_decorator_recorded(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/legacy.py",
+            """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.route("/legacy")
+def legacy():
+    return "x"
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        routes = [r for r in index.routes if r.handler_symbol == "app.legacy.legacy"]
+        assert len(routes) == 1
+        assert routes[0].method == "ROUTE"
+        assert routes[0].path == "/legacy"
+
+    def test_dynamic_path_is_omitted_not_guessed(self, tmp_path: Path) -> None:
+        # Non-literal decorator path -> no RouteEdge (deterministic contract).
+        _write(
+            tmp_path,
+            "app/dynamic.py",
+            """
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+def register(path):
+    @app.get(path)
+    def handler():
+        return 1
+
+    return handler
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        assert index.routes == []
+
+    def test_non_route_decorator_ignored(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/deco.py",
+            """
+import functools
+
+
+@functools.cache
+def cached():
+    return 1
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        assert index.routes == []
+
+
+@pytest.mark.skipif(not HAS_TREE_SITTER, reason="tree-sitter TypeScript grammar not installed")
+class TestReactRouterRoutes:
+    def test_jsx_route_elements_produce_edges(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "src/App.tsx",
+            """
+import { Routes, Route } from "react-router-dom";
+import Home from "./Home";
+import { About } from "./pages/About";
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/about" element={<About />} />
+    </Routes>
+  );
+}
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        routes = [r for r in index.routes if r.framework == "react-router"]
+        by_path = {r.path: r for r in routes}
+
+        assert "/" in by_path
+        assert by_path["/"].method == "ROUTE"
+        # Default import from ./Home resolves the component to its module.
+        assert by_path["/"].handler_symbol == "Home.Home"
+        assert by_path["/"].file_path == "src/App.tsx"
+
+        assert "/about" in by_path
+        # Named relative import -> qualified to the target module.
+        assert by_path["/about"].handler_symbol == "pages/About.About"
+
+    def test_unimported_component_keeps_bare_name(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "src/Routes.tsx",
+            """
+import { Route } from "react-router-dom";
+
+function AppRoutes() {
+  return <Route path="/x" element={<LocalOnly />} />;
+}
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        routes = [r for r in index.routes if r.framework == "react-router"]
+        assert len(routes) == 1
+        # No in-repo import -> bare component name, never a fabricated module.
+        assert routes[0].handler_symbol == "LocalOnly"
+        assert routes[0].path == "/x"
+
+    def test_spread_element_is_omitted_not_guessed(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "src/Spread.tsx",
+            """
+import { Route } from "react-router-dom";
+
+function AppRoutes(routeDef: any) {
+  return <Route path="/dyn" element={routeDef.el} />;
+}
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        # element is not a nameable JSX component -> no RouteEdge.
+        assert [r for r in index.routes if r.framework == "react-router"] == []
+
+    def test_object_literal_router_form_deferred(self, tmp_path: Path) -> None:
+        # createBrowserRouter object form is deferred for v1 — nothing emitted,
+        # never guessed. (Documented deferral in call_graph_routes.py.)
+        _write(
+            tmp_path,
+            "src/router.tsx",
+            """
+import { createBrowserRouter } from "react-router-dom";
+import Home from "./Home";
+
+const router = createBrowserRouter([
+  { path: "/", element: <Home /> },
+]);
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        assert [r for r in index.routes if r.framework == "react-router"] == []
+
+
+class TestRouteQueries:
+    def test_handler_for_path(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/api.py",
+            """
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int):
+    return item_id
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        result = query_route_handler(index, "/items/{item_id}")
+        assert result["found"] is True
+        assert result["handlers"][0]["handler_symbol"] == "app.api.read_item"
+
+        miss = query_route_handler(index, "/nope")
+        assert miss["found"] is False
+        assert miss["handlers"] == []
+
+    def test_routes_for_handler_blast_radius(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/api.py",
+            """
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/a")
+@app.post("/a")
+def shared():
+    return 1
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        result = query_routes_for_handler(index, "shared")
+        assert result["found"] is True
+        methods = sorted(r["method"] for r in result["routes"])
+        assert methods == ["GET", "POST"]
+
+        # Exact qualified name also matches.
+        exact = query_routes_for_handler(index, "app.api.shared")
+        assert exact["found"] is True
+        assert len(exact["routes"]) == 2
+
+    def test_query_helpers_direct(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/api.py",
+            """
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping():
+    return "pong"
+""",
+        )
+        index = build_call_graph_index(tmp_path, force_rebuild=True)
+        assert len(handlers_for_path(index.routes, "/ping")) == 1
+        assert len(routes_for_handler(index.routes, "ping")) == 1
+        assert routes_for_handler(index.routes, "") == []
+
+
+class TestRoutesPersisted:
+    def test_routes_survive_cache_round_trip(self, tmp_path: Path) -> None:
+        from tapps_mcp.project.call_graph import load_call_graph_index
+
+        _write(
+            tmp_path,
+            "app/api.py",
+            """
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.delete("/thing/{id}")
+def drop(id: int):
+    return id
+""",
+        )
+        built = build_call_graph_index(tmp_path, force_rebuild=True)
+        assert built.routes
+
+        loaded = load_call_graph_index(tmp_path)
+        assert loaded is not None
+        assert len(loaded.routes) == 1
+        assert loaded.routes[0].method == "DELETE"
+        assert loaded.routes[0].path == "/thing/{id}"
+        assert loaded.routes[0].handler_symbol == "app.api.drop"


### PR DESCRIPTION
Closes TAP-4532 (Tier 2 / TAP-4530).

## What
First-class ROUTE edges linking HTTP path → handler/component symbol.
- **FastAPI** (`ast`): `@app|router.get/post/...` + generic `@router.route` → `{method, path, handler_symbol}`.
- **React Router** (tree-sitter): `<Route path=... element={<Comp/>} />` → component symbol (resolves via the TS import table from TAP-4531).
- **Queries**: `tapps_call_graph` gains `query="route_handler"` (handler for a path) and `query="handler_routes"` (routes affected by changing a handler).
- New `RouteEdge` + `routes` on `CallGraphIndex`; `INDEX_VERSION` 3→4 (persisted, cache self-invalidates).

## Live proof
FastAPI `GET /health→health`, `POST /users/{user_id}→create_user`; React Router `/→Home` (default import), `/about→About` (named). Dynamic `@app.get(path)` and `element={route.el}` → no edge (ADR-0004, never guessed).

## Tests
265 passed; Python + TS paths green; ruff/mypy clean on changed files.

Deferred (explicit, tested): React Router `createBrowserRouter([{path, element}])` object-literal form emits nothing rather than guessing — follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)