### PR TITLE
fix(memory): cross-project recall and HTTP fleet hardening

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,13 @@
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "tapps-mcp",
-    "docs-mcp"
+    "docs-mcp",
+    "nlt-build",
+    "nlt-linear-issues",
+    "nlt-memory",
+    "nlt-project-docs",
+    "nlt-release-ship",
+    "nlt-setup"
   ],
   "defaultMode": "acceptEdits"
 }

--- a/packages/tapps-core/src/tapps_core/brain_bridge.py
+++ b/packages/tapps-core/src/tapps_core/brain_bridge.py
@@ -139,6 +139,18 @@ _MCP_ACCEPT_HEADERS: dict[str, str] = {"Accept": "application/json, text/event-s
 _HTTP_ERROR_BODY_MAX = 500
 
 
+def _tenant_override_headers(project_id: str | None) -> dict[str, str]:
+    """Per-request ``X-Project-Id`` when a caller overrides the bridge default tenant.
+
+    Cross-project recall (TAP-1257 / tapps-mcp #6) passes ``project_id`` on
+    ``tapps_memory`` actions; the HTTP fleet bridge keeps its session-scoped
+    default header but merges this override on individual ``tools/call`` posts
+    without mutating :attr:`HttpBrainBridge._http_headers`.
+    """
+    pid = (project_id or "").strip()
+    return {"X-Project-Id": pid} if pid else {}
+
+
 def _raise_with_body(response: httpx.Response, tool_name: str) -> None:
     """Like ``response.raise_for_status()`` but includes the response body.
 
@@ -1467,7 +1479,13 @@ class HttpBrainBridge(BrainBridge):
     # HTTP JSON-RPC call layer
     # -------------------------------------------------------------------------
 
-    async def _http_mcp_call(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+    async def _http_mcp_call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        project_id: str | None = None,
+    ) -> Any:
         """Call a tapps-brain MCP tool with circuit-breaker + retry semantics."""
         if self.circuit_open:
             raise BrainBridgeUnavailable("circuit open")
@@ -1475,7 +1493,9 @@ class HttpBrainBridge(BrainBridge):
         last_exc: Exception | None = None
         for attempt in range(_RETRY_ATTEMPTS):
             try:
-                result = await self._do_mcp_post(tool_name, arguments)
+                result = await self._do_mcp_post(
+                    tool_name, arguments, project_id=project_id
+                )
                 self._record_success()
                 return result
             except BrainBridgeUnavailable:
@@ -1703,7 +1723,13 @@ class HttpBrainBridge(BrainBridge):
             "negotiation_error": self._negotiation_error,
         }
 
-    async def _do_mcp_post(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+    async def _do_mcp_post(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        project_id: str | None = None,
+    ) -> Any:
         """POST a single ``tools/call`` to ``{brain_http_url}/mcp``."""
         import json as _json
 
@@ -1728,14 +1754,18 @@ class HttpBrainBridge(BrainBridge):
         # but the wire is now authoritative — a genuinely gated tool still
         # surfaces as :class:`ToolNotInProfileError` from the brain's
         # ``-32602 INVALID_PARAMS`` response, just one round-trip later.
-        extra_headers: dict[str, str] = {}
+        extra_headers = _tenant_override_headers(project_id)
         if session_id and session_id != "__no_session__":
             extra_headers["Mcp-Session-Id"] = session_id
+        project_id = (project_id or "").strip()
+        params: dict[str, Any] = {"name": tool_name, "arguments": arguments}
+        if project_id:
+            params["_meta"] = {"project_id": project_id}
         payload = {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/call",
-            "params": {"name": tool_name, "arguments": arguments},
+            "params": params,
         }
         response = await self._http_client.post(
             f"{self._http_url}/mcp/", json=payload, headers=extra_headers
@@ -1747,7 +1777,9 @@ class HttpBrainBridge(BrainBridge):
         if response.status_code in (400, 404) and self._session_id:
             self._session_id = None
             session_id = await self._ensure_session()
-            extra_headers = {"Mcp-Session-Id": session_id} if session_id != "__no_session__" else {}
+            extra_headers = _tenant_override_headers(project_id)
+            if session_id != "__no_session__":
+                extra_headers["Mcp-Session-Id"] = session_id
             response = await self._http_client.post(
                 f"{self._http_url}/mcp/", json=payload, headers=extra_headers
             )
@@ -1849,17 +1881,26 @@ class HttpBrainBridge(BrainBridge):
         query: str,
         limit: int = 10,
         tier: str | None = None,
+        *,
+        project_id: str | None = None,
     ) -> list[dict[str, Any]]:
         args: dict[str, Any] = {"query": query, "limit": limit}
         if tier is not None:
             args["tier"] = tier
-        result = await self._http_mcp_call("memory_search", args)
+        result = await self._http_mcp_call("memory_search", args, project_id=project_id)
         if isinstance(result, list):
             return result
         return result.get("results", []) if isinstance(result, dict) else []
 
-    async def get(self, key: str) -> dict[str, Any] | None:
-        result = await self._http_mcp_call("memory_get", {"key": key})
+    async def get(
+        self,
+        key: str,
+        *,
+        project_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        result = await self._http_mcp_call(
+            "memory_get", {"key": key}, project_id=project_id
+        )
         if isinstance(result, dict) and result.get("key") and not result.get("error"):
             return result
         return None
@@ -1868,11 +1909,13 @@ class HttpBrainBridge(BrainBridge):
         self,
         limit: int = 20,
         tier: str | None = None,
+        *,
+        project_id: str | None = None,
     ) -> list[dict[str, Any]]:
         args: dict[str, Any] = {"limit": limit}
         if tier is not None:
             args["tier"] = tier
-        result = await self._http_mcp_call("memory_list", args)
+        result = await self._http_mcp_call("memory_list", args, project_id=project_id)
         if isinstance(result, list):
             return result
         return result.get("entries", []) if isinstance(result, dict) else []
@@ -1914,13 +1957,21 @@ class HttpBrainBridge(BrainBridge):
     # Knowledge graph (TAP-1630)
     # -------------------------------------------------------------------------
 
-    async def find_related(self, key: str, max_hops: int = 2) -> list[dict[str, Any]]:
+    async def find_related(
+        self,
+        key: str,
+        max_hops: int = 2,
+        *,
+        project_id: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Walk the knowledge graph from *key* outward and return related entries.
 
         Maps to the brain's ``memory_find_related`` tool.
         """
         args: dict[str, Any] = {"key": key, "max_hops": max_hops}
-        result = await self._http_mcp_call("memory_find_related", args)
+        result = await self._http_mcp_call(
+            "memory_find_related", args, project_id=project_id
+        )
         if isinstance(result, list):
             return result
         if isinstance(result, dict):
@@ -2163,6 +2214,7 @@ class HttpBrainBridge(BrainBridge):
         *,
         session_id: str = "",
         details_json: str = "",
+        project_id: str | None = None,
     ) -> dict[str, Any]:
         """Record an unmet-recall signal — the agent searched and got nothing.
 
@@ -2174,7 +2226,9 @@ class HttpBrainBridge(BrainBridge):
             args["session_id"] = session_id
         if details_json:
             args["details_json"] = details_json
-        result = await self._http_mcp_call("feedback_gap", args)
+        result = await self._http_mcp_call(
+            "feedback_gap", args, project_id=project_id
+        )
         return result if isinstance(result, dict) else {"recorded": True}
 
     async def flywheel_report(self, period_days: int = 7) -> dict[str, Any]:
@@ -2665,6 +2719,7 @@ class HttpBrainBridge(BrainBridge):
         tier: str = "pattern",
         scope: str = "project",
         tags: list[str] | None = None,
+        project_id: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         if self.circuit_open:
@@ -2682,12 +2737,16 @@ class HttpBrainBridge(BrainBridge):
         if tags:
             args["tags"] = tags
         args.update(kwargs)
-        result: dict[str, Any] = await self._http_mcp_call("memory_save", args)
+        result: dict[str, Any] = await self._http_mcp_call(
+            "memory_save", args, project_id=project_id
+        )
         self._maybe_start_drain()
         return result if isinstance(result, dict) else {"key": key, "success": True}
 
-    async def delete(self, key: str) -> bool:
-        result = await self._http_mcp_call("memory_delete", {"key": key})
+    async def delete(self, key: str, *, project_id: str | None = None) -> bool:
+        result = await self._http_mcp_call(
+            "memory_delete", {"key": key}, project_id=project_id
+        )
         if isinstance(result, bool):
             return result
         if isinstance(result, dict):

--- a/packages/tapps-core/tests/unit/test_brain_bridge_http.py
+++ b/packages/tapps-core/tests/unit/test_brain_bridge_http.py
@@ -727,6 +727,63 @@ class TestDoMcpPost:
         mock_cls.assert_called_once()
         assert bridge._http_client is not None
 
+    @pytest.mark.asyncio
+    async def test_project_id_override_sent_on_post(self) -> None:
+        """Cross-project recall merges X-Project-Id on the tools/call POST."""
+        from tapps_core.brain_bridge import _tenant_override_headers
+
+        bridge = _make_http_bridge(
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-Project-Id": "nlt-orchestrator",
+            }
+        )
+        bridge._session_id = "__test__"
+        bridge._negotiated = True
+        post_mock = _make_async_post(_mcp_response({"results": []}))
+        bridge._http_client = AsyncMock()
+        bridge._http_client.post = post_mock
+
+        await bridge._do_mcp_post(
+            "memory_search", {"query": "q"}, project_id="tapps-mcp"
+        )
+
+        headers = post_mock.call_args[1]["headers"]
+        assert headers["X-Project-Id"] == "tapps-mcp"
+        assert _tenant_override_headers(None) == {}
+        assert _tenant_override_headers("  tapps-mcp  ") == {"X-Project-Id": "tapps-mcp"}
+
+    @pytest.mark.asyncio
+    async def test_search_forwards_project_id(self) -> None:
+        bridge = _make_http_bridge()
+        bridge._session_id = "__test__"
+        bridge._negotiated = True
+        post_mock = _make_async_post(_mcp_response([]))
+        bridge._http_client = AsyncMock()
+        bridge._http_client.post = post_mock
+
+        await bridge.search("query", project_id="tapps-brain")
+
+        headers = post_mock.call_args[1]["headers"]
+        assert headers["X-Project-Id"] == "tapps-brain"
+
+    @pytest.mark.asyncio
+    async def test_project_id_override_includes_meta(self) -> None:
+        """Cross-project recall also sends ``params._meta.project_id`` for MCP."""
+        bridge = _make_http_bridge()
+        bridge._session_id = "__test__"
+        bridge._negotiated = True
+        post_mock = _make_async_post(_mcp_response([]))
+        bridge._http_client = AsyncMock()
+        bridge._http_client.post = post_mock
+
+        await bridge._do_mcp_post(
+            "memory_search", {"query": "q"}, project_id="tapps-mcp"
+        )
+
+        payload = post_mock.call_args[1]["json"]
+        assert payload["params"]["_meta"]["project_id"] == "tapps-mcp"
+
 
 # ---------------------------------------------------------------------------
 # Read operations

--- a/packages/tapps-mcp/src/tapps_mcp/diagnostics.py
+++ b/packages/tapps-mcp/src/tapps_mcp/diagnostics.py
@@ -9,8 +9,9 @@ import shutil
 import subprocess
 import tempfile
 import time
+from collections.abc import Coroutine
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from tapps_core.common.models import (
     CacheDiagnostic,
@@ -189,6 +190,25 @@ async def probe_context7_async(
         await client.close()
 
 
+def _run_coroutine_sync(coro: Coroutine[Any, Any, Context7Diagnostic]) -> Context7Diagnostic:
+    """Run ``coro`` to completion, tolerating a caller already inside a loop.
+
+    ``asyncio.run()`` raises ``RuntimeError`` when invoked from within a
+    running event loop (e.g. an MCP tool handler such as ``tapps_doctor``).
+    In that case the coroutine is driven to completion on its own event loop
+    in a dedicated worker thread instead of failing the caller.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)  # no loop running here — safe to own one
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
 def probe_context7(
     project_root: Path,
     api_key: SecretStr | None,
@@ -196,18 +216,18 @@ def probe_context7(
     force: bool = False,
     timeout: float = 3.0,
 ) -> Context7Diagnostic:
-    """Throttled, synchronous live probe — safe to call from sync CLI paths.
+    """Throttled, synchronous live probe.
 
     Returns a cached verdict when a fresh marker (< ``_PROBE_TTL_SECONDS``)
-    exists unless ``force`` is set (init/upgrade just wrote the key). Must not
-    be called from within a running event loop — use
-    :func:`probe_context7_async` there.
+    exists unless ``force`` is set (init/upgrade just wrote the key).
+    Safe to call both from plain sync CLI paths and from within a running
+    event loop (e.g. an MCP tool handler) — see :func:`_run_coroutine_sync`.
     """
     if not force:
         cached = _read_probe_marker(project_root)
         if cached is not None:
             return cached
-    diagnostic = asyncio.run(probe_context7_async(api_key, timeout=timeout))
+    diagnostic = _run_coroutine_sync(probe_context7_async(api_key, timeout=timeout))
     _write_probe_marker(project_root, diagnostic)
     return diagnostic
 

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/doctor.py
@@ -378,11 +378,13 @@ def check_vscode_config(project_root: Path) -> CheckResult:
 
 
 def _iter_http_fleet_endpoints(project_root: Path) -> list[tuple[str, str, str]]:
-    """Return ``(host_label, server_name, url)`` for ``streamableHttp`` entries.
+    """Return ``(host_label, server_name, url)`` for HTTP fleet entries.
 
-    Scans the host MCP configs for shared-fleet (ADR-0024) ``streamableHttp``
-    entries so doctor can probe whether their ports are actually listening.
+    Scans the host MCP configs for shared-fleet (ADR-0024) HTTP entries
+    (``streamableHttp`` on Cursor, ``http`` on Claude Code / VS Code) so
+    doctor can probe whether their ports are actually listening.
     """
+    from tapps_mcp.distribution.nlt_http_fleet import HTTP_FLEET_ENTRY_TYPES
     from tapps_mcp.distribution.setup_generator import _load_mcp_config_json
 
     sources = (
@@ -402,7 +404,7 @@ def _iter_http_fleet_endpoints(project_root: Path) -> list[tuple[str, str, str]]
         if not isinstance(servers, dict):
             continue
         for name, entry in servers.items():
-            if not isinstance(entry, dict) or entry.get("type") != "streamableHttp":
+            if not isinstance(entry, dict) or entry.get("type") not in HTTP_FLEET_ENTRY_TYPES:
                 continue
             url = entry.get("url")
             if isinstance(url, str) and url.startswith("http"):
@@ -1834,8 +1836,8 @@ def check_pipeline_enforce_recommendations(project_root: Path) -> CheckResult:
     skip_rate = float(stats.get("gate_skip_rate", 0.0))
     lookup_ratio = float(stats.get("lookup_docs_to_edit_ratio", 0.0))
     loops = int(stats.get("loops", 0))
-    skip_pct = int(round(skip_rate * 100))
-    lookup_pct = int(round(lookup_ratio * 100))
+    skip_pct = round(skip_rate * 100)
+    lookup_pct = round(lookup_ratio * 100)
     message = (
         f"7d gate_skip_rate={skip_pct}% lookup_docs_to_edit_ratio={lookup_pct}% "
         f"({loops} loops in loop-metrics)"
@@ -1946,7 +1948,7 @@ def check_lookup_docs_discipline(project_root: Path) -> CheckResult:
 
     stats = compute_rolling_stats(project_root, window_days=_PROMOTE_WINDOW_DAYS)
     lookup_ratio = float(stats.get("lookup_docs_to_edit_ratio", 0.0))
-    lookup_pct = int(round(lookup_ratio * 100))
+    lookup_pct = round(lookup_ratio * 100)
     loops = int(stats.get("loops", 0))
 
     parts = [f"7d lookup_docs_to_edit_ratio={lookup_pct}% ({loops} loops)"]

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_control.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_control.py
@@ -170,7 +170,7 @@ def start_fleet(*, force: bool = False) -> dict[str, Any]:
                     f"\n--- fleet start {time.strftime('%Y-%m-%dT%H:%M:%S')} ---\n"
                 )
                 log_handle.flush()
-                proc = subprocess.Popen(  # noqa: S603
+                proc = subprocess.Popen(
                     cmd,
                     stdout=log_handle,
                     stderr=subprocess.STDOUT,
@@ -334,17 +334,38 @@ def fleet_any_running() -> bool:
     return fleet_status()["running"] > 0
 
 
+def _wait_fleet_ports_listening(*, timeout: float = 30.0, poll: float = 0.5) -> list[str]:
+    """Block until every fleet port accepts TCP, up to *timeout* seconds.
+
+    Freshly spawned ``serve`` processes need a moment to import and bind;
+    smoking them immediately after ``start_fleet`` reads as connection
+    refused. Returns the server ids still not listening at the deadline.
+    """
+    host = resolve_fleet_host()
+    deadline = time.monotonic() + timeout
+    pending = dict(NLT_HTTP_FLEET_PORTS)
+    while pending and time.monotonic() < deadline:
+        for server_id, port in list(pending.items()):
+            if _port_listening(host, port, timeout=1.0):
+                del pending[server_id]
+        if pending:
+            time.sleep(poll)
+    return sorted(pending)
+
+
 def restart_fleet_with_smoke(*, project_root: Path | None = None) -> dict[str, Any]:
-    """Stop, start, then run Cursor-style MCP smoke on every fleet server."""
+    """Stop, start, wait for readiness, then MCP-smoke every fleet server."""
     from tapps_mcp.distribution.fleet_smoke import smoke_test_fleet
 
     stop_fleet()
     started = start_fleet(force=True)
+    not_ready = _wait_fleet_ports_listening()
     smoke = smoke_test_fleet(project_root=project_root)
     return {
-        "ok": bool(smoke.get("ok")),
+        "ok": bool(smoke.get("ok")) and not not_ready,
         "started": started.get("started", []),
         "errors": started.get("errors", []),
+        "not_ready": not_ready,
         "smoke": smoke,
     }
 

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_smoke.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/fleet_smoke.py
@@ -60,7 +60,7 @@ def _post_mcp(
     }
     if session_id:
         headers["mcp-session-id"] = session_id
-    req = urllib.request.Request(
+    req = urllib.request.Request(  # noqa: S310 — URL validated localhost-only above
         url,
         data=json.dumps(payload).encode(),
         headers=headers,
@@ -71,6 +71,11 @@ def _post_mcp(
             return resp.status, resp.headers.get("mcp-session-id"), resp.read().decode()
     except urllib.error.HTTPError as exc:
         return exc.code, exc.headers.get("mcp-session-id"), exc.read().decode()
+    except OSError as exc:
+        # Connection refused / reset / timeout (URLError is an OSError). A
+        # just-restarted fleet server that has not bound its port yet must
+        # surface as a failed probe stage, not crash the whole deploy.
+        return 0, None, f"connection failed: {exc}"
 
 
 def probe_fleet_mcp_session(

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/nlt_http_fleet.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/nlt_http_fleet.py
@@ -112,15 +112,31 @@ def resolve_http_project_root_header(project_root: Path | None) -> str:
     return str(resolved)
 
 
+def http_entry_type_for_host(host: str) -> str:
+    """MCP entry ``type`` string for an HTTP fleet server on *host*.
+
+    Cursor names the Streamable HTTP transport ``streamableHttp``; Claude Code
+    and VS Code name it ``http`` and *reject* ``streamableHttp`` entries
+    outright ("unknown MCP server type"), silently dropping the server.
+    """
+    if host in ("claude-code", "vscode"):
+        return "http"
+    return "streamableHttp"
+
+
+HTTP_FLEET_ENTRY_TYPES: Final[frozenset[str]] = frozenset({"streamableHttp", "http"})
+
+
 def build_nlt_http_mcp_entry(
     server_id: str,
     *,
     project_root: Path | None = None,
     fleet_host: str | None = None,
+    host: str = "cursor",
 ) -> dict[str, Any]:
-    """Build one ``streamableHttp`` MCP config entry for *server_id*."""
+    """Build one HTTP fleet MCP config entry for *server_id* on *host*."""
     return {
-        "type": "streamableHttp",
+        "type": http_entry_type_for_host(host),
         "url": build_http_fleet_url(server_id, fleet_host=fleet_host),
         "headers": {
             PROJECT_ROOT_HEADER: resolve_http_project_root_header(project_root),
@@ -129,8 +145,8 @@ def build_nlt_http_mcp_entry(
 
 
 def is_valid_http_fleet_mcp_entry(entry: dict[str, Any]) -> bool:
-    """Return True when *entry* is a valid shared-fleet streamableHttp block."""
-    if entry.get("type") != "streamableHttp":
+    """Return True when *entry* is a valid shared-fleet HTTP block."""
+    if entry.get("type") not in HTTP_FLEET_ENTRY_TYPES:
         return False
     url = entry.get("url")
     if not isinstance(url, str) or not url.startswith("http"):

--- a/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
+++ b/packages/tapps-mcp/src/tapps_mcp/distribution/setup_generator.py
@@ -1054,6 +1054,7 @@ def _build_nlt_server_entry(
             server_id,
             project_root=project_root,
             fleet_host=fleet_host,
+            host=host,
         )
 
     spec = NLT_SERVER_SPECS[server_id]

--- a/packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py
+++ b/packages/tapps-mcp/src/tapps_mcp/server_memory_tools.py
@@ -2508,7 +2508,9 @@ async def _handle_related(store: MemoryStore, p: _Params) -> dict[str, Any]:
         return _graph_transport_unavailable("related")
     max_hops = p.max_hops if p.max_hops > 0 else 2
     try:
-        entries = await bridge.find_related(p.key, max_hops=max_hops)
+        entries = await bridge.find_related(
+            p.key, max_hops=max_hops, project_id=_params_project_id(p)
+        )
     except BrainBridgeUnavailable as exc:
         return _bridge_call_failed_response("related", exc)
     return {
@@ -2819,6 +2821,7 @@ async def _maybe_emit_feedback_gap(
     results: int,
     top_score: float | None,
     session_id: str,
+    project_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Emit a ``feedback_gap`` to the brain when a search came back empty
     (or below the configured similarity floor). No-op when:
@@ -2852,7 +2855,9 @@ async def _maybe_emit_feedback_gap(
         return {"emitted": False, "reason": "results_above_threshold"}
 
     try:
-        response = await bridge.feedback_gap(query, session_id=session_id or "")
+        response = await bridge.feedback_gap(
+            query, session_id=session_id or "", project_id=project_id
+        )
     except BrainBridgeUnavailable as exc:
         logger.warning("memory_feedback_gap_emit_failed", error=str(exc))
         return {"emitted": False, "reason": "bridge_call_failed", "error": str(exc)}
@@ -3512,6 +3517,12 @@ def _require_bridge() -> Any:
     return bridge
 
 
+def _params_project_id(p: _Params) -> str | None:
+    """Optional cross-project tenant override from ``tapps_memory(project_id=...)``."""
+    pid = (p.project_id or "").strip()
+    return pid or None
+
+
 async def _http_handle_save(p: _Params) -> dict[str, Any]:
     if not p.key:
         return {"error": "missing_key", "message": "Key is required for save."}
@@ -3532,6 +3543,7 @@ async def _http_handle_save(p: _Params) -> dict[str, Any]:
         tier=p.tier,
         scope=p.scope,
         tags=p.tag_list or None,
+        project_id=_params_project_id(p),
         **save_kwargs,
     )
     return {
@@ -3545,7 +3557,7 @@ async def _http_handle_get(p: _Params) -> dict[str, Any]:
     if not p.key:
         return {"error": "missing_key", "message": "Key is required for get."}
     bridge = _require_bridge()
-    entry = await bridge.get(p.key)
+    entry = await bridge.get(p.key, project_id=_params_project_id(p))
     if entry is None:
         return {
             "action": "get",
@@ -3565,7 +3577,7 @@ async def _http_handle_delete(p: _Params) -> dict[str, Any]:
     if not p.key:
         return {"error": "missing_key", "message": "Key is required for delete."}
     bridge = _require_bridge()
-    deleted = await bridge.delete(p.key)
+    deleted = await bridge.delete(p.key, project_id=_params_project_id(p))
     return {
         "action": "delete",
         "deleted": bool(deleted),
@@ -3583,7 +3595,12 @@ async def _http_handle_search(p: _Params) -> dict[str, Any]:
     effective_limit = p.limit if p.limit > 0 else _SEARCH_DEFAULT_LIMIT
     bridge = _require_bridge()
     tier = p.tier if p.tier and p.tier != "pattern" else None
-    results = await bridge.search(p.query, limit=effective_limit, tier=tier)
+    results = await bridge.search(
+        p.query,
+        limit=effective_limit,
+        tier=tier,
+        project_id=_params_project_id(p),
+    )
     payload: dict[str, Any] = {
         "action": "search",
         "query": p.query,
@@ -3598,6 +3615,7 @@ async def _http_handle_search(p: _Params) -> dict[str, Any]:
         results=len(results),
         top_score=_search_top_score(payload),
         session_id=p.session_id or "",
+        project_id=_params_project_id(p),
     )
     if feedback is not None:
         payload["feedback"] = feedback
@@ -3608,7 +3626,9 @@ async def _http_handle_list(p: _Params) -> dict[str, Any]:
     effective_limit = p.limit if p.limit > 0 else _LIST_DEFAULT_LIMIT
     bridge = _require_bridge()
     tier = p.tier if p.tier and p.tier != "pattern" else None
-    entries = await bridge.list_memories(limit=effective_limit, tier=tier)
+    entries = await bridge.list_memories(
+        limit=effective_limit, tier=tier, project_id=_params_project_id(p)
+    )
     return {
         "action": "list",
         "entries": entries,

--- a/packages/tapps-mcp/tests/unit/test_diagnostics.py
+++ b/packages/tapps-mcp/tests/unit/test_diagnostics.py
@@ -328,3 +328,27 @@ class TestProbeContext7Throttle:
         assert loaded is not None
         assert loaded.status == "unreachable"
         assert loaded.detail == "x"
+
+    def test_force_probe_from_within_running_event_loop_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: tapps_doctor(quick=False) crashed with
+        "asyncio.run() cannot be called from a running event loop" because
+        probe_context7 called asyncio.run() unconditionally from a sync call
+        site that MCP tool dispatch had already entered from a running loop.
+        """
+        import asyncio
+
+        import tapps_mcp.diagnostics as diag_mod
+
+        client = _FakeClient(result=[object()])
+        _patch_client(monkeypatch, client)
+
+        async def _probe_on_loop_thread() -> Context7Diagnostic:
+            # Calling the sync probe_context7 directly here reproduces the
+            # original crash context: the current thread already has a
+            # running event loop when probe_context7's asyncio.run() fires.
+            return diag_mod.probe_context7(tmp_path, SecretStr("k"), force=True)
+
+        result = asyncio.run(_probe_on_loop_thread())
+        assert result.status == "available"

--- a/packages/tapps-mcp/tests/unit/test_fleet_smoke.py
+++ b/packages/tapps-mcp/tests/unit/test_fleet_smoke.py
@@ -71,6 +71,32 @@ class TestProbeFleetMcpSession:
         assert result["ok"] is False
         assert result["stage"] == "initialize"
 
+    def test_connection_refused_is_a_failed_stage_not_a_crash(self) -> None:
+        """Regression: deploy-local crashed with an unhandled URLError when a
+        just-restarted fleet server had not bound its port yet. _post_mcp must
+        translate connection errors into a failed probe result instead.
+        """
+        import io
+        import urllib.error
+        import urllib.request
+
+        refused = urllib.error.URLError(OSError(111, "Connection refused"))
+        with patch.object(urllib.request, "urlopen", side_effect=refused):
+            result = fleet_smoke.probe_fleet_mcp_session("nlt-build")
+
+        assert result["ok"] is False
+        assert result["stage"] == "initialize"
+        assert "connection failed" in result["error"]
+
+        # HTTPError (has a real status) must keep flowing through unchanged.
+        http_err = urllib.error.HTTPError(
+            "http://127.0.0.1:8760/mcp", 500, "boom", {}, io.BytesIO(b"body")  # type: ignore[arg-type]
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=http_err):
+            result = fleet_smoke.probe_fleet_mcp_session("nlt-build")
+        assert result["ok"] is False
+        assert result["http_status"] == 500
+
 
 class TestSmokeTestFleet:
     def test_aggregates_failures(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -109,10 +135,39 @@ class TestRestartFleetWithSmoke:
             lambda *, force: calls.append(f"start:{force}") or {"started": ["nlt-build"], "errors": []},
         )
         monkeypatch.setattr(
+            fleet_control,
+            "_wait_fleet_ports_listening",
+            lambda **_: calls.append("wait") or [],
+        )
+        monkeypatch.setattr(
             fleet_smoke,
             "smoke_test_fleet",
             lambda **_: {"ok": True, "passed": 6, "total": 6, "servers": {}, "failures": []},
         )
         report = fleet_control.restart_fleet_with_smoke()
-        assert calls == ["stop", "start:True"]
+        assert calls == ["stop", "start:True", "wait"]
         assert report["ok"] is True
+        assert report["not_ready"] == []
+
+    def test_restart_fails_when_ports_never_bind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tapps_mcp.distribution import fleet_control
+
+        monkeypatch.setattr(fleet_control, "stop_fleet", lambda: {})
+        monkeypatch.setattr(
+            fleet_control,
+            "start_fleet",
+            lambda *, force: {"started": [], "errors": []},
+        )
+        monkeypatch.setattr(
+            fleet_control,
+            "_wait_fleet_ports_listening",
+            lambda **_: ["nlt-build"],
+        )
+        monkeypatch.setattr(
+            fleet_smoke,
+            "smoke_test_fleet",
+            lambda **_: {"ok": True, "passed": 6, "total": 6, "servers": {}, "failures": []},
+        )
+        report = fleet_control.restart_fleet_with_smoke()
+        assert report["ok"] is False
+        assert report["not_ready"] == ["nlt-build"]

--- a/packages/tapps-mcp/tests/unit/test_nlt_http_fleet.py
+++ b/packages/tapps-mcp/tests/unit/test_nlt_http_fleet.py
@@ -34,11 +34,26 @@ class TestNltHttpFleet:
         assert entry["url"] == "http://127.0.0.1:8761/mcp"
         assert entry["headers"][PROJECT_ROOT_HEADER] == str(tmp_path.resolve())
 
+    def test_http_mcp_entry_type_is_host_aware(self, tmp_path: Path) -> None:
+        """Claude Code / VS Code reject ``streamableHttp`` ("unknown MCP server
+        type") and silently drop the server — they require ``http``. Cursor
+        keeps its historical ``streamableHttp`` spelling.
+        """
+        for host in ("claude-code", "vscode"):
+            entry = build_nlt_http_mcp_entry("nlt-memory", project_root=tmp_path, host=host)
+            assert entry["type"] == "http", host
+        cursor = build_nlt_http_mcp_entry("nlt-memory", project_root=tmp_path, host="cursor")
+        assert cursor["type"] == "streamableHttp"
+
     def test_validates_http_entry(self, tmp_path: Path) -> None:
         from tapps_mcp.distribution.nlt_http_fleet import is_valid_http_fleet_mcp_entry
 
         entry = build_nlt_http_mcp_entry("nlt-build", project_root=tmp_path)
         assert is_valid_http_fleet_mcp_entry(entry) is True
+        claude_entry = build_nlt_http_mcp_entry(
+            "nlt-build", project_root=tmp_path, host="claude-code"
+        )
+        assert is_valid_http_fleet_mcp_entry(claude_entry) is True
         assert is_valid_http_fleet_mcp_entry({"type": "stdio", "command": "x"}) is False
 
     def test_resolve_transport_explicit(self) -> None:


### PR DESCRIPTION
## Summary
- Per-call `X-Project-Id` override on HttpBrainBridge for cross-project recall (#6)
- Fleet deploy waits for port readiness before smoke; no crash on unbound port
- Claude Code/VS Code HTTP MCP entry type fix (`http` vs `streamableHttp`)
- Context7 probe runs on worker loop when called from inside an event loop

## Test plan
- [x] Unit tests for bridge header override
- [x] Fleet smoke 6/6 after deploy
- [x] Live cross-project recall via `tapps_memory(project_id=...)`

Made with [Cursor](https://cursor.com)