### PR TITLE
ADR-0029 unified cache substrate + P1 pilot (TAP-4556, TAP-4560)

### DIFF
--- a/docs/CALL_GRAPH.md
+++ b/docs/CALL_GRAPH.md
@@ -163,8 +163,9 @@ Format: `code_symbol<TAB>test_file<TAB>test_symbol` — useful for CI scripts an
 
 - General graph-query language (Cypher/openCypher) — the graph is served by fixed, purpose-built tools only ([ADR-0028](adr/0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md))
 - Adopting an external code-graph store (e.g. codebase-memory-mcp) as the graph or memory source — permitted only as a fenced, opt-in *comprehension* tool ([ADR-0028](adr/0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md))
+- Vector/RAG retrieval over the repo, or modeling the code graph as a docs-cache (`KBCache`) provider — the graph's on-disk cache shares only the atomic primitive + metrics surface with the docs cache, never its staleness model or a vector retrieval path ([ADR-0029](adr/0029-unified-cache-substrate.md))
 
-See [ADR-0017](adr/0017-function-level-call-graph-python-first.md) for scope and alternatives, and [ADR-0028](adr/0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md) for the external-tool / query-language boundary.
+See [ADR-0017](adr/0017-function-level-call-graph-python-first.md) for scope and alternatives, [ADR-0028](adr/0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md) for the external-tool / query-language boundary, and [ADR-0029](adr/0029-unified-cache-substrate.md) for the unified cache-substrate boundary (shared atomic primitive vs domain-specific staleness/provider/retrieval).
 
 ---
 

--- a/docs/adr/0029-unified-cache-substrate.md
+++ b/docs/adr/0029-unified-cache-substrate.md
@@ -1,0 +1,271 @@
+# 29. Unified cache substrate — one atomic primitive, pluggable staleness, no code-as-provider and no vector-RAG
+
+Date: 2026-07-01
+
+## Status
+
+Accepted (2026-07-01; TAP-4556)
+
+Ratifies [DESIGN-unified-cache-substrate-and-context-layer](../design/DESIGN-unified-cache-substrate-and-context-layer.md).
+
+## Context
+
+tapps-mcp caches two unrelated kinds of "knowledge" the same shape — *on-demand
+tool + on-disk cache + graceful degradation* — but has grown **five parallel
+file-cache implementations**, each re-writing atomic-write, staleness, and
+(sometimes) warming/metrics:
+
+| # | Cache | File | Staleness model | Provider |
+|---|---|---|---|---|
+| 1 | Docs (`KBCache`) | `tapps_core/knowledge/cache.py` | TTL / clock (24h + per-lib) | Context7 (network) + breaker |
+| 2 | Code graph | `tapps_mcp/project/call_graph_cache.py` | content fingerprint (per-file sha) + `INDEX_VERSION` | local tree-sitter/ast build |
+| 3 | Per-file tool results | `tapps_mcp/tools/content_hash_cache.py` | SHA-256 content hash | local (scoring/gate/security) |
+| 4 | Dependency scan | `tapps_mcp/tools/dependency_scan_cache.py` | session / TTL | local (pip-audit) |
+| 5 | Linear snapshots | `server_linear_tools.py` + `tools/linear_list_gateway.py` + `docs-mcp/.../linear_gateway.py` | TTL (`cached_at`/`expires_at`) | agent-fetched |
+
+The two anchor caches make the split concrete. `KBCache` is a
+**TTL / network-provider** cache: 24h clock with per-library overrides, a
+Context7 fetch behind a circuit breaker, a `filelock`-guarded markdown+sidecar
+layout, and the only `CacheStats` in the set. `call_graph_cache` is a
+**fingerprint / local-build** cache: per-file sha plus `INDEX_VERSION`, a
+deterministic local tree-sitter/ast build, a `mkstemp`+`replace` atomic write,
+and no metrics. Their `_write_atomic` bodies are *different mechanisms*; their
+staleness models (a clock vs a content hash) are *irreconcilable by nature*.
+
+This is the load-bearing decision for the consolidation epic (TAP-4555): the
+substrate boundary must be ratified **before** any code moves, because the two
+tempting wrong turns are both cheap to start and expensive to unwind:
+
+- **"Code becomes a `KBCache` provider."** Superficially "merge the caches", but
+  it jams a fingerprint/local-build cache into a TTL/network-provider cache —
+  forcing a clock onto a content hash and a fetch-with-breaker onto a
+  deterministic build.
+- **"Vector-RAG over the repo."** The 2026 research the design doc cites is
+  explicit that structural graph beats vector retrieval for code (SWE-bench
+  Verified leaders don't vector-index the target repo; code relevance ≠ text
+  similarity). Routing the code graph through embeddings would regress
+  [ADR-0004](0004-deterministic-tools-only-contract.md) determinism and the
+  fixed-tool boundary [ADR-0028](0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md)
+  just set.
+
+This ADR fixes the boundary and rules both out. It decides *what is shared*; it
+does **not** authorize the P1–P3 code — each phase stays a separate go/no-go.
+
+### 2026 research grounding (verified independently, not relayed from the design doc)
+
+The design doc's direction was re-checked against current (mid-2026) primary
+sources rather than cited second-hand:
+
+- **Structural graph / AST beats vector RAG for code.** The SWE-bench Verified
+  leaderboard (>80%) is dominated by agentic systems, and none of the top
+  entries use vector retrieval over the target repo; Cursor, Claude Code, Codex,
+  Cline, and Devin all use grep-like structural retrieval over embeddings for
+  code, where exactness and composability matter. Embeddings flatten the import /
+  call / type structure that carries code relevance. (Grewal 2026; MindStudio
+  "Why Cursor, Claude Code, and Devin Use grep, Not Vectors"; SparkCo agent-memory
+  comparison 2026.)
+- **Tree-sitter file-incremental via content-hash is the 2026 consensus, and it
+  is exactly our fingerprint model.** Incremental re-index by per-file content
+  hash is ~4× faster than full re-index; Claude Code's own LSP-integration
+  experiment *regressed* (symbol-resolution failures, +8.5% tokens, no quality
+  gain). `call_graph_cache`'s per-file sha + `INDEX_VERSION` is the
+  research-backed staleness model — keeping it (not generalizing it to a clock)
+  is the correct call. (sheeptechnologies RFC-001; AutomaDocs "Tree-sitter vs
+  LSP"; arXiv 2603.27277.)
+- **Hybrid vector+graph and layered memory are real — but at the retrieval/memory
+  layer, not the cache substrate.** 2026 memory architectures converge on
+  episodic (vector, recent interactions) + semantic (graph, multi-hop) + state
+  layers; the sanctioned hybrid is *vector for entry-points + graph for
+  traversal*. This is a **retrieval-semantics** decision, orthogonal to *how a
+  derived artifact is cached on disk*. It informs P3's boundary (below), not this
+  substrate. (mem0 State-of-Agent-Memory 2026; Atlan "Agent Memory Architectures
+  2026"; DigitalApplied "Vector, Graph, Episodic 2026".)
+
+## Decision
+
+### Decision 1 — one shared substrate: primitive + pluggable staleness + unified metrics/warming
+
+A thin shared substrate lands in `tapps_core.cache`. **Only the mechanical,
+domain-independent machinery is shared; every domain difference stays
+pluggable.**
+
+Shared (the substrate):
+
+- **`AtomicJsonCache`** — the single read / write / atomic-replace primitive,
+  replacing the five hand-rolled `_write_atomic` copies. Mechanics only (temp
+  file + `os.replace`, locking, JSON (de)serialization) — it holds no staleness
+  or provider opinion.
+- **`StalenessStrategy` protocol** — `TTLStaleness` | `FingerprintStaleness` |
+  `VersionStaleness` (`INDEX_VERSION`). Pluggable **because the models are
+  irreconcilable**; the substrate composes a strategy, it does not unify them.
+- **Unified `CacheStats`** — every cache reports hit/miss/stale into one surface
+  (`tapps_stats` / `server_metrics_tools`), taking metrics from 1/5 to 5/5.
+- **One session-start warmer** — schedules docs + code + (optionally) the rest,
+  replacing the three warmers (`knowledge/warming.py`, `experts/rag_warming.py`,
+  `_schedule_call_graph_rebuild`).
+- **Degradation contract** — stale/absent → domain fallback (docs:
+  serve-stale + refresh; code: local rebuild), preserving the
+  [ADR-0027](0027-shareable-call-graph-artifact.md) "cache is never a source of
+  truth" boundary.
+
+Domain-specific (stays where it lives, never absorbed into the substrate):
+
+- **Staleness implementation** — a clock (TTL) vs a content hash (fingerprint)
+  vs an index version. Composed, never collapsed.
+- **Provider / network** — Context7 fetch + circuit breaker for docs; a local
+  deterministic build for the code graph and per-file tools. The substrate never
+  learns to fetch.
+- **Retrieval mechanism** — docs are semantic/external; the code graph is a
+  deterministic structural graph. These do not converge onto one query surface.
+
+### Decision 2 — reject "code-as-`KBCache`-provider"
+
+The code graph is **not** modeled as a `KBCache` provider, and `KBCache` staleness
+is **not** generalized to swallow fingerprinting. They share `AtomicJsonCache`
+and the `CacheStats` surface and nothing else. `KBCache` keeps
+`TTLStaleness` + its Context7 provider + breaker; `call_graph_cache` keeps
+`FingerprintStaleness` + `VersionStaleness` + its local build. A clock and a
+content hash are different staleness models on purpose; merging them produces a
+cache that fits neither and re-introduces the coupling this epic exists to remove.
+
+### Decision 3 — reject "vector-RAG over code"; the hybrid retrieval layer is out of scope, not foreclosed
+
+Code retrieval stays a **deterministic structural graph**
+([ADR-0004](0004-deterministic-tools-only-contract.md) /
+[ADR-0017](0017-function-level-call-graph-python-first.md) /
+[ADR-0026](0026-typescript-call-graph-via-tree-sitter.md)). No phase of this epic
+introduces embeddings, vector similarity, or RAG over the repository **as a code
+retrieval path**. The verified 2026 evidence above is unambiguous that structural
+graph beats vector RAG for code and that grep+graph is what the leading agents
+ship.
+
+This decision draws a deliberate line between two layers that the naive framing
+conflates:
+
+- **Cache substrate (this epic's scope).** How a *derived artifact* is written,
+  invalidated, measured, and warmed on disk. Vector similarity has no place here
+  regardless of domain — a cache is not a retriever.
+- **Retrieval semantics (out of scope).** *How* an agent finds relevant context.
+  The research-sanctioned hybrid — *vector for entry-points + graph for
+  traversal*, inside a layered episodic/semantic/state memory model — is a real
+  2026 direction, but it is a **retrieval-layer** decision, not a cache-substrate
+  one.
+
+**Resolution of the scoping question (Q2):** the hybrid retrieval layer is
+**scoped out of this epic entirely, and gated behind a fresh, telemetry-backed
+ADR — but it is explicitly *not* foreclosed.** The door stays open for the P3
+context-retrieval layer to front code(graph) + docs(semantic) + brain(episodic)
+behind a common provider protocol, *if and only if* a future ADR shows a measured
+retrieval need the deterministic graph cannot meet and weighs it against the
+ADR-0004 determinism / ADR-0028 fixed-tool cost. What is foreclosed here, and only
+here, is: (a) modeling the code graph as a vector-RAG source, and (b) letting any
+such hybrid ride in on this cache-substrate work without its own decision. Keeping
+these two layers separate is the load-bearing point — the substrate must not grow
+a retrieval opinion, and the retrieval layer must not smuggle vector RAG into the
+deterministic code path.
+
+### Decision 4 — success metric: net code goes DOWN across P1–P3, or stop
+
+The substrate is justified only if it **removes more than it adds**. The metric
+is **cumulative net lines of code across the affected cache implementations must
+go DOWN by the end of P3** — the design doc's over-build guard rail is binding,
+not advisory.
+
+Two honest qualifications on how that metric applies per phase:
+
+- **P1 is the pilot and front-loads the substrate.** Extracting `AtomicJsonCache`
+  + `StalenessStrategy` and migrating a single consumer (`call_graph_cache`,
+  byte-equivalent) is expected to be **net-up in isolation** — it adds the shared
+  primitive while removing only one `_write_atomic` copy. That is acceptable
+  *only* because the primitive is the prerequisite that makes P3's deletions
+  (4 more `_write_atomic` copies, 3 warmers → 1, 3 Linear gateways → 1) possible.
+  P1's gate is therefore **"does it prove the primitive works byte-equivalent,
+  and is the trajectory to a cumulative net-down credible?"** — not "is this one
+  phase net-down."
+- **Each phase is a separate go/no-go on that trajectory.** If at any phase the
+  running total is not on track to end net-down — i.e. the abstraction is adding
+  more than the remaining consumers can remove — that phase **stops** and the
+  substrate is reconsidered. P3 (the unified context-retrieval layer over code +
+  docs + brain) proceeds **only** if P1–P2 have shown the substrate earns its
+  keep and the cumulative count is trending down.
+
+The number to watch is the epic-wide total (5 `_write_atomic` copies → 1,
+3 warmers → 1, 3 Linear gateways → 1, metrics unified), not any single phase's
+diff.
+
+## Consequences
+
+### Positive
+
+- One atomic-write primitive and one metrics surface replace five hand-rolled
+  copies; metrics coverage goes 1/5 → 5/5; three warmers become one.
+- The two staleness models stay explicitly separate, so neither the docs cache
+  nor the code cache is contorted to fit the other.
+- Determinism and the fixed-tool boundary
+  ([ADR-0004](0004-deterministic-tools-only-contract.md) /
+  [ADR-0028](0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md))
+  are preserved — no embeddings enter the code path.
+- The net-code-down metric gives every phase an objective kill switch, guarding
+  against the over-abstraction the design review flagged.
+
+### Negative / constraints
+
+- A shared `StalenessStrategy` protocol is a new seam every cache must adopt;
+  the payoff is realized only as consumers migrate (P1 pilot →
+  P3 remainder), so intermediate states carry both the substrate and not-yet-migrated
+  copies.
+- The back-compat re-export shims (`tapps_mcp/knowledge/cache.py`,
+  `warming.py`) persist until a major, adding a few low-value indirection lines
+  that the net-code-down metric must account for.
+
+### Revisiting
+
+- **Decisions 2 & 3** (no code-as-provider, no vector-RAG) reverse only via a
+  fresh ADR backed by telemetry — a measured retrieval need the deterministic
+  graph provably cannot meet, weighed against the determinism/fixture cost.
+  Collapsing the two staleness models is out of scope, not a revisit.
+- **Decision 4** (net-code-down) is the standing gate: a phase that cannot meet
+  it does not proceed by exception; the boundary is re-opened here instead.
+
+## Alternatives considered
+
+1. **Merge all five caches into one `KBCache`-shaped cache.** Rejected
+   (Decision 2) — forces a clock onto a content hash and a network fetch onto a
+   local build; the result fits neither domain and re-couples what the epic
+   exists to separate.
+2. **Add vector/RAG retrieval over the code graph as part of the substrate.**
+   Rejected (Decision 3) — 2026 evidence has structural graph beating vector RAG
+   for code, and it would regress ADR-0004 determinism and the ADR-0028
+   fixed-tool boundary. Out of scope for a cache-substrate epic.
+3. **Leave the five caches as-is (status quo).** Rejected — the fragmentation
+   (5× atomic-write, metrics on 1/5, three warmers) is the documented cost this
+   epic removes; the substrate pays for itself only under the net-code-down
+   metric, which status quo cannot deliver.
+4. **Build the substrate but keep it code-only (skip the shared primitive).**
+   Rejected — the value is precisely the *shared* atomic primitive + unified
+   metrics across both domains; a code-only helper duplicates rather than
+   consolidates.
+
+## References
+
+- [DESIGN-unified-cache-substrate-and-context-layer](../design/DESIGN-unified-cache-substrate-and-context-layer.md) — the design this ADR ratifies (fragmentation inventory, 2026 research, phase map)
+- [ADR-0004](0004-deterministic-tools-only-contract.md) deterministic-tools-only — same input, same output; no LLM/embedding in the tool chain
+- [ADR-0016](0016-needs-based-nlt-mcp-taxonomy.md) needs-based MCP taxonomy — zero-duplication rule
+- [ADR-0017](0017-function-level-call-graph-python-first.md) function-level call graph — the deterministic review-graph store
+- [ADR-0026](0026-typescript-call-graph-via-tree-sitter.md) TypeScript call graph via tree-sitter — structural, not vector
+- [ADR-0027](0027-shareable-call-graph-artifact.md) shareable call-graph artifact — cache-is-never-a-source-of-truth boundary
+- [ADR-0028](0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md) code-graph boundary — fixed tools, no query language
+- `docs/CALL_GRAPH.md` — consumer guide for the fixed graph tools
+- [TAP-4556](https://linear.app/tappscodingagents/issue/TAP-4556) this ADR · parent epic [TAP-4555](https://linear.app/tappscodingagents/issue/TAP-4555)
+
+### 2026 research (verified for this ADR)
+
+1. Grewal — AI Agents Don't Need Vector Search Anymore (2026): https://buzzgrewal.medium.com/ai-agents-dont-need-vector-search-anymore-inside-the-agentic-search-stack-replacing-rag-in-2026-58efcabe4f6f
+2. MindStudio — Why Cursor, Claude Code, and Devin Use grep, Not Vectors (2026): https://www.mindstudio.ai/blog/is-rag-dead-what-ai-agents-use-instead
+3. SparkCo — AI Agent Memory in 2026: RAG vs Vector Stores vs Graph (2026): https://sparkco.ai/blog/ai-agent-memory-in-2026-comparing-rag-vector-stores-and-graph-based-approaches
+4. sheeptechnologies RFC-001 — Remove SCIP, adopt tree-sitter file-incremental indexing: https://github.com/orgs/sheeptechnologies/discussions/4
+5. AutomaDocs — Tree-sitter vs LSP for Code Analysis (2026): https://automadocs.com/blog/tree-sitter-vs-lsp-code-analysis
+6. arXiv 2603.27277 — Codebase-Memory: Tree-Sitter Knowledge Graphs via MCP: https://arxiv.org/html/2603.27277v1
+7. mem0 — State of AI Agent Memory 2026: https://mem0.ai/blog/state-of-ai-agent-memory-2026
+8. Atlan — Agent Memory Architectures: Patterns and Trade-offs (2026): https://atlan.com/know/agent-memory-architectures/
+9. DigitalApplied — AI Agent Memory 2026: Vector, Graph, Episodic: https://www.digitalapplied.com/blog/ai-agent-memory-vector-graph-episodic-2026

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ CLAUDE.md and per-package CLAUDE.md files point at ADRs by number rather than em
 | [0026](0026-typescript-call-graph-via-tree-sitter.md) | TypeScript call graph via tree-sitter (language dispatch + honesty boundary) | Accepted |
 | [0027](0027-shareable-call-graph-artifact.md) | Shareable call-graph artifact (CI build + load-on-session-start) | Proposed |
 | [0028](0028-code-graph-boundary-fenced-external-comprehension-and-no-query-language.md) | Code-graph boundary — fenced external comprehension tool + no query language | Accepted |
+| [0029](0029-unified-cache-substrate.md) | Unified cache substrate — one atomic primitive, pluggable staleness, no code-as-provider / no vector-RAG | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/design/DESIGN-unified-cache-substrate-and-context-layer.md
+++ b/docs/design/DESIGN-unified-cache-substrate-and-context-layer.md
@@ -1,8 +1,8 @@
 # DESIGN — Unified cache substrate + context-retrieval layer
 
 Date: 2026-07-01
-Status: Draft (design-support for the cache-consolidation epic; not yet an ADR)
-Related: ADR-0004 (deterministic tools), ADR-0016 (needs-based MCP taxonomy), ADR-0017 (Python-first call graph), ADR-0026 (TS call graph), ADR-0027 (shareable artifact), ADR-0028 (code-graph boundary)
+Status: Ratified by [ADR-0029](../adr/0029-unified-cache-substrate.md) (2026-07-01, TAP-4556) — substrate boundary Accepted; P1–P3 code stays a per-phase go/no-go.
+Related: ADR-0004 (deterministic tools), ADR-0016 (needs-based MCP taxonomy), ADR-0017 (Python-first call graph), ADR-0026 (TS call graph), ADR-0027 (shareable artifact), ADR-0028 (code-graph boundary), ADR-0029 (unified cache substrate — ratifies this design)
 
 ## Why this exists
 

--- a/packages/tapps-core/src/tapps_core/cache/__init__.py
+++ b/packages/tapps-core/src/tapps_core/cache/__init__.py
@@ -1,0 +1,25 @@
+"""Shared cache substrate (ADR-0029): one atomic primitive + pluggable staleness.
+
+Consolidates the atomic-write and staleness machinery that tapps caches
+re-implemented independently. Only the *mechanics* are shared; each cache keeps
+its own staleness model, provider, and retrieval — see
+``docs/adr/0029-unified-cache-substrate.md``.
+"""
+
+from __future__ import annotations
+
+from tapps_core.cache.atomic import AtomicJsonCache
+from tapps_core.cache.staleness import (
+    FingerprintStaleness,
+    StalenessStrategy,
+    TTLStaleness,
+    VersionStaleness,
+)
+
+__all__ = [
+    "AtomicJsonCache",
+    "FingerprintStaleness",
+    "StalenessStrategy",
+    "TTLStaleness",
+    "VersionStaleness",
+]

--- a/packages/tapps-core/src/tapps_core/cache/atomic.py
+++ b/packages/tapps-core/src/tapps_core/cache/atomic.py
@@ -1,0 +1,78 @@
+"""Atomic JSON file primitive (TAP-4556, ADR-0029).
+
+The single read / write / atomic-replace primitive shared across tapps caches,
+replacing the hand-rolled ``_write_atomic`` copies. Mechanics only — it holds no
+staleness or provider opinion (those are ``StalenessStrategy`` and each cache's
+own provider, per ADR-0029). A cache is not a retriever: this never fetches,
+embeds, or decides freshness.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+class AtomicJsonCache:
+    """Atomic file read/write via ``tempfile`` + ``os.replace``.
+
+    The class is a namespace of static methods, not a stateful cache: every call
+    targets an explicit path, so single-file callers (the code-graph index) and
+    directory-of-entries callers (the docs cache) share one implementation.
+    """
+
+    @staticmethod
+    def write_text(target: Path, content: str) -> None:
+        """Write *content* to *target* atomically.
+
+        The temp file is created in *target*'s directory so ``os.replace`` is
+        atomic on the same filesystem. On any failure the partial temp file is
+        removed and *target* is left untouched (readers never see a half-written
+        file).
+        """
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(target.parent),
+            prefix=".tmp_",
+            suffix=target.suffix,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+            Path(tmp_path).replace(target)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+
+    @staticmethod
+    def write_json(
+        target: Path,
+        obj: Any,
+        *,
+        indent: int | None = 2,
+        sort_keys: bool = False,
+    ) -> None:
+        """Serialize *obj* to JSON and write it atomically to *target*.
+
+        ``indent`` / ``sort_keys`` mirror :func:`json.dumps` so a caller
+        migrating onto this primitive preserves its existing on-disk byte layout.
+        """
+        AtomicJsonCache.write_text(target, json.dumps(obj, indent=indent, sort_keys=sort_keys))
+
+    @staticmethod
+    def read_json(path: Path) -> Any | None:
+        """Return the parsed JSON at *path*, or ``None`` if absent or unreadable.
+
+        A missing file or malformed JSON returns ``None`` rather than raising — a
+        derived cache treats an unreadable entry as a miss and rebuilds it.
+        """
+        if not path.is_file():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None

--- a/packages/tapps-core/src/tapps_core/cache/staleness.py
+++ b/packages/tapps-core/src/tapps_core/cache/staleness.py
@@ -1,0 +1,78 @@
+"""Pluggable cache staleness strategies (TAP-4556, ADR-0029).
+
+The staleness models tapps caches use are irreconcilable by nature — a wall
+clock (TTL) vs a content fingerprint vs a schema version. ADR-0029 keeps them
+*pluggable* behind a common protocol rather than collapsing them into one
+(collapsing is exactly the "code-as-KBCache-provider" anti-pattern the ADR
+rejects). Each strategy is constructed with the *current* expectation and, given
+a cached marker, answers one question: is the cached entry stale?
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol, TypeVar
+
+# Contravariant: the marker type appears only in an input position (``is_stale``
+# consumes a cached marker), so a strategy over a wider marker type substitutes
+# for one over a narrower type.
+T_contra = TypeVar("T_contra", contravariant=True)
+
+
+class StalenessStrategy(Protocol[T_contra]):
+    """Answers whether a cached marker of type ``T_contra`` is stale.
+
+    The marker is what a cache persists alongside each entry: a timestamp (TTL),
+    a content fingerprint (str), or a schema version (int). The strategy holds
+    the current expectation; ``is_stale`` compares the cached marker to it.
+    """
+
+    def is_stale(self, cached: T_contra, /) -> bool: ...
+
+
+@dataclass(frozen=True)
+class TTLStaleness:
+    """Clock-based: stale once ``ttl_seconds`` have elapsed since ``cached``.
+
+    The model for network/agent-fetched values that simply age out — docs
+    (KBCache), dependency-scan, and Linear snapshots. ``now_fn`` is injectable so
+    tests can advance the clock deterministically.
+    """
+
+    ttl_seconds: float
+    now_fn: Callable[[], float] = time.time
+
+    def is_stale(self, cached: float, /) -> bool:
+        return (self.now_fn() - cached) >= self.ttl_seconds
+
+
+@dataclass(frozen=True)
+class FingerprintStaleness:
+    """Content-fingerprint: stale when the cached hash differs from current.
+
+    The model for locally-derived artifacts that are fresh exactly while their
+    inputs are unchanged — the code graph (per-file sha) and content-hash cache.
+    This is the tree-sitter file-incremental model 2026 research favors over full
+    re-index; ADR-0029 keeps it rather than forcing a clock onto it.
+    """
+
+    current: str
+
+    def is_stale(self, cached: str, /) -> bool:
+        return cached != self.current
+
+
+@dataclass(frozen=True)
+class VersionStaleness:
+    """Schema-version: stale when the cached version differs from current.
+
+    Rejects an on-disk artifact whose *schema* predates the running code (e.g.
+    the call-graph ``INDEX_VERSION``), independent of content freshness.
+    """
+
+    current: int
+
+    def is_stale(self, cached: int, /) -> bool:
+        return cached != self.current

--- a/packages/tapps-core/tests/unit/test_cache_substrate.py
+++ b/packages/tapps-core/tests/unit/test_cache_substrate.py
@@ -1,0 +1,85 @@
+"""Unit tests for the shared cache substrate (TAP-4556, ADR-0029).
+
+Covers the atomic JSON primitive and the three pluggable staleness strategies
+that the call-graph cache pilot-migrates onto.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tapps_core.cache import (
+    AtomicJsonCache,
+    FingerprintStaleness,
+    TTLStaleness,
+    VersionStaleness,
+)
+
+
+class TestAtomicJsonCache:
+    def test_write_text_round_trips(self, tmp_path: Path) -> None:
+        target = tmp_path / "note.txt"
+        AtomicJsonCache.write_text(target, "hello")
+        assert target.read_text(encoding="utf-8") == "hello"
+
+    def test_write_json_byte_layout_matches_json_dumps(self, tmp_path: Path) -> None:
+        # The pilot's byte-equivalence contract: write_json must produce exactly
+        # what json.dumps(indent=2, sort_keys=True) would, so an on-disk cache is
+        # unchanged after migration.
+        obj = {"b": 2, "a": [1, 2, 3], "c": {"z": 1, "y": 2}}
+        target = tmp_path / "index.json"
+        AtomicJsonCache.write_json(target, obj, indent=2, sort_keys=True)
+        assert target.read_text(encoding="utf-8") == json.dumps(obj, indent=2, sort_keys=True)
+
+    def test_read_json_returns_parsed_object(self, tmp_path: Path) -> None:
+        target = tmp_path / "index.json"
+        AtomicJsonCache.write_json(target, {"k": "v"})
+        assert AtomicJsonCache.read_json(target) == {"k": "v"}
+
+    def test_read_json_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert AtomicJsonCache.read_json(tmp_path / "absent.json") is None
+
+    def test_read_json_malformed_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "broken.json"
+        target.write_text("{not valid json", encoding="utf-8")
+        assert AtomicJsonCache.read_json(target) is None
+
+    def test_write_atomic_leaves_original_on_failure(self, tmp_path: Path) -> None:
+        target = tmp_path / "index.json"
+        AtomicJsonCache.write_json(target, {"good": True})
+        # A non-serializable payload raises inside the temp write; the original
+        # file must be untouched and no .tmp_ debris left behind.
+        try:
+            AtomicJsonCache.write_json(target, {"bad": object()})
+        except TypeError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected TypeError on non-serializable payload")
+        assert AtomicJsonCache.read_json(target) == {"good": True}
+        assert not list(tmp_path.glob(".tmp_*"))
+
+
+class TestStalenessStrategies:
+    def test_version_staleness(self) -> None:
+        strat = VersionStaleness(current=5)
+        assert strat.is_stale(4) is True
+        assert strat.is_stale(5) is False
+
+    def test_fingerprint_staleness(self) -> None:
+        strat = FingerprintStaleness(current="abc123")
+        assert strat.is_stale("stale-hash") is True
+        assert strat.is_stale("abc123") is False
+
+    def test_ttl_staleness_uses_injected_clock(self) -> None:
+        clock = {"now": 1000.0}
+        strat = TTLStaleness(ttl_seconds=60.0, now_fn=lambda: clock["now"])
+        # cached at t=1000, now=1000 -> fresh; advance past the TTL -> stale.
+        assert strat.is_stale(1000.0) is False
+        clock["now"] = 1061.0
+        assert strat.is_stale(1000.0) is True
+
+    def test_ttl_staleness_boundary_is_stale_at_exactly_ttl(self) -> None:
+        strat = TTLStaleness(ttl_seconds=60.0, now_fn=lambda: 1060.0)
+        # >= ttl is stale (matches the KBCache/dep-scan expire-at semantics).
+        assert strat.is_stale(1000.0) is True

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import contextlib
-import json
-import os
-import tempfile
 import time
 from dataclasses import asdict
 from pathlib import Path
 
 import structlog
 
+from tapps_core.cache import AtomicJsonCache, FingerprintStaleness, VersionStaleness
 from tapps_mcp.pipeline.agent_contract import (
     CALL_GRAPH_DEGRADED_HINT,
     CALL_GRAPH_STALE_HINT,
@@ -39,23 +36,6 @@ from tapps_mcp.project.call_graph_types import (
 logger = structlog.get_logger(__name__)
 
 
-def _write_atomic(target: Path, content: str) -> None:
-    """Write *content* to *target* atomically via tempfile + replace (TAP-4075)."""
-    fd, tmp_path = tempfile.mkstemp(
-        dir=str(target.parent),
-        prefix=".tmp_",
-        suffix=target.suffix,
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(content)
-        Path(tmp_path).replace(target)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            Path(tmp_path).unlink()
-        raise
-
-
 def index_fingerprint(
     project_root: Path,
     exclude_patterns: list[str] | None,
@@ -74,10 +54,9 @@ def load_call_graph_index(project_root: Path) -> CallGraphIndex | None:
     path = project_root / CALL_GRAPH_CACHE_REL
     if not path.is_file():
         return None
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("call_graph_cache_read_failed", path=str(path), error=str(exc))
+    raw = AtomicJsonCache.read_json(path)
+    if raw is None:
+        logger.warning("call_graph_cache_read_failed", path=str(path))
         return None
     if not isinstance(raw, dict):
         return None
@@ -88,8 +67,8 @@ def save_call_graph_index(project_root: Path, index: CallGraphIndex) -> None:
     path = project_root / CALL_GRAPH_CACHE_REL
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        payload = json.dumps(index_to_dict(index), indent=2, sort_keys=True)
-        _write_atomic(path, payload)
+        # sort_keys/indent preserve the exact prior byte layout (ADR-0029 pilot).
+        AtomicJsonCache.write_json(path, index_to_dict(index), indent=2, sort_keys=True)
     except OSError as exc:
         logger.warning("call_graph_cache_write_failed", path=str(path), error=str(exc))
 
@@ -298,7 +277,7 @@ def summarize_call_graph_cache(
             "hint": CALL_GRAPH_STALE_HINT,
         }
 
-    if cached.version != INDEX_VERSION:
+    if VersionStaleness(INDEX_VERSION).is_stale(cached.version):
         return {
             "status": "stale",
             "ready": False,
@@ -312,7 +291,7 @@ def summarize_call_graph_cache(
         }
 
     current_fp = compute_index_fingerprint(settings, index_version=INDEX_VERSION)
-    stale = cached.fingerprint != current_fp
+    stale = FingerprintStaleness(current_fp).is_stale(cached.fingerprint)
     edge_count = len(cached.edges)
     gap_count = len(cached.resolution_gaps)
     parse_fail_count = len(cached.parse_failures)


### PR DESCRIPTION
## Summary

Two units of the unified-cache-substrate epic (parent TAP-4555):

- **P0 (TAP-4556)** — decision ADR `docs/adr/0029-unified-cache-substrate.md` (Accepted). Ratifies the design doc's substrate boundary: one shared `AtomicJsonCache` primitive + pluggable `StalenessStrategy` + unified metrics/warming, with staleness impl / provider / retrieval staying domain-specific. Explicitly rejects **code-as-KBCache-provider** and **vector-RAG-over-code**, grounded in independently-verified 2026 research (structural graph > vector RAG for code; tree-sitter file-incremental = our fingerprint model; hybrid retrieval scoped out but not foreclosed). Success metric: **cumulative net code DOWN across P1–P3, or stop**.
- **P1 (TAP-4560)** — extract `tapps_core.cache` (`AtomicJsonCache` + `TTL/Fingerprint/Version` staleness) and pilot-migrate `call_graph_cache` **byte-equivalently** (`indent=2, sort_keys=True`); `summarize_call_graph_cache` now uses `VersionStaleness` + `FingerprintStaleness` with identical verdicts. Removes the duplicated `_write_atomic` helper.

## Net-line accounting (per ADR-0029)

P1 is **net-up in isolation** (substrate +181 / consumer −21) — accepted under the cumulative metric. The removal payoff (KBCache + content-hash + dep-scan + Linear×3 → substrate, 3 warmers → 1, 3 gateways → 1) lands in P3.

## Verification

- 10 new substrate unit tests + 30 existing call-graph/session tests pass unchanged.
- `ruff` + `mypy` + `vulture` clean; pre-commit tapps gate score **100** on all 5 files.
- 3 `test_doctor.py` failures are **pre-existing** (confirmed identical with this work stashed), unrelated to caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)