### PR TITLE
feat(call_graph): attribute TS callback-body calls to the enclosing named symbol (TAP-4552)

### DIFF
--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_analyze_ts.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_analyze_ts.py
@@ -276,6 +276,15 @@ class _TsFileAnalyzer:
         self._local_functions: dict[str, str] = {}
         # "ClassName.method" -> qualified name.
         self._class_methods: dict[str, str] = {}
+        # tree-sitter node ids of the callable bodies that ARE registered
+        # symbols (top-level function decls, top-level arrow-const values, class
+        # methods). Phase 2 re-walks each of these as its own caller, so
+        # ``_walk_calls`` must STOP at them. Any *other* nested callable body —
+        # an anonymous arrow/function-expression closure (e.g. the callback in
+        # ``items.forEach(x => helper())``) — is NOT in this set, so the walk
+        # descends through it and attributes its calls to the nearest enclosing
+        # named symbol (TAP-4552), never dropping or mis-attributing them.
+        self._symbol_bodies: set[int] = set()
         # Cross-module import bindings (TAP-4539). Each maps a local binding name
         # to a resolution decision:
         #  - _named_bindings: local -> qualified callee ("<module>.<realName>"),
@@ -392,11 +401,13 @@ class _TsFileAnalyzer:
             if name:
                 qname = self._qualify(name)
                 self._local_functions[name] = qname
+                self._symbol_bodies.add(id(node))
                 self.symbols.append(self._symbol(qname, node, "function"))
         elif node.type == "lexical_declaration":
             for name, arrow in _arrow_declarators(node, self.source):
                 qname = self._qualify(name)
                 self._local_functions[name] = qname
+                self._symbol_bodies.add(id(arrow))
                 self.symbols.append(self._symbol(qname, arrow, "function"))
         elif node.type == "class_declaration":
             self._register_class(node)
@@ -419,6 +430,7 @@ class _TsFileAnalyzer:
                 continue
             qname = self._qualify_method(class_name, method_name)
             self._class_methods[f"{class_name}.{method_name}"] = qname
+            self._symbol_bodies.add(id(member))
             self.symbols.append(self._symbol(qname, member, "method"))
 
     # ------------------------------------------------------------------
@@ -553,24 +565,41 @@ class _TsFileAnalyzer:
             self._record_call(call, caller=caller, class_name=class_name)
 
     def _walk_calls(self, node: Any, *, skip_root: bool) -> list[Any]:
-        """Collect ``call_expression`` nodes owned by ``node``'s body.
+        """Collect ``call_expression`` nodes attributed to ``node``'s symbol.
 
         Descends through non-callable containers — crucially including
         ``variable_declarator`` — so a call in ``const x = f()`` is attributed
-        to the enclosing symbol (AC3). It does NOT descend into a nested
-        callable body (arrow / function / method): those are either their own
-        registered symbol (re-walked in phase 2) or an anonymous inline closure,
-        whose calls are deliberately dropped here rather than mis-attributed to
-        the enclosing caller (deterministic contract — never guess a caller).
+        to the enclosing symbol (AC3).
+
+        Nested callable bodies split two ways (TAP-4552):
+
+        * A callable that IS a registered symbol (a top-level function decl,
+          top-level arrow-const, or class method — tracked in
+          ``self._symbol_bodies``) is its own scope and is re-walked in phase 2
+          as its own caller, so the walk STOPS at it here to avoid
+          double-attribution.
+        * An ANONYMOUS closure (arrow / function-expression not registered as a
+          symbol — e.g. ``x => helper()`` in ``items.forEach(x => helper())``)
+          has no symbol of its own. The walk DESCENDS through it so its calls
+          attribute to the nearest enclosing NAMED symbol. Previously these
+          calls were dropped; now they are attributed correctly. Resolution of
+          the recovered call is identical to a direct call (``_resolve``), so an
+          unresolved callee still becomes an honest gap — never a guess.
         """
         out: list[Any] = []
         for child in node.children:
             if not skip_root and child.type == "call_expression":
                 out.append(child)
-            if child.type in (_ARROW_TYPE, _FUNCTION_DECL_TYPE, "function_expression"):
-                continue
-            if child.type == _METHOD_TYPE:
-                continue
+            if child.type in (
+                _ARROW_TYPE,
+                _FUNCTION_DECL_TYPE,
+                "function_expression",
+                _METHOD_TYPE,
+            ):
+                # Stop only at a registered symbol body (its own scope); descend
+                # through an anonymous closure to attribute its calls upward.
+                if id(child) in self._symbol_bodies:
+                    continue
             out.extend(self._walk_calls(child, skip_root=False))
         return out
 

--- a/packages/tapps-mcp/tests/unit/test_call_graph_analyze_ts.py
+++ b/packages/tapps-mcp/tests/unit/test_call_graph_analyze_ts.py
@@ -374,3 +374,158 @@ function run() { Component(); }
         _edges, gaps = self._gaps(tmp_path, "consumer", src)
         gap = next(g for g in gaps if g.expr == "Component")
         assert gap.reason == "import_unresolved"
+
+
+class TestCallbackAttribution:
+    """TAP-4552: calls inside anonymous callbacks attribute to the enclosing
+    NAMED symbol instead of being dropped.
+
+    Resolution of the recovered call is identical to a direct call: an
+    in-module callee produces a resolved edge; an unimported/unknown callee
+    produces an honest ``import_unresolved`` gap (ADR-0004 — never guessed).
+    """
+
+    def _run(self, tmp_path: Path, module: str, src: str, name: str = "mod.ts"):
+        f = _write(tmp_path, name, src)
+        _s, edges, gaps, failures = analyze_file_ts(f, module, tmp_path)
+        assert failures == []
+        return edges, gaps
+
+    def test_foreach_callback_resolved_callee(self, tmp_path: Path) -> None:
+        # AC1: `function render() { items.forEach(x => helper()); }`
+        # -> edge render -> helper (resolved in-module), NOT dropped.
+        src = """\
+function helper() {}
+function render() {
+  items.forEach(x => helper());
+}
+"""
+        edges, _gaps = self._run(tmp_path, "mod", src)
+        helper_edges = [e for e in edges if e.callee_expr == "helper"]
+        assert len(helper_edges) == 1
+        assert helper_edges[0].caller == "mod.render"
+        assert helper_edges[0].callee == "mod.helper"
+        assert helper_edges[0].resolved is True
+
+    def test_foreach_callback_unresolved_callee_is_honest_gap(
+        self, tmp_path: Path
+    ) -> None:
+        # AC2: an unknown callee inside the callback stays an honest gap.
+        src = """\
+function render() {
+  items.forEach(x => mysteryGlobal());
+}
+"""
+        edges, gaps = self._run(tmp_path, "mod", src)
+        assert not any(e.callee_expr == "mysteryGlobal" for e in edges)
+        gap = next(g for g in gaps if g.expr == "mysteryGlobal")
+        assert gap.caller == "mod.render"
+        assert gap.reason == "import_unresolved"
+
+    def test_map_callback_resolved_and_unresolved(self, tmp_path: Path) -> None:
+        # `.map` callback, resolved + unresolved callees together.
+        src = """\
+function transform(x) {}
+function build(rows) {
+  return rows.map(r => transform(unknownFn()));
+}
+"""
+        edges, gaps = self._run(tmp_path, "mod", src)
+        transform_edges = [e for e in edges if e.callee_expr == "transform"]
+        assert len(transform_edges) == 1
+        assert transform_edges[0].caller == "mod.build"
+        assert transform_edges[0].callee == "mod.transform"
+        gap = next(g for g in gaps if g.expr == "unknownFn")
+        assert gap.caller == "mod.build"
+        assert gap.reason == "import_unresolved"
+
+    def test_then_callback_resolved_and_unresolved(self, tmp_path: Path) -> None:
+        # A `.then` promise callback (function_expression form) — resolved and
+        # unresolved callees both attribute to the enclosing named function.
+        src = """\
+function onResult(v) {}
+function load(p) {
+  p.then(function (v) { onResult(missingCb()); });
+}
+"""
+        edges, gaps = self._run(tmp_path, "mod", src)
+        res_edges = [e for e in edges if e.callee_expr == "onResult"]
+        assert len(res_edges) == 1
+        assert res_edges[0].caller == "mod.load"
+        assert res_edges[0].callee == "mod.onResult"
+        gap = next(g for g in gaps if g.expr == "missingCb")
+        assert gap.caller == "mod.load"
+        assert gap.reason == "import_unresolved"
+
+    def test_callback_inside_method_attributes_to_method(self, tmp_path: Path) -> None:
+        # Inside a class method, a callback's `this.method()` resolves intra-class
+        # and its calls attribute to the enclosing method (not dropped).
+        src = """\
+class C {
+  helper() {}
+  run(items) {
+    items.forEach(x => this.helper());
+  }
+}
+"""
+        edges, _gaps = self._run(tmp_path, "c", src)
+        helper_edges = [e for e in edges if e.callee_expr == "this.helper"]
+        assert len(helper_edges) == 1
+        assert helper_edges[0].caller == "c.C.run"
+        assert helper_edges[0].callee == "c.C.helper"
+
+    def test_nested_anonymous_callbacks_attribute_to_outermost_named(
+        self, tmp_path: Path
+    ) -> None:
+        # `a.forEach(() => b.map(() => helper()))` -> attribute to the enclosing
+        # NAMED symbol, through two anonymous closures.
+        src = """\
+function helper() {}
+function render(a, b) {
+  a.forEach(() => b.map(() => helper()));
+}
+"""
+        edges, _gaps = self._run(tmp_path, "mod", src)
+        helper_edges = [e for e in edges if e.callee_expr == "helper"]
+        assert len(helper_edges) == 1
+        assert helper_edges[0].caller == "mod.render"
+        assert helper_edges[0].callee == "mod.helper"
+
+    def test_imported_callee_in_callback_resolves_cross_module(
+        self, tmp_path: Path
+    ) -> None:
+        # AC2: recovered call uses the same import resolution as a direct call.
+        src = """\
+import { greet } from "./util";
+function render(items) {
+  items.forEach(x => greet());
+}
+"""
+        edges, _gaps = self._run(tmp_path, "consumer", src)
+        edge = next(e for e in edges if e.callee_expr == "greet")
+        assert edge.caller == "consumer.render"
+        assert edge.callee == "util.greet"
+        assert edge.resolved is True
+
+    def test_module_top_level_callback_not_fabricated(self, tmp_path: Path) -> None:
+        # AC3: a callback at module top level (no enclosing named symbol) is
+        # handled sanely — dropped, never a fabricated caller, no crash.
+        src = """\
+function helper() {}
+items.forEach(x => helper());
+"""
+        edges, gaps = self._run(tmp_path, "mod", src)
+        assert not any(e.callee_expr == "helper" for e in edges)
+        assert not any(g.expr == "helper" for g in gaps)
+
+    def test_top_level_named_arrow_const_still_own_scope(self, tmp_path: Path) -> None:
+        # Regression guard: a TOP-LEVEL named arrow-const remains its own caller
+        # scope (must NOT be swallowed by the callback-attribution change).
+        src = """\
+function target() {}
+const runner = () => { target(); };
+"""
+        edges, _gaps = self._run(tmp_path, "mod", src)
+        edge = next(e for e in edges if e.callee_expr == "target")
+        assert edge.caller == "mod.runner"
+        assert edge.callee == "mod.target"


### PR DESCRIPTION
Closes TAP-4552 (follow-up to TAP-4538). Recovers previously-dropped callback-body calls.

## What
`_walk_calls` now descends through anonymous closures and attributes their calls to the nearest enclosing NAMED symbol, instead of dropping them. Implemented via a `_symbol_bodies` set (ids of registered callable bodies); the walk stops only at a registered symbol's own body, so `items.forEach(x => helper())` inside `render()` yields `render → helper`. Recovered calls resolve through the unchanged `_resolve` — unresolved stays an honest gap (ADR-0004), never guessed.

- Nested closures → outermost enclosing named symbol; callbacks in methods keep `this` context; named arrow-const stays its own scope; module-top-level callbacks still dropped (no crash).

## Live proof
`render→helper` (forEach), `render→util.greet` (cross-module map callback); unresolved callee in a callback → honest `import_unresolved` gap.

## Tests
179 passed (9 new `TestCallbackAttribution`: forEach/map/.then × resolved/unresolved, nested, intra-class, cross-module, top-level drop, named-arrow regression guard). No regressions — incremental byte-equivalence + cross-module tests green. Gate 100.

Note: `.then`/setTimeout/event-handler callbacks treated same as synchronous (lexical attribution — the caller registers the callback); correct for a static graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)