### PR TITLE
P2+P3: unified cache stats + one warmer; substrate migrations + honest Decision-4 verdict (TAP-4561, TAP-4562)

### DIFF
--- a/docs/adr/0029-unified-cache-substrate.md
+++ b/docs/adr/0029-unified-cache-substrate.md
@@ -227,6 +227,26 @@ diff.
 - **Decision 4** (net-code-down) is the standing gate: a phase that cannot meet
   it does not proceed by exception; the boundary is re-opened here instead.
 
+## Outcome (2026-07-01, P1–P3 measured)
+
+The phases shipped (TAP-4560 / TAP-4561 / TAP-4562) and the Decision 4 metric
+was measured honestly: **cumulative net code went UP ~+287 lines (excl. tests),
+not down.** The design doc's deletion inventory did not survive contact with the
+code — only 2 real `_write_atomic` copies existed (not 5), 2 warmers (not 3),
+the "3 Linear gateways" are two deliberately distinct Agent-Gateway sentinel
+checks (TAP-2009 write-gate, TAP-2010 read-gate) plus one real cache and are
+**not collapsible**, and the content-hash / dependency-scan caches are
+in-memory (no file migration applies).
+
+What the +287 lines bought: metrics coverage 1/5 → 5/5 caches
+(`tapps_stats.caches`), zero hand-rolled atomic-write copies, three staleness
+models behind one protocol, one session-start warmer entry, byte-equivalent
+migrations throughout. Real consolidation value — but the Decision 4 gate is
+the gate: **further substrate phases (including the P3 unified
+context-retrieval layer) are STOPPED** and require a fresh ADR with a
+justification that does not lean on deletion volume, per this ADR's Revisiting
+clause.
+
 ## Alternatives considered
 
 1. **Merge all five caches into one `KBCache`-shaped cache.** Rejected

--- a/docs/design/DESIGN-unified-cache-substrate-and-context-layer.md
+++ b/docs/design/DESIGN-unified-cache-substrate-and-context-layer.md
@@ -54,6 +54,18 @@ Retrieval mechanisms stay separate and domain-specific. Per 2026: code stays a d
 
 Once the substrate exists, the three retrieval sources — **code graph (structural)**, **docs (external/semantic)**, **brain (episodic/cross-session)** — front a common on-demand *retrieval-provider* protocol, matching the 2026 layered-memory model (graph + semantic + episodic). This is where the redundant per-cache implementations are **migrated and deleted**.
 
+> **Verified inventory corrections (2026-07-01, during P2/P3 implementation):**
+> the table above overstates the duplication. Measured against the code:
+> (1) only **2** real `_write_atomic` helpers existed (KBCache + call-graph) —
+> content-hash (#3) and dependency-scan (#4) are **in-memory** dicts, not file
+> caches, so no file migration applies; (2) there are **2** warmers, not 3 —
+> `experts/rag_warming.py` is a tech-stack→domain mapping, its warming
+> infrastructure was already removed; (3) the "3 Linear gateway" sites are two
+> deliberately distinct Agent-Gateway sentinel checks (TAP-2009 write-gate,
+> TAP-2010 read-gate) plus one real snapshot cache — **not collapsible**.
+> Consequence: the net-code-DOWN success metric was unachievable as scoped; see
+> [ADR-0029 § Outcome](../adr/0029-unified-cache-substrate.md#outcome-2026-07-01-p1p3-measured).
+
 ## 4. Refactor / delete inventory (rolled into Phase 3; pulled earlier only where prereq)
 
 | Item | Action | Phase | Note |

--- a/packages/tapps-core/src/tapps_core/cache/__init__.py
+++ b/packages/tapps-core/src/tapps_core/cache/__init__.py
@@ -15,6 +15,11 @@ from tapps_core.cache.staleness import (
     TTLStaleness,
     VersionStaleness,
 )
+from tapps_core.cache.stats import (
+    collect_cache_stats,
+    register_cache_stats,
+    unregister_cache_stats,
+)
 
 __all__ = [
     "AtomicJsonCache",
@@ -22,4 +27,7 @@ __all__ = [
     "StalenessStrategy",
     "TTLStaleness",
     "VersionStaleness",
+    "collect_cache_stats",
+    "register_cache_stats",
+    "unregister_cache_stats",
 ]

--- a/packages/tapps-core/src/tapps_core/cache/stats.py
+++ b/packages/tapps-core/src/tapps_core/cache/stats.py
@@ -1,0 +1,48 @@
+"""Unified cache-stats registry (TAP-4561, ADR-0029).
+
+Every cache registers a zero-arg provider returning its counters
+(hits / misses / whatever it tracks); ``collect_cache_stats`` reports them all
+into one surface (``tapps_stats``). The registry holds no opinion about what a
+cache counts — it only unifies *where* the numbers show up.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+_providers: dict[str, Callable[[], dict[str, Any]]] = {}
+_lock = threading.Lock()
+
+
+def register_cache_stats(name: str, provider: Callable[[], dict[str, Any]]) -> None:
+    """Register (or replace) the stats provider for cache *name*.
+
+    Idempotent by design — module-import registration may run more than once.
+    """
+    with _lock:
+        _providers[name] = provider
+
+
+def unregister_cache_stats(name: str) -> None:
+    """Remove a provider (tests)."""
+    with _lock:
+        _providers.pop(name, None)
+
+
+def collect_cache_stats() -> dict[str, dict[str, Any]]:
+    """Snapshot every registered cache's stats.
+
+    A failing provider reports ``{"error": ...}`` instead of breaking the
+    collection — one broken cache must not take down ``tapps_stats``.
+    """
+    with _lock:
+        providers = dict(_providers)
+    out: dict[str, dict[str, Any]] = {}
+    for name, provider in providers.items():
+        try:
+            out[name] = dict(provider())
+        except Exception as exc:
+            out[name] = {"error": str(exc)}
+    return out

--- a/packages/tapps-core/src/tapps_core/knowledge/cache.py
+++ b/packages/tapps-core/src/tapps_core/knowledge/cache.py
@@ -6,11 +6,8 @@ Uses ``filelock`` for cross-platform file locking (Windows compatible).
 
 from __future__ import annotations
 
-import contextlib
 import datetime
 import json
-import os
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -19,6 +16,7 @@ from typing import Any, ClassVar
 import structlog
 from filelock import FileLock
 
+from tapps_core.cache import AtomicJsonCache, TTLStaleness, register_cache_stats
 from tapps_core.knowledge.models import CacheEntry
 
 logger = structlog.get_logger(__name__)
@@ -80,8 +78,17 @@ class KBCache:
     # Class-level lock timeout (seconds)
     LOCK_TIMEOUT: ClassVar[float] = 5.0
 
+    # ADR-0029 / TAP-4561: process-lifetime hit/miss counters for the unified
+    # cache-stats surface. Class-level because KBCache instances are created
+    # ad-hoc per lookup, so per-instance ``_stats`` never accumulates.
+    _process_stats: ClassVar[dict[str, int]] = {"hits": 0, "misses": 0}
+
     def __post_init__(self) -> None:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _count_miss(self) -> None:
+        self._stats.misses += 1
+        KBCache._process_stats["misses"] += 1
 
     # ------------------------------------------------------------------
     # Public API
@@ -96,7 +103,7 @@ class KBCache:
         content_path = self._content_path(library, topic)
 
         if not meta_path.exists() or not content_path.exists():
-            self._stats.misses += 1
+            self._count_miss()
             return None
 
         lock = FileLock(str(self._lock_path(library, topic)), timeout=self.LOCK_TIMEOUT)
@@ -104,7 +111,7 @@ class KBCache:
             with lock:
                 meta = self._read_meta(meta_path)
                 if meta is None:
-                    self._stats.misses += 1
+                    self._count_miss()
                     return None
                 content = content_path.read_text(encoding="utf-8")
 
@@ -114,7 +121,7 @@ class KBCache:
                 self._write_meta_atomic(meta_path, meta)
         except TimeoutError:
             logger.warning("cache_lock_timeout", library=library, topic=topic)
-            self._stats.misses += 1
+            self._count_miss()
             return None
 
         # Record access timestamp for LRU eviction
@@ -137,6 +144,7 @@ class KBCache:
         )
 
         self._stats.hits += 1
+        KBCache._process_stats["hits"] += 1
         return entry
 
     def put(self, entry: CacheEntry) -> None:
@@ -163,7 +171,7 @@ class KBCache:
 
         try:
             with lock:
-                self._write_atomic(content_path, entry.content)
+                AtomicJsonCache.write_text(content_path, entry.content)
                 self._write_meta_atomic(meta_path, meta)
         except TimeoutError:
             logger.warning("cache_write_lock_timeout", library=entry.library, topic=entry.topic)
@@ -320,7 +328,7 @@ class KBCache:
 
     def _save_metadata(self, metadata: dict[str, float]) -> None:
         """Persist access-timestamp metadata to disk atomically."""
-        self._write_atomic(self._metadata_path, json.dumps(metadata, indent=2))
+        AtomicJsonCache.write_text(self._metadata_path, json.dumps(metadata, indent=2))
 
     def _check_size(self, max_mb: int = 100) -> int:
         """Evict LRU entries if total cache size exceeds *max_mb* MB.
@@ -411,8 +419,7 @@ class KBCache:
         """Check if *cached_at* ISO timestamp is past TTL for *library*."""
         try:
             ts = datetime.datetime.fromisoformat(cached_at.replace("Z", "+00:00"))
-            age = (datetime.datetime.now(datetime.UTC) - ts).total_seconds()
-            return age > self._ttl_for(library)
+            return TTLStaleness(self._ttl_for(library)).is_stale(ts.timestamp())
         except (ValueError, TypeError):
             return True
 
@@ -431,21 +438,8 @@ class KBCache:
     def _write_meta_atomic(meta_path: Path, meta: dict[str, Any]) -> None:
         """Write metadata via atomic temp-file + rename."""
         raw = json.dumps(meta, indent=2, default=str)
-        KBCache._write_atomic(meta_path, raw)
+        AtomicJsonCache.write_text(meta_path, raw)
 
-    @staticmethod
-    def _write_atomic(target: Path, content: str) -> None:
-        """Write *content* to *target* atomically via tempfile + replace."""
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(target.parent),
-            prefix=".tmp_",
-            suffix=target.suffix,
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(content)
-            Path(tmp_path).replace(target)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                Path(tmp_path).unlink()
-            raise
+
+# ADR-0029 / TAP-4561: report into the unified cache-stats surface.
+register_cache_stats("kb_docs", lambda: dict(KBCache._process_stats))

--- a/packages/tapps-core/tests/unit/test_cache_substrate.py
+++ b/packages/tapps-core/tests/unit/test_cache_substrate.py
@@ -14,6 +14,9 @@ from tapps_core.cache import (
     FingerprintStaleness,
     TTLStaleness,
     VersionStaleness,
+    collect_cache_stats,
+    register_cache_stats,
+    unregister_cache_stats,
 )
 
 
@@ -83,3 +86,41 @@ class TestStalenessStrategies:
         strat = TTLStaleness(ttl_seconds=60.0, now_fn=lambda: 1060.0)
         # >= ttl is stale (matches the KBCache/dep-scan expire-at semantics).
         assert strat.is_stale(1000.0) is True
+
+
+class TestCacheStatsRegistry:
+    def test_register_and_collect(self) -> None:
+        register_cache_stats("_test_cache_a", lambda: {"hits": 3, "misses": 1})
+        try:
+            collected = collect_cache_stats()
+            assert collected["_test_cache_a"] == {"hits": 3, "misses": 1}
+        finally:
+            unregister_cache_stats("_test_cache_a")
+
+    def test_register_is_idempotent_replace(self) -> None:
+        register_cache_stats("_test_cache_b", lambda: {"hits": 0})
+        register_cache_stats("_test_cache_b", lambda: {"hits": 9})
+        try:
+            assert collect_cache_stats()["_test_cache_b"] == {"hits": 9}
+        finally:
+            unregister_cache_stats("_test_cache_b")
+
+    def test_provider_error_is_isolated(self) -> None:
+        def _boom() -> dict[str, int]:
+            raise RuntimeError("provider exploded")
+
+        register_cache_stats("_test_cache_boom", _boom)
+        register_cache_stats("_test_cache_ok", lambda: {"hits": 1})
+        try:
+            collected = collect_cache_stats()
+            # The broken provider reports an error entry; the healthy one is intact.
+            assert collected["_test_cache_boom"] == {"error": "provider exploded"}
+            assert collected["_test_cache_ok"] == {"hits": 1}
+        finally:
+            unregister_cache_stats("_test_cache_boom")
+            unregister_cache_stats("_test_cache_ok")
+
+    def test_unregister_removes_provider(self) -> None:
+        register_cache_stats("_test_cache_gone", lambda: {"hits": 1})
+        unregister_cache_stats("_test_cache_gone")
+        assert "_test_cache_gone" not in collect_cache_stats()

--- a/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
+++ b/packages/tapps-mcp/src/tapps_mcp/project/call_graph_cache.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 import structlog
 
-from tapps_core.cache import AtomicJsonCache, FingerprintStaleness, VersionStaleness
+from tapps_core.cache import (
+    AtomicJsonCache,
+    FingerprintStaleness,
+    VersionStaleness,
+    register_cache_stats,
+)
 from tapps_mcp.pipeline.agent_contract import (
     CALL_GRAPH_DEGRADED_HINT,
     CALL_GRAPH_STALE_HINT,
@@ -35,6 +40,10 @@ from tapps_mcp.project.call_graph_types import (
 
 logger = structlog.get_logger(__name__)
 
+# ADR-0029 / TAP-4561: unified cache-stats counters (index load hits/misses).
+_stats: dict[str, int] = {"hits": 0, "misses": 0}
+register_cache_stats("call_graph", lambda: dict(_stats))
+
 
 def index_fingerprint(
     project_root: Path,
@@ -53,13 +62,17 @@ def index_fingerprint(
 def load_call_graph_index(project_root: Path) -> CallGraphIndex | None:
     path = project_root / CALL_GRAPH_CACHE_REL
     if not path.is_file():
+        _stats["misses"] += 1
         return None
     raw = AtomicJsonCache.read_json(path)
     if raw is None:
         logger.warning("call_graph_cache_read_failed", path=str(path))
+        _stats["misses"] += 1
         return None
     if not isinstance(raw, dict):
+        _stats["misses"] += 1
         return None
+    _stats["hits"] += 1
     return index_from_dict(raw)
 
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_linear_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_linear_tools.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from tapps_core.cache import AtomicJsonCache, register_cache_stats
 from tapps_core.config.settings import load_settings
 from tapps_mcp.mcp_register import register_tool
 from tapps_mcp.server_helpers import error_response, success_response
@@ -143,32 +144,41 @@ def _ttl_for_state(state: str | None, ttl_open: int, ttl_closed: int) -> int:
     return ttl_open
 
 
+# ADR-0029 / TAP-4561: unified cache-stats counters (snapshot reads/writes).
+_snapshot_stats: dict[str, int] = {"hits": 0, "misses": 0, "writes": 0}
+register_cache_stats("linear_snapshot", lambda: dict(_snapshot_stats))
+
+
 def _cache_read(cache_dir: Path, cache_key: str) -> dict[str, Any] | None:
     """Return cached payload if present and unexpired; None otherwise."""
     cache_file = cache_dir / f"{cache_key}.json"
     if not cache_file.exists():
+        _snapshot_stats["misses"] += 1
         return None
     try:
         raw = cache_file.read_text(encoding="utf-8")
         payload = json.loads(raw)
     except (OSError, json.JSONDecodeError) as exc:
         logger.debug("linear_cache_read_failed", key=cache_key, exc=str(exc))
+        _snapshot_stats["misses"] += 1
         return None
     expires_at = float(payload.get("expires_at", 0))
     if expires_at <= time.time():
+        _snapshot_stats["misses"] += 1
         return None
+    _snapshot_stats["hits"] += 1
     return payload  # type: ignore[no-any-return]
 
 
 def _cache_write(
     cache_dir: Path, cache_key: str, payload: dict[str, Any]
 ) -> None:
-    """Write payload to the cache atomically (tmp + rename)."""
+    """Write payload to the cache atomically (ADR-0029 shared primitive)."""
     cache_file = cache_dir / f"{cache_key}.json"
-    tmp = cache_file.with_suffix(".json.tmp")
     try:
-        tmp.write_text(json.dumps(payload), encoding="utf-8")
-        tmp.replace(cache_file)
+        # indent=None keeps the compact json.dumps byte layout from before.
+        AtomicJsonCache.write_json(cache_file, payload, indent=None)
+        _snapshot_stats["writes"] += 1
     except OSError as exc:
         logger.debug("linear_cache_write_failed", key=cache_key, exc=str(exc))
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_metrics_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_metrics_tools.py
@@ -269,6 +269,11 @@ def tapps_stats(
         payload["docs_tools"] = docs_tools
         payload["docs_tool_calls"] = sum(int(t.get("call_count", 0)) for t in docs_tools)
 
+    # ADR-0029 / TAP-4561: unified per-cache hit/miss counters.
+    from tapps_core.cache import collect_cache_stats
+
+    payload["caches"] = collect_cache_stats()
+
     elapsed_ms = (time.perf_counter_ns() - start) // 1_000_000
     _record_execution("tapps_stats", start)
 

--- a/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_pipeline_tools.py
@@ -673,12 +673,13 @@ async def tapps_session_start(
         data["search_first"] = search_first
         # TAP-1331: schedule background lookup_docs cache warm so the next
         # session's first call is a hit, not a 1-3s Context7 round-trip.
+        # Routed through the single session-start warmer (ADR-0029 / TAP-4561).
         try:
-            from tapps_mcp.tools.session_start_helpers import _schedule_lookup_docs_warm
+            from tapps_mcp.tools.session_start_helpers import schedule_session_warm
 
-            data["cache_warm"] = _schedule_lookup_docs_warm(
-                settings.project_root, search_first.get("covered", [])
-            )
+            data["cache_warm"] = schedule_session_warm(
+                settings.project_root, covered=search_first.get("covered", [])
+            )["docs"]
         except Exception:
             data["cache_warm"] = {"scheduled": False, "skipped": "exception"}
 
@@ -692,12 +693,15 @@ async def tapps_session_start(
         _logger.debug("repo_orientation_session_start_failed", exc_info=True)
 
     # Epic 114: surface call-graph cache readiness for symbol-level refactors.
+    # Rebuild scheduling routes through the single warmer (ADR-0029 / TAP-4561).
     try:
         from tapps_mcp.project.call_graph_cache import summarize_call_graph_cache
-        from tapps_mcp.tools.session_start_helpers import _schedule_call_graph_rebuild
+        from tapps_mcp.tools.session_start_helpers import schedule_session_warm
 
         call_graph_summary = summarize_call_graph_cache(Path(settings.project_root))
-        rebuild = _schedule_call_graph_rebuild(Path(settings.project_root), call_graph_summary)
+        rebuild = schedule_session_warm(
+            Path(settings.project_root), call_graph_summary=call_graph_summary
+        )["call_graph"]
         if rebuild.get("scheduled"):
             call_graph_summary["rebuild_scheduled"] = True
         data["call_graph"] = call_graph_summary

--- a/packages/tapps-mcp/src/tapps_mcp/tools/content_hash_cache.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/content_hash_cache.py
@@ -110,3 +110,9 @@ def size() -> int:
     """Current number of entries in the cache."""
     with _lock:
         return len(_cache)
+
+
+# ADR-0029 / TAP-4561: report into the unified cache-stats surface.
+from tapps_core.cache import register_cache_stats as _register_cache_stats
+
+_register_cache_stats("content_hash", lambda: {**stats(), "size": size()})

--- a/packages/tapps-mcp/src/tapps_mcp/tools/dependency_scan_cache.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/dependency_scan_cache.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 import time
 
+from tapps_core.cache import TTLStaleness, register_cache_stats
 from tapps_mcp.tools.pip_audit import VulnerabilityFinding
 
 # TTL in seconds (5 minutes)
 _CACHE_TTL = 300
 
 _cache: dict[str, tuple[list[VulnerabilityFinding], float]] = {}
+
+# ADR-0029 / TAP-4561: unified cache-stats counters.
+_stats: dict[str, int] = {"hits": 0, "misses": 0}
+register_cache_stats("dependency_scan", lambda: {**_stats, "size": len(_cache)})
 
 
 def set_dependency_findings(project_root: str, findings: list[VulnerabilityFinding]) -> None:
@@ -26,11 +31,14 @@ def get_dependency_findings(project_root: str, ttl: int = _CACHE_TTL) -> list[Vu
     """Return cached dependency findings if present and not expired."""
     entry = _cache.get(str(project_root))
     if entry is None:
+        _stats["misses"] += 1
         return []
     findings, ts = entry
-    if time.monotonic() - ts > ttl:
+    if TTLStaleness(float(ttl), now_fn=time.monotonic).is_stale(ts):
         _cache.pop(str(project_root), None)
+        _stats["misses"] += 1
         return []
+    _stats["hits"] += 1
     return findings
 
 

--- a/packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py
+++ b/packages/tapps-mcp/src/tapps_mcp/tools/session_start_helpers.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
     from tapps_brain.models import MemorySnapshot
     from tapps_brain.store import MemoryStore
 
@@ -1197,6 +1199,45 @@ _CACHE_WARM_FLAG_NAME = ".cache-warm-marker"
 _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 
 
+def _fire_and_forget(
+    coro_factory: Callable[[], Coroutine[Any, Any, None]],
+    tasks: set[asyncio.Task[Any]],
+) -> bool:
+    """Schedule a background task if an event loop is running (ADR-0029).
+
+    The one scheduling envelope shared by every session-start warmer: create
+    the coroutine only once a loop exists, track the task so it isn't GC'd,
+    and report ``False`` (instead of raising) when called without a loop.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    task = loop.create_task(coro_factory())
+    tasks.add(task)
+    task.add_done_callback(tasks.discard)
+    return True
+
+
+def schedule_session_warm(
+    project_root: Path,
+    covered: list[dict[str, str]] | None = None,
+    call_graph_summary: dict[str, object] | None = None,
+) -> dict[str, Any]:
+    """The single session-start warmer (ADR-0029 / TAP-4561).
+
+    Schedules every derived-cache warm-up in one place: docs (when *covered*
+    libraries are known) and the call-graph rebuild (when a staleness summary
+    is available). Returns per-cache scheduling results keyed by cache name.
+    """
+    out: dict[str, Any] = {}
+    if covered is not None:
+        out["docs"] = _schedule_lookup_docs_warm(project_root, covered)
+    if call_graph_summary is not None:
+        out["call_graph"] = _schedule_call_graph_rebuild(project_root, call_graph_summary)
+    return out
+
+
 def _schedule_lookup_docs_warm(
     project_root: Path,
     covered: list[dict[str, str]],
@@ -1276,19 +1317,14 @@ def _schedule_lookup_docs_warm(
         except Exception:
             _logger.debug("cache_warm_runner_failed", exc_info=True)
 
-    try:
-        loop = asyncio.get_running_loop()
-        task = loop.create_task(_runner())
-        _BACKGROUND_TASKS.add(task)
-        task.add_done_callback(_BACKGROUND_TASKS.discard)
+    if _fire_and_forget(_runner, _BACKGROUND_TASKS):
         return {
             "scheduled": True,
             "libraries": libraries,
             "count": len(libraries),
             "via_brain": via_brain,
         }
-    except RuntimeError:
-        return {"scheduled": False, "skipped": "no_running_loop"}
+    return {"scheduled": False, "skipped": "no_running_loop"}
 
 
 # ---------------------------------------------------------------------------
@@ -1316,11 +1352,6 @@ def _schedule_call_graph_rebuild(
         except Exception:
             _logger.debug("call_graph_background_rebuild_failed", exc_info=True)
 
-    try:
-        loop = asyncio.get_running_loop()
-        task = loop.create_task(_runner())
-        _host._background_tasks.add(task)
-        task.add_done_callback(_host._background_tasks.discard)
+    if _fire_and_forget(_runner, _host._background_tasks):
         return {"scheduled": True, "reason": status or "stale"}
-    except RuntimeError:
-        return {"scheduled": False, "skipped": "no_running_loop"}
+    return {"scheduled": False, "skipped": "no_running_loop"}


### PR DESCRIPTION
## Summary

Final two phases of the unified-cache-substrate epic (TAP-4555, ADR-0029).

**P2 (TAP-4561)** — unified `CacheStats`: thread-safe registry in `tapps_core.cache`; all **5 caches** (content-hash, dep-scan, call-graph, KBCache, Linear snapshot) report hit/miss into `tapps_stats.caches` (was 1/5). Both session-start warmers route through one `schedule_session_warm` + shared `_fire_and_forget` envelope; response payload keys unchanged.

**P3 (TAP-4562)** — migrations + deletions: KBCache `_write_atomic` staticmethod **deleted** (→ `AtomicJsonCache.write_text`; `tempfile`/`os`/`contextlib` imports dropped), `_is_expired` → `TTLStaleness` (per-library TTL preserved), Linear `_cache_write` → `AtomicJsonCache.write_json(indent=None)` (byte-identical), dep-scan expiry → `TTLStaleness(now_fn=time.monotonic)`. Zero hand-rolled atomic-write copies remain.

## Verified-inventory corrections (recorded in design doc + ADR Outcome)

- Only **2** real `_write_atomic` copies existed (not 5); content-hash + dep-scan are **in-memory**.
- **2** warmers (not 3) — rag_warming's warming infra was already removed.
- "3 Linear gateways" = distinct TAP-2009/TAP-2010 Agent-Gateway checks + one cache — **not collapsible**.

## ADR-0029 Decision 4 verdict (honest)

Cumulative P1–P3 net code: **UP ~+287 lines excl. tests** — the net-DOWN target was unachievable as scoped because the promised deletion volume didn't exist. Per the ADR's own gate, **further substrate phases (incl. the P3 context-retrieval layer) are STOPPED**; recorded in ADR-0029 § Outcome. What the lines bought: metrics 1/5→5/5, one atomic primitive, one staleness protocol, one warmer, byte-equivalent throughout.

## Verification

- 14 substrate + 78 knowledge/eviction + 768 selected tapps-mcp tests pass; remaining failures **pre-existing on master** (verified by stash).
- Byte-equivalence (compact Linear payload) + 5/5 stats registration proven by smoke script.
- ruff/mypy/vulture clean on changed files; pre-commit tapps gate pass on all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)