### PR TITLE
fix(spec): add test_linker_cache to PyInstaller hiddenimports (TAP-4571)

### DIFF
--- a/tapps_mcp.spec
+++ b/tapps_mcp.spec
@@ -196,6 +196,7 @@ a = Analysis(
         "tapps_mcp.project.call_graph_gap_classify",
         "tapps_mcp.project.diff_impact",
         "tapps_mcp.project.test_linker",
+        "tapps_mcp.project.test_linker_cache",
         "tapps_mcp.project.report",
         "tapps_mcp.project.import_graph",
         "tapps_mcp.project.cycle_detector",


### PR DESCRIPTION
## What
`tapps_mcp.project.test_linker_cache` (added by #195, TAP-4575) was missing from `tapps_mcp.spec` hiddenimports, so `test_pyinstaller_spec.py::test_all_modules_have_hidden_imports` failed on master — 1 failed / 5960 passed. The frozen exe would ImportError at runtime on this module.

## Fix
Add the module to the spec hiddenimports (next to `test_linker`).

## Test
`pytest packages/tapps-mcp/tests/unit/test_pyinstaller_spec.py` → 3 passed. Restores green `pytest -m 'not slow'` on the tapps-mcp package.

Closes the Phase 0 residual on TAP-4571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)